### PR TITLE
Add spouse activity extraction script

### DIFF
--- a/extract_spouse_activity.py
+++ b/extract_spouse_activity.py
@@ -1,0 +1,109 @@
+"""Extract spouse activity information from HATVP declaration files.
+
+Each declaration may contain an ``<activProfConjointDto>`` element that
+lists the professional activity of the declarant's spouse:
+
+``<declaration>``
+└─ ``<activProfConjointDto>``
+   └─ ``<items>``
+      └─ ``<items>`` (repeated)
+         ├─ ``<nomConjoint>``
+         ├─ ``<employeurConjoint>``
+         ├─ ``<activiteProf>``
+         └─ ``<commentaire>``
+
+The script extracts these fields along with the declaration ``uuid`` and
+stores the results in ``pii/spouse_activities.csv``.
+"""
+
+import csv
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+
+def extract_spouse_activities(xml_path: Path) -> list[dict]:
+    """Return spouse activity entries from ``xml_path``.
+
+    Parameters
+    ----------
+    xml_path:
+        Path to a declaration XML file.
+
+    Returns
+    -------
+    list[dict]
+        Each dict contains ``uuid``, ``nomConjoint``, ``employeurConjoint``,
+        ``activiteProf`` and ``commentaire`` for one spouse activity.
+    """
+
+    try:
+        tree = ET.parse(xml_path)
+    except ET.ParseError as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Invalid XML in {xml_path}: {exc}") from exc
+
+    root = tree.getroot()
+
+    def get_unique_desc(parent, tag):
+        """Return a single descendant element or ``None`` if missing.
+
+        Raises ``ValueError`` if more than one matching element is found.
+        """
+
+        if parent is None:
+            return None
+        elements = parent.findall(f".//{tag}")
+        if len(elements) > 1:
+            raise ValueError(f"Multiple <{tag}> elements found in {xml_path}")
+        return elements[0] if elements else None
+
+    declaration = root if root.tag == "declaration" else get_unique_desc(root, "declaration")
+    uuid = declaration.findtext("uuid", default="").strip() if declaration is not None else ""
+
+    activ_dto = get_unique_desc(declaration, "activProfConjointDto")
+    if activ_dto is None:
+        return []
+
+    def clean(text: str) -> str:
+        """Collapse internal whitespace and strip ends."""
+
+        return " ".join(text.split()) if text else ""
+
+    activities = []
+    for item in activ_dto.findall("./items/items"):
+        activities.append(
+            {
+                "uuid": uuid,
+                "nomConjoint": clean(item.findtext("nomConjoint")),
+                "employeurConjoint": clean(item.findtext("employeurConjoint")),
+                "activiteProf": clean(item.findtext("activiteProf")),
+                "commentaire": clean(item.findtext("commentaire")),
+            }
+        )
+
+    return activities
+
+
+def main() -> None:
+    decl_dir = Path("split_declarations")
+
+    output_dir = Path("pii")
+    output_dir.mkdir(exist_ok=True)
+    output_file = output_dir / "spouse_activities.csv"
+    fieldnames = [
+        "uuid",
+        "nomConjoint",
+        "employeurConjoint",
+        "activiteProf",
+        "commentaire",
+    ]
+
+    with output_file.open("w", newline="", encoding="utf-8") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+        for xml_file in sorted(decl_dir.glob("*.xml")):
+            for activity in extract_spouse_activities(xml_file):
+                writer.writerow(activity)
+
+
+if __name__ == "__main__":
+    main()

--- a/pii/spouse_activities.csv
+++ b/pii/spouse_activities.csv
@@ -1,0 +1,8728 @@
+uuid,nomConjoint,employeurConjoint,activiteProf,commentaire
+000b18d0-40c0-4edf-8bf5-e76841fe46df,[Données non publiées],SARL Peyrard,Commerce de vetements pour hommes,
+000e2a7c-5fae-4a8d-a1a4-8d04821effc7,[Données non publiées],Societe Evidensia,vétérinaire,[Données non publiées]
+000e41c4-3ae3-46b7-be32-1aa8b74c778b,[Données non publiées],SLEA,Travailleur social,
+00138e83-44ec-4da1-89f3-37d2309a62a2,[Données non publiées],dekra,[Données non publiées],
+0014115c-cbae-4bdd-98d1-39c8e6062095,[Données non publiées],SAS SLTS,[Données non publiées],[Données non publiées]
+00221bbf-875f-4e2d-8772-5fcb483e2a3f,[Données non publiées],Néant,Néant,[Données non publiées] Conseillère régionale en région Centre-Val de Loire [Données non publiées]
+002c2aae-c0e3-4056-8e4b-a804f56a9d25,[Données non publiées],Région Nouvelle-Aquitaine,Chargé de mission,
+002e21a3-a6cc-4861-8a01-f1f2b01e9d6f,[Données non publiées],NEANT,retraitée,[Données non publiées]
+0037f81f-6f0f-4179-86ef-1490201c15c1,[Données non publiées],Arlim Prestige,[Données non publiées] agent immobilier [Données non publiées],
+003d375a-3bf4-4441-817e-8593c32e7d57,[Données non publiées],Entreprise Individuelle,Direction Artistique & Graphisme,
+003d375a-3bf4-4441-817e-8593c32e7d57,[Données non publiées],[Données non publiées] SAS,Conception et commercialisation de vêtements Made In France,Création en 2018. Pas encore de revenus généré par cette activité
+0056f16f-6d5c-48dc-9474-dfe5968fc181,[Données non publiées],PCM TEARI,[Données non publiées],
+005da0ad-9344-499a-b849-3a68f6726130,[Données non publiées],profession libérale,masseur-kinésithérapeute,
+0067f38c-d05b-4649-ae0a-62484ed1a376,[Données non publiées],Commune de Lormont,Secrétaire [Données non publiées],
+00774e03-3570-4f51-9ab9-760628526c95,[Données non publiées],CEA,[Données non publiées],
+0077a7f4-91ae-4442-98e4-d3233342bd8d,[Données non publiées],SAGVRA,Commercial [Données non publiées],[Données non publiées]
+0077f258-22a6-473d-bffe-e13f8ee5b6cd,[Données non publiées],Association [Données non publiées],[Données non publiées],activité de crèche parentale associative
+007be442-7dc6-4628-acec-b384d03030ad,[Données non publiées],université [Données non publiées],[Données non publiées],
+007e3535-60b1-410b-9c35-68ebdacf610a,[Données non publiées],Université [Données non publiées],Maitre de conférences,
+0081d68f-d47c-4b8e-83c3-86c33d2c17d3,[Données non publiées],[Données non publiées],Directeur général,
+008ab22a-71d8-41ef-aeaf-611aff5eee2b,[Données non publiées],BOULANGERIE PATISSERIE [Données non publiées],VENDEUSE MAGASIN BOULANGERIE PATISSERIE,
+008f54ff-97d5-48ac-acca-6cd88027b4ee,[Données non publiées],profession libérale,Kinésithérapeute,[Données non publiées]
+00a17af9-65e7-4082-b26e-e5ef67f912af,[Données non publiées],Région Grand Est,[Données non publiées],[Données non publiées]
+00a7352e-ceb7-4e19-b072-edf4ba8e90dc,[Données non publiées],[Données non publiées],Soins esthétiques,
+00b054e0-31a5-4ce1-8262-19fe942241e0,[Données non publiées],Néant,Avocate,
+00b1c41b-824f-49f9-a0be-b1956cc80ca4,[Données non publiées],Maison Familiale et Rurale [Données non publiées],Formateur / enseignement agricole privé sous contrat,
+00c47ed3-750f-4b3e-8aa5-02357b0725e6,[Données non publiées],[Données non publiées],Ergonome/Psychologue du travail [Données non publiées],
+00c7ffff-9132-49c3-99c3-ef7eb132a221,[Données non publiées],conseil départemental de La Réunion,[Données non publiées],[Données non publiées]
+00ca9fdf-2b46-4581-848a-6de6419606ea,[Données non publiées],PRATICIEN HOSPITALIER,[Données non publiées],
+00ce51d1-8f1f-4538-b0ce-d0f0d11ca12f,[Données non publiées],SOFIPEL,[Données non publiées],
+00d19b56-a918-4d26-bf32-208cd036786b,[Données non publiées],Néant,Retraitée de l'Education Nationale,
+00d924ee-0d2c-4ff5-afd9-a74cf6d9bcf5,[Données non publiées],C C A S [Données non publiées],Infirmière Puéricultrice [Données non publiées],Retraitée [Données non publiées]
+00dd4530-d2be-434b-bad5-102304a171aa,[Données non publiées],[Données non publiées],"expert-comptable, associé et co-gérant de la société [Données non publiées]",[Données non publiées]
+01023bff-59c2-4bea-b5ee-726445acb541,[Données non publiées],[Données non publiées],Comptable,
+01052673-7a70-40e7-811a-ba09269ead50,[Données non publiées],néant,néant,
+0117a4e7-aa55-4f59-b3cd-36ab3ece035e,[Données non publiées],[Données non publiées],Retraitée [Données non publiées],
+01306741-3d7f-4fc6-add1-0ba1b60cc537,[Données non publiées],UDAF [Données non publiées],Déléguée [Données non publiées],[Données non publiées]
+0131d5aa-b83b-40eb-bc53-0081c3454f49,[Données non publiées],Groupama Méditerranée,[Données non publiées],[Données non publiées] retraite [Données non publiées]
+0138f902-97a2-4cf4-9983-f4a0d13cb6fc,[Données non publiées],auto entrepreneur,peinture,
+013dff4a-e566-4f91-9991-2f57c39679ac,[Données non publiées],SARL cabinet 2H,Economiste de la construction,[Données non publiées]
+0146d1d8-c8ad-4513-95be-2ef49a41e39a,[Données non publiées],BlueSolutions,[Données non publiées],
+01482c2e-90e0-4ead-93ab-03222f4027d8,[Données non publiées],Daimler Trucks,Responsable administration [Données non publiées],
+014eafe0-8800-437f-bbd5-b4f4528b7e72,[Données non publiées],FlexThings,[Données non publiées],[Données non publiées]
+015071e8-2df8-4b7d-8392-81e29fa425a5,[Données non publiées],Mickael Page Interim,Manager de transition,
+015f2310-f5a3-4e60-b8a1-d79a60cbb345,[Données non publiées],MAIRIE D'EPINAY SUR SEINE,ATTACHE TERRITORIALE,
+016e562a-79ce-40fd-b4e0-a78938f80782,[Données non publiées],ASSOCIATION LE RULEAU,Aide Médico Psycologique en EHPAD [Données non publiées],
+01743d3c-d4db-4554-b254-e21fdac17be9,[Données non publiées],hopital [Données non publiées],IDE,en retraite [Données non publiées]
+01771bd8-9f1a-4e3b-9897-617cd0dea0c9,[Données non publiées],[Données non publiées],Professeur des écoles,
+0189d2b1-fab3-474f-bd05-9582bd9cb616,[Données non publiées],Ministère de l'Intérieur,Attachée de presse,
+018e077d-6fb9-489e-8672-620791359893,[Données non publiées],Hopital [Données non publiées],Infirmière,
+01910f1e-f1d8-448c-a852-426df89d843a,[Données non publiées],Parties prenantes,Directrice Conseil [Données non publiées],
+019972a0-d115-4a5a-b382-523cff5a747a,[Données non publiées],néant,néant,
+01a6dc99-c27d-47cf-94d4-edba1da61e11,[Données non publiées],La Banque Postale,Téléconseillère,[Données non publiées]
+01b1c423-865c-4de8-9650-f5ed01f92cdb,[Données non publiées],SFS,Infimière,
+01c1c2f3-9f57-4b38-8ef0-670e24a6a86a,[Données non publiées],[Données non publiées],entrepreneur de travaux agricoles,[Données non publiées]
+01de32aa-f831-4c01-9f61-223e96ff30dd,[Données non publiées],Entreprise Individuelle [Données non publiées],Artisan Torréfacteur,
+01e02490-47a1-4d2b-86aa-c8ffbddc8ca4,[Données non publiées],Vice-Rectorat,Personnelle de cuisine,[Données non publiées]
+01e6629a-9063-466e-87a9-6d61624cdc43,[Données non publiées],STE MECAFORM,CADRE ADMINISTRATIF,
+01e889f4-7c43-4f0a-a8bc-863cf13205cf,[Données non publiées],PROFESSION LIBERALE,INFIRMIERE LIBERALE,
+01ebc57d-e292-4137-98b5-eb64eb194a32,[Données non publiées],GBH,ELECTRICIEN,[Données non publiées]
+01f7b9f1-c2f0-47ad-a734-6370600bd19e,[Données non publiées],Ministère de l'Education Nationale,Administrateur de l'Etat détaché à l'IGESR,
+01f7d03e-1adf-4bfd-92b8-148fd7e7e7cc,[Données non publiées],FIDUCIAIRE COMPTABLE NC,[Données non publiées],
+01fe44fd-7025-4ea2-a0b8-0523cd0bf411,[Données non publiées],INTERMITTENT DU SPECTACLE,COMEDIEN,
+020041d9-b68c-48cb-bf1c-0d368d78d904,[Données non publiées],Retraité du CEA,AutoEntrepreneur [Données non publiées],
+0204f9eb-56d5-407b-bf28-5efcc6038402,[Données non publiées],régie networks,[Données non publiées],
+020c726c-2b20-4b6e-a3e1-6c8b8c871a37,[Données non publiées],Neant,Néant,
+02179eea-452e-4cdc-b2c0-2174ea2a5f86,[Données non publiées],[Données non publiées],Infirmière,
+0226f36d-ac50-42fb-a673-eee517bf91e9,[Données non publiées],Activité libérale,Architecte,
+022b6cc7-b759-43bb-8932-a82072fe1c8e,[Données non publiées],EDUCATION NATIONALE,ENSEIGNANTE,
+022fdbe5-4550-47e7-9b86-0cbe67a40cb3,[Données non publiées],la Caisse d'allocations Familiales,Charge [Données non publiées],
+024cd40d-71c8-4421-8937-e7c8458ea6ca,[Données non publiées],palais des congrès,directrice [Données non publiées],
+025e5fe1-f02f-4acc-9a07-e641eda50c17,[Données non publiées],néant,néant,
+0261152e-c45c-48ed-83e9-edce91406f84,[Données non publiées],Tout en Vélo Grenoble,Dirigeant,
+02643242-2290-49ae-8d41-215f5d68b521,[Données non publiées],Hynamics,[Données non publiées] [Données non publiées],[Données non publiées]
+0277707b-11d6-47da-9800-67c40c23af6c,[Données non publiées],Néant,Néant,
+027a758f-f83b-4acc-bd8d-37abd5a87e1c,[Données non publiées],Néant,Néant,
+0295b354-6a2d-4dc4-a223-71dcb05f83dd,[Données non publiées],AUCUN,[Données non publiées],
+0299a108-e50f-41ed-8c9b-07e3ea2b214d,[Données non publiées],GAEC DE KERMORIN,Exploitant agricole,
+02a283a9-dfa2-4c4e-a9ea-4455464a1f73,[Données non publiées],[Données non publiées],COMPTABLE,
+02b01a67-7d68-4451-8089-db23908609c6,[Données non publiées],Education Nationale,Professeur Mathématique,
+02c717b9-a962-4643-bcfa-0fb6ee3e7de3,[Données non publiées],CONSEIL DEPARTEMENTALE 22,Educatrice spécialisée,
+02d11078-811c-4e87-b7a2-5187824300b5,[Données non publiées],Ville de Paris,[Données non publiées],
+02e390c7-308d-4a37-a0eb-aa590b760699,[Données non publiées],Education Nationale,Professeure [Données non publiées],
+02ef1e36-55e4-4beb-8749-d6929a12d957,[Données non publiées],Travailleur indépendant,conseil en communication scientifique et journaliste,
+02f19c22-4279-4852-b3bd-587d5aa840a4,[Données non publiées],Mairie de Sant Fons,DGS,fin au 1er mars 2024
+02f1c329-cfc8-412b-a5bc-e075bf9edffb,[Données non publiées],Collecteam,Agent d’assurance [Données non publiées],
+0301b7f5-795d-457a-bb89-da12a9c2dff4,[Données non publiées],MMA IARD,Responsable Conseils juridiques. [Données non publiées],
+031024fe-c994-48ca-b9ed-2cbe2d94fc52,[Données non publiées],0,retraité,
+03173ff9-1ac9-428f-bc2c-a3cc6749d409,[Données non publiées],sans,sans,[Données non publiées]
+031de3df-9060-480d-a66a-57b2a3f3775b,[Données non publiées],Retraitée,Retraitée,
+03237b10-ac10-4af3-8e81-a7969159cd4d,[Données non publiées],Booking.com,agent qualité et formation,[Données non publiées]
+03296103-f49b-4b0a-90da-cc5aeed26abc,[Données non publiées],ILEX,DIRECTEUR,
+032b7434-4f23-4313-91f7-62b7c1c3aadf,[Données non publiées],ENS [Données non publiées],Ingénieur,
+032da254-ee42-4f4b-92b5-db9789f344c0,[Données non publiées],Co-Gérante SARL,"SARL Le Petit Quai [Données non publiées] Commercialisation au détail de vins, de bières, de boisons non alcoolisés, de produits d'épicerie fine frais ou secs et de plats cuisinés en bocaux.",
+033088de-e9b9-40b6-90e4-1eb693fa3090,[Données non publiées],[Données non publiées],[Données non publiées],
+033088de-e9b9-40b6-90e4-1eb693fa3090,[Données non publiées],Retraite,[Données non publiées],
+03474039-7609-4a32-952c-247ee6ac24a4,[Données non publiées],LE PROGRES,Journaliste,
+03589003-572e-47a9-8403-a156eb69cf0f,[Données non publiées],PHARMACIE,pharmacienne [Données non publiées],salariée
+0361abc2-281c-49b7-871f-3fafe3c300d8,[Données non publiées],PPG INDUSTRIES,RESPONSABLE [Données non publiées],
+036c322f-0113-45c8-9317-9d69d73cf907,[Données non publiées],Activité individuelle : statut Micro-entreprise,Réalisation d'éléments en béton,"Actuellement en micro-entreprise, le statut de son entreprise connaitra un changement courant septembre. Le nouveau statut sera EURL."
+036e2255-5bb2-4c64-9ea2-d43a592583b5,[Données non publiées],GEIE GECOTTI-PE,Chargée de mission [Données non publiées],
+037061ae-c801-4d51-ab0f-cb7d54547fea,[Données non publiées],SA GERFLOR,Directeur commercial,
+037943d2-d357-4c06-806c-a7824513a6c5,[Données non publiées],Université [Données non publiées],Enseignant-chercheur,
+0382d436-a9d7-48a4-bb55-cbe33226b312,[Données non publiées],General Electric,Ingénieur,
+038ae238-01e4-470a-af90-5a5f9704788d,[Données non publiées],SA JEAN FLOCH,RESPONSABLE [Données non publiées],
+03982f0e-7f32-48a4-9038-dbefd7abd4f9,[Données non publiées],Maitre coq,[Données non publiées],
+039de9b1-38f9-4bab-b2e2-228fc9d5c69d,[Données non publiées],Retraitée,Néant,
+039fb4f4-fe6c-47a3-8e3b-9053bd7635f2,[Données non publiées],Centre de Gestion,Attachée territoriale principale,
+03ad8e3c-b969-49c5-af03-2ac6919a00cd,[Données non publiées],retraité,[Données non publiées] retraite au 30/03/2021,
+03b62efc-334f-4287-87e4-7342adb2ec41,[Données non publiées],SNCF,Conducteur de train,
+03bde2f5-76ac-4765-b305-3d1b2cd6df02,[Données non publiées],cid [Données non publiées],employée en confection,
+03bf62d0-206f-4c8a-a1f0-ae491ad9c6bf,[Données non publiées],Ville de la Bourboule,[Données non publiées],
+03c9e7e8-93d2-40ec-8282-e856cd591f70,[Données non publiées],Retraitée,Retraitée,
+03d0fc71-e896-4e57-8371-13407032cb82,[Données non publiées],PROVENCE(S),Gérant [Données non publiées],
+03d48313-d671-4f70-9e6e-5d3fff446d9a,[Données non publiées],GAEC [Données non publiées],agriculteur,
+03d9b9de-c606-416e-b5a8-54026c6cbc0e,[Données non publiées],[Données non publiées],Technicien informatique,[Données non publiées]
+03e7f9e3-9ae1-4413-932e-3404b1c68109,[Données non publiées],[Données non publiées],entreprise &gro alimentaire Directeur technique,[Données non publiées]
+03e957e2-e23e-4e08-a4f7-6f5fb0bb9b5e,[Données non publiées],Ville de Montreuil,[Données non publiées],
+03fcdcb1-7c23-4fd0-a23a-41f25d6dc08a,[Données non publiées],Paris School of Economics,Conseiller politique [Données non publiées],
+03ffe5e7-ba02-458b-bb6a-1658777e5345,[Données non publiées],PACQUAM,"Directrice de l'association PACQUAM depuis 1997, en charge de l'aide à la scolarité - [Données non publiées]",
+040b9d60-5284-4d60-b989-9f8e3bfa4fbb,[Données non publiées],Aucun,Aucune,
+04124a2e-140c-4231-a767-ea42ed597a7a,[Données non publiées],COMPTOIR AUTO [Données non publiées] [Données non publiées],ASSISTANTE DE DIRECTION [Données non publiées],
+042747d4-011b-4bac-9ca0-feeabede7b98,[Données non publiées],Éducation Nationale,Professeur des écoles,
+043002b7-3299-48cb-bae8-9022bdfa9970,[Données non publiées],0,Retraitée,
+04341191-b05a-471b-9d28-86ce58c95f07,[Données non publiées],ACTA Vista,attachée de direction - chef de projet,
+04341f9d-c316-4b10-8c5e-663fd3a16371,[Données non publiées],Conseil de l’Ordre des médecins,[Données non publiées],Retraitée active [Données non publiées]
+0449a7e9-0de9-4705-8149-5191335067b3,[Données non publiées],[Données non publiées],Gérant de la SARL,
+044a0ef0-b6a2-4e60-a430-1d97264a01d4,[Données non publiées],[Données non publiées],co-gerante,
+044bea03-a892-4d3c-8835-09e2640d2f17,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+044bea03-a892-4d3c-8835-09e2640d2f17,[Données non publiées],Auto entrepreneur,Conseil en relations publiques,[Données non publiées]
+045714f1-ecd3-4b20-b5b6-26166e83841f,[Données non publiées],ETUDE NOTARIALE [Données non publiées],CLERC DE NOTAIRE,
+045f60d9-f00e-46ca-8337-2fc104d1134d,[Données non publiées],retraitée,retraitée,
+0465638c-88cd-42c3-9b14-558d0ab34b51,[Données non publiées],France Télévision,Journaliste,
+04661e9a-1a5d-45b5-ae34-7aa1247293b1,[Données non publiées],Systeme u,[Données non publiées],
+046a4f3c-5ca4-4ba1-9f61-7206c7f01829,[Données non publiées],Fondation Rotschild,[Données non publiées],
+046dbce8-bccf-42a4-8d9c-54c9d8223f48,[Données non publiées],néant,néant,[Données non publiées]
+0470018e-380c-486b-9aa1-f2b70a31fd14,[Données non publiées],LIBERAL,MEDECIN GENERALISTE,
+047a0380-18c7-4c36-9ad0-8343efa902a6,[Données non publiées],Drees&Sommer,Project Manager,
+048516ea-0499-4f62-a932-39c87e74ad56,[Données non publiées],ville de Vendin les Vieil,[Données non publiées],
+04932a1a-6e93-4ffe-a0fb-18af59ab03ac,[Données non publiées],Education Nationale,Professeur documentaliste,
+049b9cad-095d-443b-bec1-16490ddc5b9c,[Données non publiées],Handicap international,Psychologue,
+04a2c1e5-e921-40f2-8444-37341d03ea14,[Données non publiées],néant,néant,[Données non publiées]
+04ab852e-4de1-478f-891b-c6c7e3fb3755,[Données non publiées],SANS,AUCUNE,[Données non publiées]
+04ba9fe3-e971-44b6-b7d8-0a107f230733,[Données non publiées],néant,néant,
+04cfad6d-e0fd-43e3-87a0-9268efa509db,[Données non publiées],Commune Loireauxence,Directrice du service [Données non publiées],
+04dcd696-9d80-44b7-aef6-b4ac36f2da1f,[Données non publiées],[Données non publiées],Retraitée [Données non publiées],[Données non publiées]
+04dd08d0-c3f9-46a6-a201-7c82b379fd90,[Données non publiées],collège [Données non publiées],animatrice pastorale,
+04ddf8d8-6fd4-40f7-baf6-d74528de0375,[Données non publiées],la poste,controleur,[Données non publiées]
+04e1d634-8af7-4752-a297-f5489590ac77,[Données non publiées],MAERSK FRANCE,EMPLOYE DE CONSIGNATION,
+04e1dcc0-aa64-4396-adf4-8c2d8a15f521,[Données non publiées],OMNImeubles SARL,commercial,
+0507a255-e88e-40ae-8b77-9c5e5b2687bf,[Données non publiées],Véro coiffure,[Données non publiées],
+05099bec-c45c-40f8-acf8-0ba19ece3115,[Données non publiées],Néant,Néant,
+0512076e-0a63-43ee-a7c1-e443e6da8d7d,[Données non publiées],retraitée,retraitée,[Données non publiées]
+051ee302-8dd1-4091-b905-335d637cd564,[Données non publiées],Agricultrice,Chef exploitation,
+0534af96-c87a-4435-98a9-6725fa254df0,[Données non publiées],conseil départemental,assistante sociale,
+0534b9f5-9a8f-4123-891b-d58c3950219b,[Données non publiées],Ministère de la culture,Conservatrice du patrimoine [Données non publiées],
+0538d3fe-6e1d-4194-baab-507a7f06fda0,[Données non publiées],neant,medecin,
+053ded6b-8e37-4fa0-b29a-16351301f433,[Données non publiées],Association diocèse Dijon,[Données non publiées],[Données non publiées]
+054bbeff-cc54-49d1-b75a-2d724c78c33e,[Données non publiées],retraité,[Données non publiées],
+05538c29-2747-454c-a09a-ff22fa75b707,[Données non publiées],[Données non publiées],AVOCAT,DROIT DE LA FAMILLE
+05552535-91fa-44f0-9f04-94458580e032,[Données non publiées],GrandAngoulême,[Données non publiées] Fonctionnaire,
+055c743f-0162-4d4a-a771-27796b3b40c2,[Données non publiées],Néant,Néant,Retraité
+0562247b-ff4a-4061-9418-a181e22dd6d4,[Données non publiées],Groupe EVALIS,DGA [Données non publiées],
+05633e50-5d39-493f-b687-08aedaa68102,[Données non publiées],gérante de société [Données non publiées],conseil,
+0563b4a2-af2c-4da3-8e09-4e43d542ac59,[Données non publiées],PROVENCE(S),Gérant [Données non publiées],
+05682e8f-f5c0-4cb7-be79-be11ca06a47d,[Données non publiées],GHM [Données non publiées],Infirmière,
+05781412-8c8d-40b2-805d-b435542840ee,[Données non publiées],SCI [Données non publiées],secrétaire médicale,
+057ee29e-2fb6-4fa9-b4fa-3847443817ae,[Données non publiées],clinique vétérinaire,docteur vétérinaire salariée,
+0580c13d-8cf9-46a0-a536-909c04c863e2,[Données non publiées],DGFIP,CHEF DE BRIGADE,
+05a293d3-ece5-467f-8f69-4fd44793be5c,[Données non publiées],travailleur indépendant,[Données non publiées] SARL EDITIONS PALLADION,
+05a8a4c1-5789-4cea-b813-7f96f9dbe577,[Données non publiées],Retraitée,Retraitée,
+05b69c7a-95e2-4429-a4b6-8985956a2159,[Données non publiées],Université [Données non publiées],Enseignant-chercheur,
+05baea41-66e9-40e6-9df3-c1b9af62e9cc,[Données non publiées],centre hospitalier [Données non publiées],secrétaire médicale,
+05bea01a-8f5b-4a36-8d5a-ce40229eab06,[Données non publiées],néant,néant,
+05c0522e-4643-440e-b64e-9cc7ddee866c,[Données non publiées],neant,neant,
+05c9c89b-3789-463e-af24-42223dc475ea,[Données non publiées],Franchise McDonald's [Données non publiées],Salariée,
+05c9d411-6424-47eb-8417-dd54a194f17c,[Données non publiées],France Télévision,Journaliste,
+05d3b655-e7dd-4895-8018-37489369e0df,[Données non publiées],autoentrepreneur,Professeur de yoga,
+05dc45c2-af6d-4247-ab0b-f5f343f6c9a7,[Données non publiées],Faculté libre de Droit de Lille et UVHC,Enseignant,Professeur de Droit [Données non publiées]
+05efb008-257f-4288-b5e7-d9797c6f2005,[Données non publiées],SA JEAN FLOCH,RESPONSABLE [Données non publiées],
+05f1e65a-082e-4ae8-af40-285080e72e47,[Données non publiées],[Données non publiées],NEANT,
+05f67c12-06f7-43eb-a8fe-6e689c513a8a,[Données non publiées],vynova,[Données non publiées],
+05ffd325-cf84-4822-801e-1fbf18dc7e09,[Données non publiées],mairie de Saint-Denis,Secrétaire,
+06010c27-d6d3-4ccd-84c0-caa941a55784,[Données non publiées],BUREAU NAVAL,dirigeant d'entreprise,
+0611e28a-4eb8-4cfd-9584-db873318cf19,[Données non publiées],EDUCATION NATIONALE,ENSEIGNEMENT,
+0612f784-c21b-4405-b40e-6cdf2c5167e7,[Données non publiées],néant,néant,
+0617d441-c6cc-4c4c-8a62-3f0af9e84a98,[Données non publiées],Retraitée,Néant,
+0618c75d-196c-4386-a822-c9fa901e0508,[Données non publiées],Education nationale,Conseiller principal d'éducation,[Données non publiées]
+06346cd5-db58-434e-b9ed-5dfb4aca3713,[Données non publiées],Néant,Néant,[Données non publiées] retraite [Données non publiées]
+0636fae2-7968-43cb-b4c0-cbf47770f419,[Données non publiées],ORES,[Données non publiées],
+06393caa-bd99-4d62-87e6-c2cd3265ffe7,[Données non publiées],Casino [Données non publiées],attachée de communication,
+0642f108-832a-4d9e-8572-1884e99a841a,[Données non publiées],neant,employée commerce,[Données non publiées]
+06514673-fa61-4759-bcac-864be05725ad,[Données non publiées],Cabinet infirmier de Sophie & Hélène,Infirmière libérale,
+06515df3-55c5-413a-abff-9333801e0af0,[Données non publiées],Ministère de l'Education Nationale,Professeure d'Histoire-Géographie,
+0653ff4a-1094-4221-9aa1-842fcbfa48bf,[Données non publiées],SARL [Données non publiées],"ACTIVITE : INGENIERIE , conception de salles d'affinage de fromages [Données non publiées]",
+0683073e-8994-47a5-8f29-13b6baa41215,[Données non publiées],MINISTERE DE L INTERIEUR,Fonctionnaire de police,
+069d232c-47ed-4a51-8056-c8853ff21d2a,[Données non publiées],GROUPAMA [Données non publiées],ASSISTANTE [Données non publiées],[Données non publiées]
+069e497f-f067-47e4-a6fe-6b1663f33b08,[Données non publiées],France Télévision/Autres média,Journaliste,[Données non publiées]
+06a1b5a4-aa49-46a5-9dd7-ef2497eb2860,[Données non publiées],néant,néant,
+06a22fc0-ae49-4725-892b-4f4acfb057b4,[Données non publiées],SBB Bâle,Agent polyvalent,
+06aad3cf-e488-4cf7-83f5-24857c62323d,[Données non publiées],Retraitée,Néant,
+06aee6a4-256f-4240-8f46-2a72d2f91e4f,[Données non publiées],Haut Bugey Agglomération,[Données non publiées],
+06b64fe4-42a7-4779-b265-fb6f0d778a38,[Données non publiées],Education Nationale,Principale de collège [Données non publiées],
+06c9f776-420f-44a9-88c8-52fd3b0e92e4,[Données non publiées],retraitée,Retraitée,
+06d38352-44a8-4d64-b9b0-610985851cb7,[Données non publiées],[Données non publiées] Conseil départemental de l’Orne,[Données non publiées],[Données non publiées]
+06dd6c2c-9f79-42a5-8f8a-5ea753b11e32,[Données non publiées],MINISTERE DES FINANCES,CONTROLEUR DES DOUANES [Données non publiées],
+06e474d0-9a48-4328-ae83-53de51e0a71d,[Données non publiées],Ministère de la justice,Magistrate,
+06ec6596-0d40-4658-84b6-c5b5fd5220d9,[Données non publiées],retraite,retraité neant,
+06ec6596-0d40-4658-84b6-c5b5fd5220d9,[Données non publiées],néant,néant,[Données non publiées]
+06f2f542-73f1-4348-9470-68b5815798aa,[Données non publiées],Orange SA,Ingénieur,
+06f56198-0fc6-43bd-b810-50167faa2080,[Données non publiées],earl [Données non publiées],agriculture,[Données non publiées]
+07036718-ace7-43f2-84a4-90ba062f6940,[Données non publiées],SDIS DE LA GIRONDE,SAPEUR POMPIER,
+0705833c-ab4c-4052-ada8-c14da48bf9ae,[Données non publiées],APRR. Autoroutes Paris-Rhin-Rhône,Technicienne assurances [Données non publiées],
+070767fe-7e08-4545-ad43-6588852ed296,[Données non publiées],néant,néant,
+070ad703-2cfc-4d29-8ccd-35a2d258f8bb,[Données non publiées],Département des Hautes-Alpes,Fonctionnaire territorial catégorie A Chef de Service,
+070e8a62-4c58-47f4-920b-2d563506f19c,[Données non publiées],Anne Ventalon,Attaché parlementaire,
+070e8a62-4c58-47f4-920b-2d563506f19c,[Données non publiées],Mathieu Darnaud,Attaché parlementaire,
+07151b00-5560-4bfc-b944-58f013e6c587,[Données non publiées],ENTREPRISE INDIVIDUELLE,Artisan menuisier,
+071758a8-7ad8-4a47-857a-64cef2738c7b,[Données non publiées],Ministère de l'Education Nationale,Professeur des écoles,
+071d01dc-60a5-4097-be07-ad00096845ab,[Données non publiées],Yves Messerli architecte [Données non publiées],Architecte,
+072621de-8edb-425d-956e-827434ac431e,[Données non publiées],Atelier Mima,[Données non publiées],
+072724be-37b9-4df6-8095-9819195ed045,[Données non publiées],CHU de la Réunion,Infirmier,
+0732cd92-8afc-4785-af59-2a1144f96c99,[Données non publiées],Métropole Européenne de Lille,[Données non publiées],
+073cce1c-a436-4568-ae0f-eaa016d8401b,[Données non publiées],Centre Hospitalier de Béziers,médecin,
+07402aea-db08-40af-8f44-c290874fee7c,[Données non publiées],[Données non publiées],infirmière coordinatrice [Données non publiées],
+074d1be6-cedb-452d-a8b7-2359d419e4e1,[Données non publiées],néant,néant,
+075df8ed-4f94-4456-a4df-160d0524212e,[Données non publiées],PHI SAS,[Données non publiées],
+076a893e-cf1c-4637-90a7-65e7f3f399b2,[Données non publiées],[Données non publiées],CHARGÉE DE MISSION RH [Données non publiées],
+0770046a-7c5e-4d6a-949b-3312ee821242,[Données non publiées],retraité,[Données non publiées],
+077f7431-fd1c-4a81-9544-77d48bcd4a06,[Données non publiées],Université Aix marseille et Institut Paoli Calmettes,PU-PH [Données non publiées] faculté de pharmacie [Données non publiées],
+07859b62-1913-49df-b06a-45b420bd6d5d,[Données non publiées],Néant,Néant,[Données non publiées]
+0795b31d-b64a-4fc7-a280-2fb89d209b21,[Données non publiées],retraité,néant,[Données non publiées]
+0795b31d-b64a-4fc7-a280-2fb89d209b21,[Données non publiées],co-gérant,EURL Hôtel Noble SCI [Données non publiées],
+079642f4-7b9b-451f-b464-29bfd24f3558,[Données non publiées],EDF,Cadre commercial,
+0799c06c-3f04-4854-ac75-35754df05e39,[Données non publiées],HOLCAR,[Données non publiées],
+079a6f06-2192-4d4f-984e-baeb3c9ece20,[Données non publiées],ELIOR Services,[Données non publiées],
+079b63ec-4b10-4a8f-a3f3-c47062dbd206,[Données non publiées],SASU [Données non publiées],Secrétariat comptabilité à temps partiel,
+07a515ef-dbb5-473c-b1e2-b70e9ee9e7da,[Données non publiées],Naegelen SAS,Responsable Administratif et Financier,
+07aee395-0f17-459a-ab62-0fdc6bac4a75,[Données non publiées],auto-entrepreneur,Psychologue,
+07b6520d-be9f-4a1a-ace6-1c451d5a7ac6,[Données non publiées],NEANT,NEANT,
+07d54685-e642-4e06-a767-f9f38f994eeb,[Données non publiées],Tennis Club [Données non publiées],Chargé de communication,
+07ddb2ac-73bc-4e24-85f9-ab7357d87dac,[Données non publiées],Indépendant,agent immobilier,
+07e20a5c-f8a4-4308-89eb-40c3e0155575,[Données non publiées],Education Nationale,Personnel de direction,
+07e92f0b-5a75-4cf6-91dd-3abb6eda8fce,[Données non publiées],Caisse Primaire d'Assurance Maladie,Manager [Données non publiées],
+07eb87f0-242c-423c-b770-e258daaad21e,[Données non publiées],Conseil départemental du Var,Attachée territoriale principale [Données non publiées],
+07f4ec39-7b9a-44e2-826e-21e8e7f70069,[Données non publiées],[Données non publiées],Néant,
+0804d931-2234-4ff8-b532-5ca4be3a0542,[Données non publiées],Néant,Néant,
+0806715b-f839-4083-bcd9-a25b9b5bbc92,[Données non publiées],chacun sa rose,fleuriste,
+081e43f8-ad17-4a6c-8f61-b08747977848,[Données non publiées],entreprise individuelle,Courtier en assurances de personnes.Commerçant et assimilés.,
+08205708-2c2c-4e60-95d4-ff73138f4566,[Données non publiées],COOPERATIVE [Données non publiées],FROMAGER,
+08209bb5-e7fd-483a-b6bf-405b2f8fa6ba,[Données non publiées],HYGIENAZUR,RESPONSABLE D'ETABLISSEMENT,
+082bc1c8-6d38-42d8-86f8-f52d34a4c105,[Données non publiées],Infirmière,profession exercée dans un cadre libéral,
+0835b23f-100e-422b-8409-b6ef23038429,[Données non publiées],AISMT36,[Données non publiées],
+08365dd2-7e6e-4118-b2a2-f3d385428034,[Données non publiées],Société EKNO,Directrice [Données non publiées] [Données non publiées],
+0836d7ee-a539-4f59-9f11-d42470dcb2ab,[Données non publiées],NOM PROPRE,RESTAURATEUR,
+083bc8cf-6b1b-43e7-8f63-b2a4833f5a72,[Données non publiées],Profession liberale,Notaire [Données non publiées],
+08474268-6651-483f-9d86-a3ef8750d4fe,[Données non publiées],CEREP,Arthérapeute,[Données non publiées]
+0848c952-ed67-4039-ba9f-32debd739e91,[Données non publiées],Ecole [Données non publiées],Enseignante,
+08595435-a7cf-48e0-96e8-403950962493,[Données non publiées],Education Nationale,Professeur de Sport,
+085b5cc9-ff58-4f71-9ca5-941dcec138a2,[Données non publiées],Agriculteur,Responsable d'exploitation agricole,
+0864e1b5-b63d-4f04-8517-b36af9da3de7,[Données non publiées],Communauté de communes [Données non publiées],Directrice générale des services,
+08756afd-7e38-442a-bb36-650eecf4b3a0,[Données non publiées],CHU [Données non publiées],Ingénieur,
+088848c9-64c8-4817-bf2a-dc50ef926761,[Données non publiées],néant,néant,
+0888ba09-f34a-4964-aa4e-58c92f0cb424,[Données non publiées],Assistance Publique - Hôpitaux de Paris,Interne [Données non publiées],
+088e14d4-94cc-4fc3-aeff-83799f57e842,[Données non publiées],Eurazeo,"""Managing Director - Portfolio Performance"" [Données non publiées]",
+089fc2ef-c2ee-458e-939e-82d61a871b51,[Données non publiées],Education nationale,enseignante,
+08a3a43b-f5ed-400f-9bc7-2a47c6cf5a57,[Données non publiées],EARL [Données non publiées],Gérante,[Données non publiées]
+08b010ad-a138-49fb-b6b6-a7b6260721a3,[Données non publiées],Auto-entrepreneur,Enseignement en centre d'apprentissage,
+08b670ed-6c5b-420f-9b93-406d07fa9ad2,[Données non publiées],CHRU [Données non publiées],Cadre Supérieur de Santé,
+08b9fa20-1b88-4d46-a542-1dfdc03d2d84,[Données non publiées],sans,Néant,[Données non publiées]
+08bde402-7036-4f0b-b6f0-5bbe944e0995,[Données non publiées],Mairie de sains en gohelle,Directrice générale des services,
+08ce5808-f7e2-459b-9dbe-8af4cf61889c,[Données non publiées],Laboratoire [Données non publiées] [Données non publiées],Secrétaire Médicale [Données non publiées],
+08db06f3-a179-4ead-aad5-e7c3fb85247e,[Données non publiées],Société Dewalt,[Données non publiées],
+08e06c2b-9cc1-4cd8-a339-1301cf102613,[Données non publiées],auto-entrepreneur,Conseillère en décoration d'intérieur,
+08f18bdc-976d-4c70-86de-aaa1b368c13b,[Données non publiées],CLAROPLAST,employé d'une société de fabrication de menuiseries PVC. [Données non publiées],[Données non publiées]
+08fcc616-23c5-4748-b8f5-53ec68975e95,[Données non publiées],commerçante indépendante,Fabrication de pain et gâteaux bio et négoces de produits régionaux,
+08fcc616-23c5-4748-b8f5-53ec68975e95,[Données non publiées],Sarl Le Poher hebdo,graphiste polyvalente,
+09008b35-0eac-4db2-8d69-c38277e879ab,[Données non publiées],aucun,[Données non publiées] sarl maki papier recyclé confection artisanale articles papeteries,
+0903ae44-7381-4252-b293-68c67a314fe5,[Données non publiées],Laboratoire Serres,laborantine,
+09065bc9-a045-4357-b3db-8529229c1a1e,[Données non publiées],Ets LAURIERE,Agent Comptable,
+0908bfdb-db04-4483-b667-99e7f1607b53,[Données non publiées],[Données non publiées],AGENT COMMERCIAL (PROFESSION LIBERALE) SECTEUR : PYROTECHNIE,
+090c4845-927a-4dad-a50b-0e4fb3e35e46,[Données non publiées],Exploitant individuel,Sophrologue,
+090dab08-e050-4d48-9e4b-0555a3106ca7,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+090e370f-e931-4de1-9ee8-3b95040cbbe4,[Données non publiées],Education nationale,Professeur des écoles,
+0911bd71-fd2b-4d26-989b-b37cfdc86e5c,[Données non publiées],LEROY MERLIN,Cadre,
+0915b9c3-abc4-45d4-9445-792ab63ae032,[Données non publiées],RETRAITEE DE L'ARS,ASSISTANTE DE DIRECTION,RETRAITEE [Données non publiées]
+091e3b93-745f-42f5-848f-13c8b88b1009,[Données non publiées],néant,néant,
+09249938-2a4e-4c69-853a-f7c7cb0b4109,[Données non publiées],[Données non publiées],Retraitée,
+0926c2b7-a27a-4a23-902f-881869c601ff,[Données non publiées],Université Aix marseille et Institut Paoli Calmettes,PU-PH [Données non publiées] faculté de pharmacie [Données non publiées],
+093207f3-e061-4d98-9b02-aea49ce88d35,[Données non publiées],Evolis,technicienne qualité,[Données non publiées]
+0935b450-c4cb-47e4-9143-64301aac726b,[Données non publiées],éducation nationale,professeur de l'enseignement secondaire,
+0940b930-9691-4d77-b594-34fe619abb9d,[Données non publiées],[Données non publiées] Côtes d'Armor,professeur des écoles,
+0952b75d-24a4-4f0a-a0b1-0ce609338329,[Données non publiées],Pharmacien en SELAS,Pharmacien,
+09567712-487c-4870-9ad0-af34726c8b0e,[Données non publiées],[Données non publiées] HOTEL,Gérant,
+096226c0-558b-4bf5-8d70-2c15153b7191,[Données non publiées],profession libérale,vétérinaire,
+09684034-699c-4878-a314-40a961378d5b,[Données non publiées],SDIS des LANDES,Sapeur pompier professionnel,
+096ea93f-c5d1-4818-bf28-0f0e395d3a8d,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+096ea93f-c5d1-4818-bf28-0f0e395d3a8d,[Données non publiées],objectif emplois,conseillère en insertion professionnelle,
+09720d37-a19a-43d9-9e1d-1eeb54062d01,[Données non publiées],neant,Retraitée de l'Enseignement,[Données non publiées]
+0982b7b3-78f9-421a-922c-48b51db24d24,[Données non publiées],Néant,Retraité,
+0984e2e9-ba32-474b-af26-11894e943b2e,[Données non publiées],Fluid Automation System (Suisse),Directeur de site,[Données non publiées]
+0984e6ad-7e07-4f2d-b490-21a495a3d8ec,[Données non publiées],Travailleur indépendant,Consultant RHMusicien,
+098660a1-959f-4e88-a682-c706165e7340,[Données non publiées],Avermes Distribution,Employée de Commerce,
+098b63b7-7334-4053-a114-ad13dee3215e,[Données non publiées],CNRS,Chercheur,[Données non publiées]
+09921cc3-736c-41aa-b23c-1dd0dbfe9dfa,[Données non publiées],NEANT,Retraitée depuis le 1er mars 2013,
+099385f7-4dae-4ff3-8b1e-64135db39b90,[Données non publiées],Université Paris 8,Maitre de conférence,
+099714ac-b5c6-445a-b003-e47bb3e81b33,[Données non publiées],Professionlibérale,Orthophoniste,
+099f1cbc-11a0-4fb0-9ebf-e590824d692d,[Données non publiées],LIVCER,[Données non publiées] Expert de l'impression en continu pour l'industrie,
+09a0fba0-049b-4866-be2d-cddbe7a079af,[Données non publiées],Communauté de communes des 4 rivières,Animatrice de Relais Assistants Maternels Itinérant,
+09b239e0-3055-4e0a-892a-b3b7858174cf,[Données non publiées],Centre Hospitalier [Données non publiées],Infirmière DE,[Données non publiées]
+09b8477b-5d1a-4c99-8666-f3d6ac4468e8,[Données non publiées],BIORYLIS,Secrétaire,
+09c3d532-ea19-420d-9d49-51804a56457e,[Données non publiées],Adobe,Ingénieur,
+09cf347c-ba69-4ba7-979d-8ed3a651dd7e,[Données non publiées],SNCF,Cadre statutaire SNCF,
+09cf3fba-ec9c-47d5-b6af-fc804d6094c0,[Données non publiées],Ministère de l’interieur,Gardien de la paix,
+09d77559-90f0-4a34-b93e-8caccb89ec92,[Données non publiées],CIAS,adjointe administrative,
+09e9ff67-a4ec-47b1-bfa2-ebe869db3cac,[Données non publiées],Agriculteur,Éleveuse canin,
+09ed12b6-d133-447c-81d7-e55055349f7c,[Données non publiées],Hutchinson France,Support IT,
+09f55d57-6198-4dbf-9489-e428c3e181cd,[Données non publiées],conseildépartementaldelaNievre,[Données non publiées],
+09f599b1-945e-490e-b2a8-54c7c12bf4bb,[Données non publiées],Fédération Française de Randonnée 35,animatrice,
+09f849db-7b1e-41fa-830e-13fae1db59cd,[Données non publiées],VINCI,Directeur du Business développement [Données non publiées],
+09f91d76-fd4d-4520-83a7-af36d68c9d8f,[Données non publiées],MAIRIE DE LANESTER,[Données non publiées],[Données non publiées]
+09fd4d20-a0b4-45fb-aba6-d5e3d7f3ec53,[Données non publiées],SARL Montagnani,[Données non publiées],néant
+09fd4d20-a0b4-45fb-aba6-d5e3d7f3ec53,[Données non publiées],sarl montagnani,[Données non publiées],
+0a03f266-e430-48f8-90a8-64088236a978,[Données non publiées],parti communiste français,[Données non publiées],
+0a1317f4-6964-4fc0-b09e-f1ca277f1496,[Données non publiées],Sénat,[Données non publiées],
+0a242918-0025-4441-82d0-d546bef00109,[Données non publiées],Ministère de l'éducation Nationale,Professeur des écoles,
+0a2a8bbf-1992-4f75-8855-01f0e1050e59,[Données non publiées],Education Nationale,Professeur des Ecoles,
+0a337059-6d34-4329-abd0-29f2e558784d,[Données non publiées],Education Nationale,professeur des écoles,
+0a36723a-6075-4086-bd22-4b06862c65aa,[Données non publiées],[Données non publiées],Gérant d'une agence de conseil en communication,
+0a3c3009-685c-43a5-a958-28593c975c77,[Données non publiées],Ministère de l'Education Nationale,Enseignant,
+0a40b172-1804-4251-a41c-cfe07536f85f,[Données non publiées],Mairie de Saint Pierre,[Données non publiées],
+0a48b38c-8efb-46ef-8c5c-5fb687587769,[Données non publiées],le Grand Chalon,Fonctionnaire publique territoriale [Données non publiées],
+0a58b4ca-92fe-43a7-8f2d-d6bc1ca13807,[Données non publiées],diocèse de Luçon,[Données non publiées],
+0a595381-e732-4d5b-ae40-6b4f504a69b0,[Données non publiées],CENTRE HOSPITALIER [Données non publiées],AUXILIAIRE PERICULTRICE,
+0a65a3f4-68ea-4e51-b854-cc8aa534e213,[Données non publiées],CCIR pays de la loire,[Données non publiées] accueil,
+0a70dec8-6670-4890-8329-6567a2aa81a2,[Données non publiées],neant,néant,
+0a7126ff-8317-4718-930c-6491fb29520d,[Données non publiées],[Données non publiées],Cadre territoriale,
+0a8a0e6d-5e9b-4339-907f-4612bc9a5b55,[Données non publiées],[Données non publiées],MENUISERIE,
+0a8a0e6d-5e9b-4339-907f-4612bc9a5b55,[Données non publiées],[Données non publiées],MENUISERIE ALU,
+0a8a0e6d-5e9b-4339-907f-4612bc9a5b55,[Données non publiées],[Données non publiées],HOLDING,
+0a8a0e6d-5e9b-4339-907f-4612bc9a5b55,[Données non publiées],SCI [Données non publiées],IMMOBILIER,
+0a8a0e6d-5e9b-4339-907f-4612bc9a5b55,[Données non publiées],SARL LA SABLIERE,Gestion d'équipements de loisirs et événementiel.,
+0a8fd281-0c8e-49a1-aac1-4c2395a417fd,[Données non publiées],Ville de Rennes,chargée de mission [Données non publiées],
+0ab2bace-ad39-401d-a929-7f430c3ae406,[Données non publiées],SAS [Données non publiées],PRESIDENTE,
+0ab56911-c379-4f57-b060-f1e80b8233ea,[Données non publiées],Haut Bugey Agglomération,[Données non publiées],
+0abfafe9-9a08-4b8c-9f30-7d9dab3e6a71,[Données non publiées],Centre de Gestion de la Guadeloupe,Fonctionnaire Territorial,
+0ac4987e-c53b-4a96-8d0b-b244687f8310,[Données non publiées],Département de Loire Atlantique,[Données non publiées],
+0ac74c3e-7b32-4f22-8a90-06215a907a0f,[Données non publiées],Université Jean Monnet,Ingénieur d'études,
+0acecfbc-9cb4-45df-b534-6f872499b504,[Données non publiées],travailleur indépendant,[Données non publiées] SARL EDITIONS PALLADION,
+0ad6155e-46b7-476b-bc05-9b11ea687795,[Données non publiées],Ferme des templiers,Chef d'exploitation,[Données non publiées]
+0ad6eb0d-9bc8-4b8d-ae0d-31d72addec51,[Données non publiées],[Données non publiées],SANS ACTIVITES [Données non publiées],
+0ad99016-608c-4fec-aae7-d4021f8fd772,[Données non publiées],EPDSAE,Secrétaire [Données non publiées],
+0ad9d445-3d22-43ef-b093-f7ec051d9af4,[Données non publiées],profession libérale,Medecin pneumologue,
+0af2b252-2f5f-43f8-ab53-141f0b8ea080,[Données non publiées],[Données non publiées],[Données non publiées] [Données non publiées] exploitation agricole [Données non publiées],
+0b03ec85-d9be-4177-ab30-2e9e349cc287,[Données non publiées],REGION REUNION,FONCTIONNAIRE TERRITORIAL,
+0b0fd414-2ed4-4b7b-be7c-fd2fbc202586,[Données non publiées],Ministère de l'Agriculture,Chef du service [Données non publiées],[Données non publiées]
+0b114b72-86eb-44a4-b305-e375908dd8f4,[Données non publiées],CRESS Pays de la Loire,Chargée de mission [Données non publiées],
+0b1af6a5-e96b-48ad-9f35-a90eea1b38f0,[Données non publiées],Néant,Néant,
+0b23799f-0a6a-4b0e-882f-d51a6b5ce480,[Données non publiées],Education Nationale,Professeur des Ecoles,
+0b26be78-df95-40ea-9850-a970de9f853c,[Données non publiées],Société [Données non publiées],[Données non publiées] / agent de maîtrise,
+0b27807f-9b21-4507-81d7-a1e73121419e,[Données non publiées],[Données non publiées],collaborateur parlementaire,
+0b35b1e3-cf6c-4448-9a18-ea831a916c55,[Données non publiées],caisse d'épargne,responsable sécurité,
+0b365f7c-2787-4560-a255-b0585eae5954,[Données non publiées],Mairie [Données non publiées],Fonctionnaire,
+0b44a9cd-97c9-461a-a45a-0a86ff80d3ed,[Données non publiées],Ville de Ifs,Responsable [Données non publiées] Fonctionnaire catégorie A,
+0b5cb656-d0b3-48aa-a5d7-4f7bb22b632d,[Données non publiées],[Données non publiées],[Données non publiées],retraitee [Données non publiées]
+0b63cda8-9888-47a9-93dd-d30ca78f7b54,[Données non publiées],SMTP (LINGENHELD),DIRECTEUR D'AGENCE cadre dirigeant,[Données non publiées]
+0b6ff389-4836-4a72-8c50-cb3fbe0176a9,[Données non publiées],[Données non publiées],[Données non publiées] Commerce de détail alimentaire sur éventaires et marchés,[Données non publiées]
+0b6ff389-4836-4a72-8c50-cb3fbe0176a9,[Données non publiées],[Données non publiées],[Données non publiées] Aquaculture en mer patente prise le 27 mars 2007,[Données non publiées]
+0b855a13-cdd3-49c6-9f86-19eef04bb522,[Données non publiées],CGT,Administrative,
+0b86684c-ff3a-407f-b519-d5d46f2e8199,[Données non publiées],néant,retraité,
+0b89173d-8f2f-48d7-8c95-c81a9d3d01dd,[Données non publiées],CIC [Données non publiées],CADRE,
+0b95f3c9-f34b-4773-8533-4ff8c760e2c6,[Données non publiées],Econocom,Directeur des affaires stratégiques,[Données non publiées]
+0b9ad40a-4729-4bb1-82cc-3d07af7ef9ab,[Données non publiées],diocese le havre,[Données non publiées],
+0b9f10d1-7d54-44b0-acf0-c60fcfd99354,[Données non publiées],RETRAITE,Retraite d'exploitant agricole,
+0ba18818-6f0a-450c-817d-0a91270879d3,[Données non publiées],Valtech,Consultante,
+0ba1b0a8-2f92-4586-afa9-abbf14d4fa36,[Données non publiées],SELARL MASQUELIER,secrétaire,
+0bac4342-4dba-4608-9ca7-a56bed413288,[Données non publiées],NOVAXIA,[Données non publiées],
+0bbd094b-c9f2-4d22-891d-63ed446b1ac3,[Données non publiées],DGFIP,Contrôleur des Finances Publiques,[Données non publiées]
+0bbd094b-c9f2-4d22-891d-63ed446b1ac3,[Données non publiées],Profession libérale,Infirmière libérale,[Données non publiées]
+0bbd8b85-ea79-4d56-b387-99046c9e7f49,[Données non publiées],[Données non publiées],Architecte libérale,
+0bce7d3b-6532-4374-8442-ab7d9deeecdb,[Données non publiées],Pharmacie [Données non publiées],secretaire,[Données non publiées]
+0bce7d3b-6532-4374-8442-ab7d9deeecdb,[Données non publiées],ASA [Données non publiées],secretaire,[Données non publiées]
+0bd28174-fcc3-4c8b-aa00-e0b309733ae6,[Données non publiées],AFD,Directeur exécutif adjoint,
+0c004b01-e303-45cb-b32d-c53ede26d413,[Données non publiées],DANONE,Cell manager [Données non publiées],
+0c017242-9ff9-48d2-b5c4-541f481ed637,[Données non publiées],Education Nationale,Enseignante,
+0c02b199-2a3f-460a-9301-36b98ed75503,[Données non publiées],Groupe Abbvie,[Données non publiées],
+0c02db5f-2241-4aaf-96e2-4f2c3cccccb4,[Données non publiées],ETS TARDY,ouvrier spécialisé dans la metallurgie,
+0c02db5f-2241-4aaf-96e2-4f2c3cccccb4,[Données non publiées],[Données non publiées],[Données non publiées],
+0c03c8ec-9ee5-4e20-892f-271e9b5c8dbc,[Données non publiées],Fédération des élus des entreprises publiques locales,Responsable département [Données non publiées],
+0c041d97-a760-48bc-b2bc-0a04cff0c9d2,[Données non publiées],SNCF,Directeur de Ligne TER [Données non publiées],
+0c0ad206-f1d6-4c57-b68d-92bc8c5c4be9,[Données non publiées],Néant,Néant,
+0c0c041f-a7c2-4b67-af75-ab679fc24df9,[Données non publiées],Retraitée,Néant,
+0c154239-caeb-45d4-aea3-b597c74a6e31,[Données non publiées],Neant,Neant,[Données non publiées]
+0c15ea50-d61d-4efe-bd62-385e6bea5188,[Données non publiées],Lycée [Données non publiées],Enseignante,
+0c2166f0-bdf8-47bd-a2cd-7544e1dd976b,[Données non publiées],[Données non publiées],Vendeuse,
+0c3ac148-7805-4971-aa48-ed796b9b7975,[Données non publiées],NEANT,NEANT,[Données non publiées] ELU LOCAL
+0c44cc22-0ad7-4b36-bb04-ac739bb68d00,[Données non publiées],Crédit Mutuel Arkéa,Responsable de service [Données non publiées],
+0c519a2d-1f4c-4ec3-a64f-6c466384c2cd,[Données non publiées],MINISTERE EDUCATION NATIONALE,ENSEIGNANTE CONTRACTUELLE [Données non publiées],
+0c519a2d-1f4c-4ec3-a64f-6c466384c2cd,[Données non publiées],OGEC [Données non publiées],[Données non publiées],
+0c5e9833-7026-4c45-a7f0-e60396c31e50,[Données non publiées],Hopital de Moisselles,[Données non publiées],[Données non publiées]
+0c5efbfe-53fa-4fff-9142-a9f0175fdf0d,[Données non publiées],Retraité,Retraité de la fonction publique territoriale,[Données non publiées]
+0c5efbfe-53fa-4fff-9142-a9f0175fdf0d,[Données non publiées],SAS CAMPET Entreprise,Ouvrier niveau II [Données non publiées],
+0c62d19b-ece3-49f2-8849-62012a56ee3f,[Données non publiées],Police Nationale,[Données non publiées],
+0c62d19b-ece3-49f2-8849-62012a56ee3f,[Données non publiées],Police Nationale - [Données non publiées],agent retraité,
+0c62d19b-ece3-49f2-8849-62012a56ee3f,[Données non publiées],POLICE NATIONALE,[Données non publiées],
+0c7294a9-dedd-4f71-bdc6-21ef44ce6fa5,[Données non publiées],neant,Retraitée de l'Enseignement,[Données non publiées]
+0c743cd6-5505-4a20-a5d4-754e215abf81,[Données non publiées],TECNIMODERN,[Données non publiées],
+0c74a0f9-a573-40da-bbfa-b606a44b1ed5,[Données non publiées],[Données non publiées],[Données non publiées],Retraité [Données non publiées]
+0c7c3e10-d876-4e9a-94e7-e927304d48fa,[Données non publiées],Entreprise individuelle,Infirmière Diplômée d'Etat Libérale,
+0c8221bd-1569-498e-8d20-16111ed987d2,[Données non publiées],ALTIM FRANCE,Ingénieur. [Données non publiées],
+0c8292a3-43d1-4a0d-b3ca-2215a2e2a855,[Données non publiées],Assemblée Nationale,Député du Nord Conseiller régional des Hauts-de-France,
+0c84f615-a132-4884-bb8f-61e49e29ef8e,[Données non publiées],[Données non publiées] retraitée,[Données non publiées],
+0c90c76a-8540-4e2f-8ff2-ab6307a0f3b8,[Données non publiées],CRF TE TIARE,Président Directeur Général,
+0c90c76a-8540-4e2f-8ff2-ab6307a0f3b8,[Données non publiées],AIR TAHITI NUI,NEANT,PRESIDENT DU CONSEIL D'ADMINISTRATION (04/04/2025)
+0c90c76a-8540-4e2f-8ff2-ab6307a0f3b8,[Données non publiées],AEROPORT DE TAHITI,NEANT,MEMBRE DU CONSEIL D'ADMINISTRATION [Données non publiées]
+0c915dbf-b517-4364-97d6-14c036af4f89,[Données non publiées],EDF,Activité commerciale,
+0c922148-83b4-4f90-8c54-4a792ce096a8,[Données non publiées],Education nationale,Adjointe admnistrative,
+0c9d8d2e-edb4-437b-92cb-b13b7f5622bc,[Données non publiées],Crédit Agricole Réunion,Animatrice d'activité,
+0ca63d80-982d-4c05-a6d8-bc8f55a7888f,[Données non publiées],néant,néant,
+0cb810eb-c9b4-4ada-8a31-3bca4040c68c,[Données non publiées],retraitée,Néant,Gérante [Données non publiées] SARLE DEWEZ [Données non publiées] [Données non publiées]
+0cc5771d-6297-4af8-9820-4a0e3204deaf,[Données non publiées],TEHOGIHIA,Commerce d'alimentation générale,[Données non publiées]
+0cc7df46-359e-4d36-87f5-267f83703488,[Données non publiées],Médecin Libéral,Médecin Ophtalmologiste,
+0ccb9a12-3cb8-4f35-b3af-6ac37c826a6d,[Données non publiées],Caisse d'épargne,Gestionnaire de comptes,
+0ccea5fd-5446-45a4-8d49-e1a1b71f5044,[Données non publiées],Micro entreprise,Conseil en ingénierie historique,[Données non publiées]
+0ccea5fd-5446-45a4-8d49-e1a1b71f5044,[Données non publiées],SainteMarieduMont,[Données non publiées],salarié
+0cdb24eb-80c2-47df-a047-cc7ddb7f71c0,[Données non publiées],néant,néant,
+0cdbaac1-3d47-475e-b62b-a56c0109b89c,[Données non publiées],chu [Données non publiées],masseur kinésithérapeute,
+0ce962cb-7d76-42db-9553-670ccadaef5a,[Données non publiées],Viticulteur ( son propre employeur),Viticulteur,
+0cecc254-4077-4330-a40f-f57bd80ad70e,[Données non publiées],retraité,[Données non publiées],
+0d0088a8-dc35-4927-bb11-263ebaa3b53e,[Données non publiées],néant,infirmière libérale,
+0d049263-0479-474b-bf16-af656ddb2d27,[Données non publiées],Centre Hospitalier de Laval,Infirmière,[Données non publiées]
+0d0de2ec-2068-4a37-bbee-4097984d0b20,[Données non publiées],NEANT,NEANT,
+0d18b1ea-e111-43dc-a93d-41b314fb00cd,[Données non publiées],credit agricole [Données non publiées],employée de banque,
+0d216d85-02b0-4084-974b-85bdb9ab4c8f,[Données non publiées],Procivis Maisons Individuelles,Assistante de Direction,
+0d2369a3-0730-4ee8-895a-1aed9f2eb972,[Données non publiées],NEANT,NEANT,RETRAITÉE
+0d3788f9-9698-4c35-9c62-e28bc8d70ec8,[Données non publiées],CABINET [Données non publiées],ASSISTANTE DENTAIRE,
+0d453a66-3793-4388-abca-71980f710aa6,[Données non publiées],Congrès de la Nouvelle-Calédonie,[Données non publiées],
+0d569695-a920-4650-bc75-c174c09fd745,[Données non publiées],NEANT,NEANT,
+0d5fc172-0654-4f42-b3de-488b004b025f,[Données non publiées],Jacer Primeur,Vendeur [Données non publiées],
+0d643761-7db2-4dc0-82ec-db546fdd36ed,[Données non publiées],ESMD/Université Lille,[Données non publiées],[Données non publiées]
+0d724614-9b11-4bc3-893b-82b7d4a9cd4f,[Données non publiées],Hilti France,Directrice [Données non publiées],
+0d7d74dc-ecc7-4e74-acc3-45e292a42740,[Données non publiées],Société Béguet,Soudeur,
+0d87ea95-50dd-4fd5-9d6a-310a6cfd280a,[Données non publiées],retraité,retraité,[Données non publiées]
+0d8979d2-0e15-4ee9-922f-69d7ea77fac1,[Données non publiées],sdis 34,adjoint administratif,
+0d907d8f-d9f4-42b9-bbac-955058e85452,[Données non publiées],clinique [Données non publiées],Infirmiere,[Données non publiées]
+0d9258a0-0acc-499a-a111-65298263d896,[Données non publiées],GHM [Données non publiées],Infirmière,
+0da991f4-f221-41bf-b06f-bde9e770cd56,[Données non publiées],Radio France et Marinca Prod,Journaliste,
+0dc392bc-8aa7-48d3-9780-50cd8786f6dc,[Données non publiées],EARL des Galets,Secrétaire,
+0dc546e4-afc3-4280-a487-457de7f9824e,[Données non publiées],NEANT,RETRAITEE,
+0dc7d6d9-aff4-4fae-a2d1-da0bb0a43ee9,[Données non publiées],EDUCATION NATIONALE,[Données non publiées],
+0dd424b5-fb7f-4a57-add0-b76e198778d5,[Données non publiées],Education Nationale,Enseignante,
+0de8cbe5-98ae-487c-a07f-923a2ee78747,[Données non publiées],Mairie [Données non publiées],Agent Territorial Spécialisé [Données non publiées],
+0de90d87-1ebf-4b5f-84bd-fb4d4173fb8b,[Données non publiées],Chef d'entreprise,Dataanalyste,
+0df5941e-2dd8-43ae-80c3-959b8f7f493a,[Données non publiées],AIRBUS SAS,Cadre [Données non publiées],
+0dfb7060-3952-4433-af1e-61da0beae292,[Données non publiées],néant,étudiante à l'université Paris-Nanterre,
+0e0870fa-8c16-487d-9cdf-a97bacf75d5c,[Données non publiées],[Données non publiées],MEDECIN RHUMATOLOGUE LIBERAL,[Données non publiées]
+0e09f416-70cb-49c4-abb5-3df624444a96,[Données non publiées],néant,Retraité,
+0e19457e-77ed-4a69-837e-90f86562c614,[Données non publiées],Arkéa Banking Services,Responsable [Données non publiées],[Données non publiées]
+0e1aeeae-d258-49bd-be7f-346f5788f935,[Données non publiées],[Données non publiées],Société d'Economie mixte,Emploi d'assistante [Données non publiées] [Données non publiées]
+0e21a0fb-3dfc-4818-9588-1e39e601c247,[Données non publiées],régie du palais des congrès,directrice [Données non publiées],[Données non publiées]
+0e37dd43-b1f6-4f44-ae02-872959da7cfe,[Données non publiées],mairie de Saint-Denis,Secrétaire,
+0e391ca6-4323-4215-b91a-17169ba0cb1f,[Données non publiées],profession libérale,infirmière à domicile,
+0e4a5483-373a-4096-8e07-1cd4dd13550c,[Données non publiées],néant,néant,retraitée
+0e5261f7-f298-4c76-bb0e-2377404dd058,[Données non publiées],SCEA [Données non publiées],Gérant,
+0e5ddfd4-d152-4803-b07c-e9053020490b,[Données non publiées],Département du Nord,[Données non publiées],
+0e6c7918-e1b7-4436-ba3f-70bbb3786f90,[Données non publiées],Ville de Saint-Denis,Ingénieur sans activité. élu local depuis le 4 juillet 2020 (ville de Saint-Denis et EPT Plaine COmmune),[Données non publiées]
+0e6f4a82-be1d-4f0a-9434-a879209c72ef,[Données non publiées],Présidence de la Polynesie Française,Comptable,[Données non publiées]
+0e75ed9f-00f5-4a73-a3fc-007a6eb8f363,[Données non publiées],association Isard COS,Infirmière,
+0e80ef88-cd81-4973-98db-78f72081069a,[Données non publiées],ARTISAN,Artisan,
+0e8354bd-c91a-445b-9260-e4c87d1f9e5e,[Données non publiées],Lycée Général et Technologique et Lycée Professionnel [Données non publiées],"Professeur d’Education Physique et Sportive. Activité complémentaire d’autoentrepreneur à compter du mois de mai 2019, dûment autorisée par les services de l’Education Nationale au titre des cumuls.",[Données non publiées] A cessé cette activité complémentaire au terme de sa première année.
+0e8a8929-b8f6-4890-9235-608008617541,[Données non publiées],Sans emploi,[Données non publiées],
+0e8bd306-0b28-4cbb-b5e1-50333fc75f13,[Données non publiées],néant,néant,
+0e8dc006-0012-4df3-ac72-46aeddc432b1,[Données non publiées],[Données non publiées],VENDEUSE,[Données non publiées]
+0e8dc006-0012-4df3-ac72-46aeddc432b1,[Données non publiées],UDAF,MEDIATRICE FAMILIALE,[Données non publiées]
+0e949bf4-106b-4827-9f1f-c417119ad388,[Données non publiées],Sénat,Assistant parlementaire,
+0ea1f47f-ee17-4394-b913-79554caa39a9,[Données non publiées],néant,néant,
+0ea4fd64-5754-42a6-86b0-8d9da8eefa29,[Données non publiées],Viltaïs,Directrice Générale Adjointe,
+0eaa87ba-905f-49a2-8ea7-85269e468ccf,[Données non publiées],Ville d'Aix-les-Bains,[Données non publiées],[Données non publiées]
+0eac5566-869c-400f-8f41-b268447ab215,[Données non publiées],promens,[Données non publiées],
+0eafd493-10a3-4e57-8b94-3246b0e6df98,[Données non publiées],France Télévision,Journaliste,
+0eb56834-9ec5-46c3-a6fa-1dd035f69480,[Données non publiées],néant,néant,[Données non publiées] retraitée
+0eb821b0-58f2-44da-8296-638d71460fb7,[Données non publiées],Association diosesaine,Assistante de Service,
+0ed220a2-e214-4a6d-9ef0-8e6aa0b896f0,[Données non publiées],kingfischer,Acheteuse bois [Données non publiées],
+0ed716a9-edbb-4a9d-b0ff-d49fb3a2550f,[Données non publiées],néant,néant,
+0ee98bc3-87dc-40f5-8e5f-c84a9f866e97,[Données non publiées],Parents,Assistante maternelle,
+0eeb66a2-dcaf-4dbf-a46f-99fcd6ef6b4e,[Données non publiées],CHU [Données non publiées],Chef d'unité fonctionnelle,
+0ef8642c-e0bc-4cf6-bb9d-ffaaf5ddf4b9,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] sans emploi [Données non publiées]
+0effd410-9379-400e-b4b2-b59b228da0c2,[Données non publiées],EDF,Chef de quart,
+0f131ce8-eedf-4295-a0ab-1fe915b084de,[Données non publiées],Education Nationale,Professeur des écoles,
+0f26a07d-9c1d-4f23-9d5a-1d56b36164b3,[Données non publiées],[Données non publiées],Enseignement à domicile,
+0f26e2d6-6143-4deb-8282-ad166b969959,[Données non publiées],Néant,Néant,
+0f340aca-d3b2-47b9-9f66-5af4652f93e9,[Données non publiées],AUCUN,AUCUNE,
+0f386673-ca0d-4f1f-af56-a363c2862f99,[Données non publiées],Gerante de sociétés,prêt a porter,
+0f47e417-bc8a-418a-8e36-f9333c33096a,[Données non publiées],Ministère de l'intérieur,Commissaire divisionnaire,
+0f596608-aea5-4538-aba0-bf0a856fe620,[Données non publiées],Biocoop / Les 7 épis,Responsable de rayon,
+0f5e48c5-1de0-422f-9a88-0f735a9c086a,[Données non publiées],Batibois [Données non publiées],cadre [Données non publiées],
+0f620a0c-1990-47eb-9002-26357d6f69c2,[Données non publiées],[Données non publiées],"Etiopathe, activité libérale",début de l'activité en juin 2021
+0f81d712-fa16-41e1-ac7d-95521754c78d,[Données non publiées],ENERCON,VENTE ET ENTRETIEN D’ÉOLIENNES,
+0f83b029-b605-4323-b796-396ef19402bb,[Données non publiées],Deficom,[Données non publiées],
+0f8d37db-f196-40ba-bca1-3a120be951d8,[Données non publiées],Département des Hautes-Alpes,Fonctionnaire territorial catégorie AChef de Service,
+0fa570a8-4370-4526-b699-5032ca20e37c,[Données non publiées],RETRAITE,NEANT,
+0fb1ed96-cf7b-4a36-aac6-dc4e322e6cbf,[Données non publiées],Clinique vétérinaire [Données non publiées],Vétérinaire salariée,
+0fbdd287-aa86-46fe-b361-9bf70f32b3be,[Données non publiées],Radiologie [Données non publiées],secrétaire administrative et comptable,
+0fc2e2e4-e0b2-4876-bb80-255d3e2d5375,[Données non publiées],[Données non publiées],[Données non publiées],Retraitée
+0fcb81c0-ea9e-44ee-905a-cb4d0ffa2a37,[Données non publiées],Mairie de [Données non publiées],Agent territorial [Données non publiées],
+0fcbdb31-4603-4bd1-bfda-d66f42322fc2,[Données non publiées],Mairie d'Amiens,> Maire-adjoint élue en charge de la jeunesse de 2014 à 2020. > Conseillère Municipale depuis 2020,
+0fcbdb31-4603-4bd1-bfda-d66f42322fc2,[Données non publiées],CD 80,- Conseillère Départementale de 2015 à 2021. - Vice-présidente depuis 2021,
+0fcbdb31-4603-4bd1-bfda-d66f42322fc2,[Données non publiées],Amiens Métropole,Vice-présidente en charge de l intelligence des territoires et de l innovation depuis 2020,
+0fcbdb31-4603-4bd1-bfda-d66f42322fc2,[Données non publiées],Somme Numérique,"Vice-présidente du syndicat mixte ""ouvert"" dont la mission principale consiste à déployer un réseau d'infrastructure numérique sur le département de la Somme",
+0fcc3ee0-e6ff-443b-b9ac-081701019ab1,[Données non publiées],SARL SOCA,CABINET EXPERTISE COMPTABLE,
+0fd2ffdd-6d2b-445e-8f97-c3212485c89a,[Données non publiées],Travailleur non salarié,Chef d'entreprise Administrateur de biens,
+0fe6e33e-f8aa-4f0d-83e1-f7e0b0e842e0,[Données non publiées],BNPPARIBAS,Conseiller clients,
+0fe6e33e-f8aa-4f0d-83e1-f7e0b0e842e0,[Données non publiées],BNPPARIBAS,CONSEILLÈRE CLIENTELE,EN RETRAITE [Données non publiées]
+0fedbe49-5933-4275-9603-4326bdbd7b94,[Données non publiées],Centre hospitalier [Données non publiées],Aide soignante [Données non publiées],
+0ff2b285-f377-44d8-8922-c76a00872837,[Données non publiées],ALLIANZ,Conseiller en assurance et commercial [Données non publiées],
+0ff3e728-a0d2-43e1-a180-63cb1e4d8176,[Données non publiées],OGONA,[Données non publiées],
+0ff622dc-ae89-4281-be9a-a478d08c008a,[Données non publiées],Education Nationale,Professeur documentaliste,
+0ff62d96-ccca-4563-a344-7f008fc44f76,[Données non publiées],Néant,Néant,[Données non publiées]
+100071fe-1a04-45b9-9289-afec570dbd41,[Données non publiées],CHU [Données non publiées],Medecin Pédiatre,
+1003208b-27f9-4390-b305-167be6122f90,[Données non publiées],neant,neant,retraité
+10087412-bc31-4a2c-935a-04bb106a786a,[Données non publiées],NEANT,Retraité [Données non publiées],
+100d0256-aa44-41b3-a097-eb93e6f6c204,[Données non publiées],CENTRE HOSPITALIER [Données non publiées],CADRE SUPERIEUR DE SANTE,
+100e329d-e079-40e8-bf6e-b47c621e9799,[Données non publiées],Cabinet Dentaire [Données non publiées],Cabinet Dentaire,
+1015d15f-5c41-4a8c-8615-86f286e3039b,[Données non publiées],Métropole du Grand Nancy,Directeur général adjoint,
+102af3e2-7849-48d1-aa81-3c42537b5881,[Données non publiées],SA MILLET,Fabricant de portes et fenêtres,
+103112d3-c715-46a3-9274-304515b5f18c,[Données non publiées],SCP [Données non publiées],SECRETAIRE JURIDIQUE,
+1031afaf-7187-456f-9ac4-e5fd3792845b,[Données non publiées],SARL MPC,Gérante de SARL [Données non publiées],mandat électif Conseillère Régionale Nouvelle-Aquitaine
+1033de8f-bfe5-463c-9220-f60b06f872a4,[Données non publiées],GRAND CREW CLASSE SASU,DIRIGEANT [Données non publiées],
+103ada34-4e92-4727-9a63-287c02bfbc43,[Données non publiées],Retraité,Retraite,
+103f676c-5143-4ab1-8efa-46264bc3e0b5,[Données non publiées],Cabinet d'avocat MLB (entreprise individuelle),Avocat libéral,[Données non publiées]
+1046eee0-2a6c-4387-9932-4a4c85fa849e,[Données non publiées],Sans,Sans,
+104cfe28-e5d0-4c84-9fe1-ed5b113907e6,[Données non publiées],[Données non publiées],[Données non publiées] neant,
+104cfe28-e5d0-4c84-9fe1-ed5b113907e6,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+104cfe28-e5d0-4c84-9fe1-ed5b113907e6,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+1065bfbc-2501-414c-959e-39477362dd30,[Données non publiées],Néant,Retraitée,[Données non publiées]
+106a8041-2246-46f9-b3b2-f53afbb71abd,[Données non publiées],néant,néant,[Données non publiées]
+10716a1c-4e60-4ce2-8819-24c16621e3d0,[Données non publiées],Mairie d'Oloron Sainte-Maire,Chargé de projet [Données non publiées],
+10745e3b-abfb-4122-9044-443b8817b97a,[Données non publiées],MGB,Directeur commercial,
+10899693-e48e-4a3b-a30a-1db665b89850,[Données non publiées],[Données non publiées],[Données non publiées] EXPLOITATION AGRICOLE EN CAPRIN LAIT,[Données non publiées]
+108ad918-ca99-4ade-8d02-d794425ad304,[Données non publiées],Néant,neant,[Données non publiées]
+108d3bd4-3de6-4a3b-a4af-25f883fa4829,[Données non publiées],Néant,Néant,
+10901e02-ca17-4774-bf3c-97e3643c4c4d,[Données non publiées],Centre Hospitalier [Données non publiées],Infirmier,
+1092fe89-e3c3-4733-a2cf-9839ba454c90,[Données non publiées],Auto-entrepreneur,Frigoriste,
+10941087-31bb-4ebc-a80b-84b851d699f9,[Données non publiées],Hewlett Packard,[Données non publiées],
+10a20aa7-b739-428d-85a9-74c2e42295c7,[Données non publiées],Eiffage TP,Acheteur [Données non publiées],
+10a24209-6a00-4c72-b591-406f25734522,[Données non publiées],MICRO ENTREPRISE,COIFFURE A DOMICILE,[Données non publiées]
+10a37b7f-8c45-4b83-82cd-70d1ce9dee96,[Données non publiées],NEANT,NEANT,
+10ab0f5f-3ab6-4ece-bff5-1a7a73b8574b,[Données non publiées],Daikin,Chargé d'affaires,
+10cbf672-3041-4291-b969-09e8a692162c,[Données non publiées],ministere des finances,agent des impots,
+10d04fde-8be8-4127-a49d-664212177780,[Données non publiées],Commune de Guerlédan,[Données non publiées],
+10d26e55-084d-4fd6-9f3b-d28129ec23be,[Données non publiées],EVAL IMMO,Chef d'entreprise,[Données non publiées]
+10d2cc08-1df4-47e3-9c38-5b08f630a857,[Données non publiées],G-Pods,[Données non publiées],
+10d9c4ae-2563-4a4d-8c1e-02b2d8ba7574,[Données non publiées],Ministère Education nationale,Enseignant,
+10d9c810-1b27-4ff2-a18a-1a3bbadd718a,[Données non publiées],éducation nationale,professeur des écoles,[Données non publiées]
+10de4871-8fac-45ce-baed-cb80754fbbbe,[Données non publiées],RETRAITE,NEANT,
+10e3ca28-c739-403c-83de-2c976e975640,[Données non publiées],Éducation nationale,"Professeur des écoles, [Données non publiées]",[Données non publiées]
+10ef09e7-0b55-44c2-99fb-66157a23a96f,[Données non publiées],neant,en retraite,[Données non publiées]
+10f24658-bdb9-490f-8882-83ce757aaaee,[Données non publiées],Agriculteur,Eleveur,
+10fc08e9-e3be-4426-a36b-0428ffa226b1,[Données non publiées],Centre Hospitalier de Dieppe,Technicienne de laboratoire,
+11165156-3687-4c1e-9485-aba41d97b0be,[Données non publiées],[Données non publiées],Hôtesse d'accueil / Standardiste,
+11195b66-c7d7-447f-9216-424cafafd4fc,[Données non publiées],[Données non publiées],Médecin Généraliste,
+111b1bfd-03f2-4df0-b3fe-e7f87d8210b9,[Données non publiées],USJM,[Données non publiées],
+111b4ae0-b6a7-4174-911b-7489cbb7efa3,[Données non publiées],Centre Hospitalier [Données non publiées],Directrice des Affaires médicales,
+111b77d1-b098-4b88-9190-2bbac135a46a,[Données non publiées],Néant,Néant,En retraite [Données non publiées]
+111c9dc2-c030-46a7-bd4a-d3a35b4035c9,[Données non publiées],Entreprise Individuelle [Données non publiées],Artisan Torréfacteur,
+111ea5a2-e71c-47f0-a884-d40a339da8a3,[Données non publiées],CERGY LOCATION SERVICES,[Données non publiées],
+1120e99f-17fb-46d0-9350-07617276dba4,[Données non publiées],Fund Channel S.A.,Juriste,
+1127b8f7-b251-4960-8bcd-48568fb9ef19,[Données non publiées],retraite,retraité neant,
+1127b8f7-b251-4960-8bcd-48568fb9ef19,[Données non publiées],néant,néant,[Données non publiées]
+112873e2-46c4-420f-9bae-8872efe631b8,[Données non publiées],Ministère de la Culture,Conservatrice du patrimoine,
+1134bcc9-d161-44a8-ac25-156653df1ca1,[Données non publiées],Université Jean Monnet,[Données non publiées],
+1152dc3a-656c-48ba-ad84-4d468031d2ff,[Données non publiées],[Données non publiées],veterinaire,
+11695167-714b-4bb6-87db-3e53e912c832,[Données non publiées],Education nationale,professeur des écoles,
+116afea7-5b50-4411-9104-96794ae74758,[Données non publiées],[Données non publiées],[Données non publiées],retraité
+116ddffb-07c4-4469-8abd-f24ed138a6de,[Données non publiées],CPAM de [Données non publiées],Chirurgien Dentiste,
+116ddffb-07c4-4469-8abd-f24ed138a6de,[Données non publiées],[Données non publiées],Gérante,
+116fbc79-3c68-4f15-9796-a38109264c97,[Données non publiées],Profession libérale,Expert-Comptable - [Données non publiées] [Données non publiées],
+1181553e-cfb8-498a-b473-731c4a91742b,[Données non publiées],AGRIAL,Conseiller_vendeur,[Données non publiées]
+1182be5d-ce80-4864-90bc-fcdbb801d397,[Données non publiées],Atelier [Données non publiées],salarié,
+1183f910-89c7-486d-9a5f-3baefaa45286,[Données non publiées],Education Nationale,Enseignante suppléante [Données non publiées],[Données non publiées]
+118542ce-301c-4f25-bb80-0785acf69b77,[Données non publiées],Auto-entrepreneur,Frigoriste,
+11878731-7979-419b-9729-755d3280fd75,[Données non publiées],Université [Données non publiées],Professeur Agrégé,[Données non publiées]
+118c595a-fddf-4baa-90e6-70cd7e5c598f,[Données non publiées],Education Nationale,Professeur des écoles [Données non publiées],
+118d0bd8-8e16-46fe-b0a7-0a224f54a440,[Données non publiées],néant,Retraitée,Aucune activité professionnelle.
+11afceab-52c0-41c3-a624-867c42a59fac,[Données non publiées],ETS SARRAZIN [Données non publiées],MONTEUR SOUDEUR,
+11ba3008-4728-4674-8958-3c50b592847b,[Données non publiées],néant,néant,[Données non publiées]
+11c03339-f183-4c23-bc0a-0182948852e3,[Données non publiées],CHR PERPIGNAN,[Données non publiées],
+11e1eba9-5341-4ac6-94e0-a2157a480c94,[Données non publiées],[Données non publiées],Architecte libérale,
+11e7ce13-3196-4aa3-8d6f-34023b11bda0,[Données non publiées],Lee Hecht Harrison France,"Consultante senior, salariée",
+11ed9ce1-e79b-48d0-922f-8883a8cf0cab,[Données non publiées],Avocat indépendant,Avocat au Barreau de Paris,
+11f07264-9fe6-4404-8198-85f9c48417f3,[Données non publiées],Kura Construction - EI [Données non publiées],Entreprise en bâtiment - maison d'habitation,
+11f4f41d-b544-4862-a553-23be360f9bfd,[Données non publiées],Mairie de Foug,Bibliothécaire,
+11f58044-fabc-4e19-9155-cfa239d7b9c3,[Données non publiées],Elu de la Ville de Marseille et au département 13,[Données non publiées],
+11ffc3b5-36a7-40e7-9252-76c46b692e11,[Données non publiées],Mairie de Vals les Bains,[Données non publiées],
+120e2ebb-357e-469c-ad25-51a39af1866c,[Données non publiées],université [Données non publiées],[Données non publiées],
+12132981-4426-4340-be96-55f84367bb25,[Données non publiées],OGEC ECOLE [Données non publiées],ASEM,
+12158de2-69eb-4976-be52-4ca612aae190,[Données non publiées],Mairie de Pont-Sainte-Marie,Fonctionnaire,
+1217b4c1-1e3c-4d53-a3e0-9704ecddcc3e,[Données non publiées],Métropole du Grand Nancy,Directeur général adjoint,
+12188199-58b7-4671-a349-e7785002eff1,[Données non publiées],Independante,Formatrice,
+1219d0a5-2dc3-4a85-9ce4-2aa81778b07f,[Données non publiées],Avenir ECO,Technico-commercial [Données non publiées],
+1221a33b-9d7e-491b-a584-76025cedd9f5,[Données non publiées],Retraitée,[Données non publiées],
+1224be98-de8a-480f-9f3a-f651364b1048,[Données non publiées],SAS Fertiléo,Président [Données non publiées],
+122c9b48-77e8-4bfd-b467-5b960c8f21a7,[Données non publiées],SELARL docteur [Données non publiées],Chirurgien Orthopédiste,
+12325ccd-5ed9-44ba-b2ed-537554190885,[Données non publiées],MAM'AISON VERTE,ASSISTANTE MATERNELLE,
+124668b0-e311-4aa8-a31b-1108f85ddc92,[Données non publiées],Ville de Nancy,[Données non publiées],
+124d188c-1bf4-45b7-960f-dd3ceac7da6a,[Données non publiées],retraite,retraiténeant,
+125452b5-710a-403a-b24f-a9a77d9c225a,[Données non publiées],Crédit Agricole Consumer Finance,Directeur Financier,
+1272c546-1b6f-4ded-9df9-d62f5eb4712b,[Données non publiées],Mairie de Morsang sur Orge,[Données non publiées],
+128b87dc-fd90-4f36-bdd9-4a87b73240b7,[Données non publiées],retraité et [Données non publiées],coach sportif,[Données non publiées]
+12916e1f-0455-42c5-8ee4-c75f1d20f998,[Données non publiées],Systeme u,[Données non publiées],
+1293a632-e23d-4c14-98d3-d23262ad68a3,[Données non publiées],[Données non publiées],collaborateur parlementaire,
+1294b032-f078-47d0-8838-a85d5b0c1bf1,[Données non publiées],inertam,[Données non publiées],
+1296253a-3b55-4956-aa5d-43e2ac4a2cad,[Données non publiées],[Données non publiées],"expert-comptable, associé et co-gérant de la société [Données non publiées]",[Données non publiées]
+12981f27-6b00-4bbb-b752-a481b03cf75e,[Données non publiées],MISSION LOCALE REGIONALE DE GUYANE,[Données non publiées],
+1298fcf5-0bd4-4bc0-b899-fe4a5f223b01,[Données non publiées],AIR CORSICA,[Données non publiées],
+129c4c5d-c3d4-43c5-aff9-92a2e463f602,[Données non publiées],Secrétaire médicale,Assistante d'un chef de service à l'Hôpital [Données non publiées],
+12a3cc1a-6f96-4cae-a12c-09d225a3a4dd,[Données non publiées],Artisan,Menuiserie-- -Ebénisterie,[Données non publiées]
+12a6b892-73f5-4bf4-87ff-3ec78981fff3,[Données non publiées],CARSAT,RETRAITE,
+12a6b892-73f5-4bf4-87ff-3ec78981fff3,[Données non publiées],MAIRIE DE PORTES LES VALENCE,DELEGUE,
+12a6b892-73f5-4bf4-87ff-3ec78981fff3,[Données non publiées],GARAGE PIETRI,DEPANNEUR,[Données non publiées]
+12b4235a-5e7f-4225-af36-a25dc4f47614,[Données non publiées],Néant,Néant,
+12b58c97-9677-4235-9541-e165368b7c33,[Données non publiées],Lahouratate SAS,Commerce de gros détail [Données non publiées],
+12b80a69-5b6f-476b-b820-4720874218eb,[Données non publiées],Éducation nationale,RETRAITEE,
+12c1271f-5eda-4023-a06c-3bfe6d167b51,[Données non publiées],En retraite,Néant,
+12c5aefd-0191-4384-8830-1628116cb8e8,[Données non publiées],Chef d'exploitation,Exploitant agricole [Données non publiées],[Données non publiées]
+12c91b3c-b509-486d-8cdc-9bdf0b6a6eff,[Données non publiées],LA GENDARMERIE,Adjudant en charge de la section équipement,
+12cdc4d4-3a6b-40c9-8840-81ba91734020,[Données non publiées],Mairie de Portet sur garonne,Agent administratif,
+12cef276-d353-4f3c-9898-88b0a41fd50f,[Données non publiées],Lycée [Données non publiées],Infirmière scolaire,
+12d61ac6-94df-4c91-9870-a9e732b4b96e,[Données non publiées],Caisse d'Allocations Familiales,Assistante Sociale,
+12de26b5-ea94-4e0a-a02e-18c8b56b1e15,[Données non publiées],Education Nationale,Enseignante,
+12ec31a6-436a-4548-9590-57ea3deb367c,[Données non publiées],SED,responsable technique en muséologie,
+12f5b107-a23b-4560-993d-ada89b3d9c46,[Données non publiées],SARL Montagnani,[Données non publiées],néant
+12f5b107-a23b-4560-993d-ada89b3d9c46,[Données non publiées],sarl montagnani,[Données non publiées],
+13001db6-42ae-4e13-8680-0d88b9884e5a,[Données non publiées],Parlement européen,[Données non publiées],
+1315f8c3-6716-44d4-95ff-d06333e99a34,[Données non publiées],SAS [Données non publiées],[Données non publiées],
+131d3cdb-4bd8-4fd8-8ef7-0b058638ded7,[Données non publiées],libérale,infirmière,
+131d42e4-0c0e-4570-8af5-d15c51dd16b5,[Données non publiées],[Données non publiées],[Données non publiées],En retraite
+131e6405-6c81-4f5c-b4ef-e8f13c845f89,[Données non publiées],Sans emploi,Sans,
+1320a853-eedb-44b5-95d3-493854f955f1,[Données non publiées],[Données non publiées],Secretaire Générale adjointe [Données non publiées],
+13219c6e-6c63-4bfd-97f7-def917f2e04f,[Données non publiées],néant,néant,
+132aebbd-17cf-43bb-9cdb-aeac43c2d634,[Données non publiées],sans,neant,
+1339ef0d-9352-4614-967e-6502ef683fe6,[Données non publiées],Conseil départemental du Cantal,[Données non publiées],[Données non publiées]
+1346e581-f116-4e27-80f1-2e4f6bfadb61,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+1346e581-f116-4e27-80f1-2e4f6bfadb61,[Données non publiées],Mairie de Vetraz-Monthoux,Chef du service commnication et événementiel,[Données non publiées]
+1353309a-71b2-4e5b-b239-bf2be08f09e2,[Données non publiées],UP,Commercial - employé,
+1356f9b0-9628-46eb-abae-a108fc675a43,[Données non publiées],Néant,néant,
+13670c93-f429-4f2c-950b-a6a6d3636f76,[Données non publiées],Mairie de Gonesse,Directrice adjointe de cabinet,
+1377cf4f-5173-478b-806d-6fcb8117ebab,[Données non publiées],AFLD Paris,[Données non publiées],Infirmier [Données non publiées]
+13793c96-ef53-414f-8c9d-a22a6cc43303,[Données non publiées],retraitée de l'éducation Nationale,néant,
+137ddea4-ad71-4e49-9c62-0f2f26894a0a,[Données non publiées],SENAT,Sénateur,
+1383c6cc-b2ff-47ca-b040-98b87ec03784,[Données non publiées],[Données non publiées],[Données non publiées],
+1386624e-5737-4b3e-bb55-8866daecc672,[Données non publiées],ANS Prodia +,Employé polyvalent [Données non publiées],
+13943599-0add-442a-9259-58a94841affa,[Données non publiées],ENTREPRENEUR INDIVIDUEL,PSYCHOLOGUE CLINICIENNE,
+139a85c7-93fa-4ac2-a411-73da1081b548,[Données non publiées],aucun,[Données non publiées],
+13a19a83-c808-46a9-b961-3ccda05fd416,[Données non publiées],Retraitée,néant,
+13a69b3e-ddf8-417d-8f8b-471024f166e5,[Données non publiées],Ministère chargée de l'égalité entre les femmes et les hommes,Attachée principale d'administration [Données non publiées],
+13abdbe0-8017-4782-8f03-9ed345463c23,[Données non publiées],néant,néant,
+13b9a0b3-e345-4324-ad04-bde0402d1d5a,[Données non publiées],GAEC [Données non publiées],Exploitant agricole,
+13bf4b58-c528-4bb1-b3a1-aee2c1ad046e,[Données non publiées],Education Nationale,Professeur des écoles,
+13cf7d9c-855d-4b2b-baf2-9fcbcec85d1a,[Données non publiées],conseil departemental,adjoint administratif,
+13d23545-ed01-4b73-8c6c-32dfcf612919,[Données non publiées],ADOVA,[Données non publiées],
+13e3c9aa-6869-44d7-af53-a2af8ceef01c,[Données non publiées],Société d.Ambulance [Données non publiées],Auxiliaire Ambulancier,
+13ea2294-91e7-45f9-a589-6265d19faa40,[Données non publiées],EUROLEV,cadre commercial,
+13ee9e53-a1ae-4b3d-ace1-7006c3a91b0e,[Données non publiées],SAS Fertiléo,Président [Données non publiées],
+13ffd777-d372-48bd-b613-2ce44adae0cc,[Données non publiées],néant,néant,
+14044071-4bcd-40b4-9e92-4fd214997373,[Données non publiées],[Données non publiées] Centre médical et dentaire [Données non publiées] cabinet privé [Données non publiées],Dr en Chirurgie dentaire,
+140742c7-d5dc-4674-b242-5ff6029afbfc,[Données non publiées],SEMC,Graphiste,
+140afdb9-e098-4076-ade3-e0e22dd29767,[Données non publiées],Education Nationale,institutrice Maternelle [Données non publiées],[Données non publiées]
+140afdb9-e098-4076-ade3-e0e22dd29767,[Données non publiées],Education nationale,Professeur des écoles,[Données non publiées]
+1414e917-6b96-47c4-a66c-06cf80c1de48,[Données non publiées],Laposte,Pré retraite,
+1415a15c-c3b3-4c9d-ae73-bf71a3898712,[Données non publiées],Sarl jfsi,Activité immobilière,
+141c20c7-3d53-42c9-9378-2bbbe4152c6a,[Données non publiées],Education nationale,Professeur,[Données non publiées]
+142397e1-8619-46ef-a9c3-e9169604b7cc,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+142397e1-8619-46ef-a9c3-e9169604b7cc,[Données non publiées],DIRECTION DES FINANCES PUBLIQUES,AGENT DES IMPOTS,[Données non publiées]
+14306e6d-fa64-4c06-8440-e81575bf0b9c,[Données non publiées],EDUCATION NATIONALE,Professeur d'allemand [Données non publiées],[Données non publiées]
+1435fc74-ce07-41bd-b5b0-f624231e2d1e,[Données non publiées],ITG CONSULTANTS,Ingénieure paysagiste [Données non publiées],
+14456da1-9f14-42b0-a4b8-b9ed691c4e5b,[Données non publiées],EHPAD [Données non publiées],AIDE SOIGNANTE,
+144e6f32-0aa4-4e74-9590-f7aa6de00fc4,[Données non publiées],BPCE,Chargée de communication,
+14575b3f-2010-4f06-959f-30585a0e5cfe,[Données non publiées],SARL Allais Fournier,Bijouterie,
+145f850e-559d-4d0d-9e2a-fb23f1de9223,[Données non publiées],Centre de Gestion de la Guadeloupe,Fonctionnaire Territorial,
+14709c59-2539-4eae-b19e-c1b5cbc75742,[Données non publiées],La France insoumise,Directrice de cabinet,
+14716ef9-0d19-4b61-8f8e-9bf2e6ec2e7e,[Données non publiées],Néant,Néant,Retraité depuis avril 2011
+14722bcf-4a42-404d-9dfe-3f2753f29b50,[Données non publiées],Mairie d'Hénin-Beaumont,Secrétaire aux élus,
+148bf395-d866-4e9b-97ac-fdb577a116e4,[Données non publiées],NEANT,NEANT,
+1496f4e7-8d24-4bcd-ab53-b05fd3450b90,[Données non publiées],Apple Retail,Manager commercial,
+149a8bd3-ad7c-4f74-acd1-9f441f7f9524,[Données non publiées],[Données non publiées],Directeur administratif et financier,
+149be2f9-9348-447e-8b63-8800fea4724b,[Données non publiées],Crèche associative,Directrice de crèche,[Données non publiées]
+149e7b39-664b-40a0-b5c5-62b280d95eca,[Données non publiées],néant,retraité de la fonction publique,
+14abbbc5-8148-4f8a-9a2d-06cd0054bf07,[Données non publiées],[Données non publiées],agence de communication / maison d'édition et de production,
+14b1f3f4-9f51-4d1f-a49c-ade0529b1771,[Données non publiées],[Données non publiées],RETRAITEE FONCTION PUBLIQUE,[Données non publiées] [Données non publiées]
+14b6102b-628a-4d84-9212-2654fe6c146c,[Données non publiées],sans,aucun,
+14b67672-ab2b-4f5e-8b5c-62d72c8bb359,[Données non publiées],Lee Hecht Harrison France,"Consultante senior, salariée",
+14b83a80-947e-4535-a1fd-56a8d721f906,[Données non publiées],Kim Executive,Présidente,
+14c3b15e-f82e-4a2b-a2fd-619cafd2f8b5,[Données non publiées],SCM [Données non publiées],infirmère anesthésiste,
+14ce3f01-43a4-41fd-b8e6-29bc5773294d,[Données non publiées],[Données non publiées],[Données non publiées],Retraitée [Données non publiées]
+14d6d189-184d-4e4e-a001-697f2afffe70,[Données non publiées],education nationale,néant,[Données non publiées]
+14d9cf4a-02ec-4f0a-8a32-aa861b89ab9a,[Données non publiées],Korian [Données non publiées],DIRECTRICE RÉGIONALE ADJOINTE [Données non publiées],
+14feea50-b3d4-4a4c-85d3-b2b07cd46223,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] retraite [Données non publiées]
+1501d49e-1476-4fff-b195-3d570814fef6,[Données non publiées],[Données non publiées],[Données non publiées] agence d'assurance.,
+150780c4-3f5c-402a-ae87-e9c2341a0df9,[Données non publiées],[Données non publiées],journaliste sportive,
+15082fc6-6298-4083-8394-a291a77427ae,[Données non publiées],[Données non publiées],Cadre territoriale,
+150d6651-5813-4134-9990-8b691b5cf5e1,[Données non publiées],[Données non publiées],personnel de direction éducation nationale,
+15136239-afea-4b84-b1a0-64c68cdbe852,[Données non publiées],LIBERALE,INFIRMIERE,
+15145d84-c611-432d-8ab8-13b09c39fb37,[Données non publiées],[Données non publiées],Maison de Tante Bio,
+151d0f05-1f62-4f22-87cd-e99895d82131,[Données non publiées],Nexans France Autun,Responsable [Données non publiées],[Données non publiées]
+15225ba2-fef1-4823-9ccd-2af13fb41959,[Données non publiées],néant,Journaliste retraité,
+152c52c5-c798-4e80-b9ee-1e011d146649,[Données non publiées],neant,neant,
+1530da41-3e74-4344-8420-4fd87c57a474,[Données non publiées],auto entrepreneur,professeur de langues,
+153385b6-1914-4ee0-bf9c-b35f18004344,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+153c4f75-facc-4f42-97fb-d841e63c25b9,[Données non publiées],LUNETTES GRASSET,CHEF DE PRODUITS LUNETTERIE,
+15419dd8-ba18-4cab-882c-d8f13c3b21bd,[Données non publiées],Office de Tourisme,[Données non publiées],
+1544a5f7-aa85-43e4-bf34-4e3ac08ed0a8,[Données non publiées],SAS MAISON DU GAUCHER,Président DIRECTEUR GENERAL,
+154809f6-d117-41a5-a3c4-315665add365,[Données non publiées],[Données non publiées] artisan [Données non publiées],entreprise peinture revêtements sols et murs,en retraite [Données non publiées]
+154a82f9-829f-4344-afda-b49922d08e4a,[Données non publiées],néant,néant,
+1551ec78-cfd4-46cc-907e-d594b8a8b691,[Données non publiées],[Données non publiées],ENSEIGNANT,[Données non publiées] Maire de la commune de Villetaneuse
+155ff385-ce3b-4d20-8af6-409632a17588,[Données non publiées],[Données non publiées],assistante Maternelle,
+156aac8a-9ea7-43fa-a35b-24e51963f0a2,[Données non publiées],néant,néant,
+156cd482-2e11-4d6a-b6c8-678068871280,[Données non publiées],ministère de la justice,Juge,
+1571fc2b-1d61-48f8-b513-461b958e05cf,[Données non publiées],Néant,Néant,
+1581ff78-9a3b-455a-b8d2-20100f54a8b7,[Données non publiées],Néant,Néant,
+15889291-0c7f-4040-81a4-49d361cad9b1,[Données non publiées],COOPALPHA ET Association AGAPES,Coopalpha: [Données non publiées] consultant formateur AGAPES : gestionnaire des ressources humaines,[Données non publiées]
+158f534f-bdfe-4422-b8bd-bd9bbf3311bb,[Données non publiées],WILL&CIE,Evénementiel professionnel Accompagnement en stratégie de communication Formation en relations publiques,cessation d'activité au 30 juin 2021/ [Données non publiées]
+158f534f-bdfe-4422-b8bd-bd9bbf3311bb,[Données non publiées],Dialogues et Solutions,salariée depuis le 1er avril 2021,
+15927e06-6652-4cba-9abd-b624e06253a2,[Données non publiées],Lycee [Données non publiées],Educatrice,
+159ab149-6d5e-4cdd-aa99-0095afdc9036,[Données non publiées],FERMET ALU,[Données non publiées] [Données non publiées],
+159bdfd3-fcb0-49ed-8db7-6cb9f26ee7cc,[Données non publiées],néant,néant,[Données non publiées]
+15a29828-ee23-42ea-a683-1ad35558bd97,[Données non publiées],PEPINIERES DE BEAUFORT,[Données non publiées],[Données non publiées]
+15af4a1d-894b-4046-86b7-24f3cec21a88,[Données non publiées],PTC,Ingénieur,
+15c15d47-0a34-4b3f-9599-49c7b1f46411,[Données non publiées],BIOMERIEUX,ingenieur [Données non publiées],
+15c4ab8b-c661-4ed2-8293-cab306f9cce5,[Données non publiées],ASSOCIATION DES MAIRES D'EURE ET LOIR,[Données non publiées],
+15cb0989-b35c-4dde-b8d4-e523d7fe5de2,[Données non publiées],[Données non publiées],pharmacien titulaire [Données non publiées],
+15ccb6eb-89aa-4574-bcc2-5de547cb4459,[Données non publiées],Education Nationale,Proviseur de lycée,[Données non publiées]
+15dacc21-5d4f-4b8c-9920-0964134ade5b,[Données non publiées],Néant,Néant,
+15e898a1-9a67-44b7-9e14-dc27c2d08847,[Données non publiées],néant,néant,[Données non publiées]
+15eaa6e6-0c3d-48c0-940d-f4feb5795115,[Données non publiées],SAS SFO,NEGOCE MATERIAUX,
+15edd9d5-97c6-4037-a418-d5e3d13c6d29,[Données non publiées],COVEA (assurance MMA),gestionnaire de sinistres,
+15f183c0-56ed-4c97-8c9a-0e36e09b0951,[Données non publiées],retraite,retraite,[Données non publiées]
+15faf49f-253c-4eb5-b355-566a0aacc5c6,[Données non publiées],Néant,Néant,
+15fdfed5-234c-4fd0-b75a-dd60723325c2,[Données non publiées],EDUCATION NATIONALE,PRINCIPALE ADJOINTE DE COLLEGE,[Données non publiées]
+15fed6d8-cc08-4eab-89dd-b442994a83ca,[Données non publiées],Ville d'Aix-les-Bains,[Données non publiées],
+15ff94a7-635d-4397-b91f-f52a587c1de2,[Données non publiées],PSA AUTOMOBILES,Agent professionnel,
+16094b25-67c6-4528-b8d6-4e85f9b76440,[Données non publiées],Sarl SADP,importation et distribution en cote d'ivoire de produits de para pharmacie,[Données non publiées]
+160e46e1-5509-4452-b133-10f6bb259cc2,[Données non publiées],Orange,Technicien d'intervention,
+160f1e37-9e2a-436f-9f16-dea0de4c362e,[Données non publiées],Exploitant agricole GAEC,[Données non publiées],[Données non publiées]
+161128ea-1394-460f-a5c8-59551b44d42a,[Données non publiées],SARL [Données non publiées],Gérant du garage,
+1612e96d-47b3-466a-8a91-6ec47ec2c333,[Données non publiées],NEANT,NEANT,
+161985d2-5253-422f-a4f2-06be54cd6e2a,[Données non publiées],Haut commissariat de la Polynésie française,RETRAITÉE [Données non publiées],[Données non publiées]
+162af9fd-126c-4b0d-90b9-af266d61e83b,[Données non publiées],[Données non publiées],SOCIETE DETENANT DEUX OFFICES NOTARIAUX,[Données non publiées] Notaire dirigeant de cette société [Données non publiées] [Données non publiées]
+1633a384-455d-4440-89aa-dba28082a954,[Données non publiées],Retraité,néant,aucun
+1636b273-10df-48fc-bad7-c6e2243f09f3,[Données non publiées],éducation nationale,professeur d'EPS dans un collège,
+163f08d9-3346-45da-b6de-c308f35212e5,[Données non publiées],CABINET LEFÈVRE ET RAYNAUD,AVOCAT,
+165689db-4dec-4fac-88ec-d46a9e8238db,[Données non publiées],MINISTERE AGRICULTURE [Données non publiées],Enseignante,
+1673d523-b1dc-449b-b2dc-6a448b63ddd9,[Données non publiées],[Données non publiées],Infirmière,
+16804f15-0091-462f-8670-a7cb24ebeb2b,[Données non publiées],CAMG,Directrice des ressources humaines,
+1682b181-9473-46ba-8a48-1c0ac087c449,[Données non publiées],Etat,Retraitée,
+16870529-7cd5-4f85-884a-9316b2eb203f,[Données non publiées],Education nationale (retraitée),Attachée d'administration [Données non publiées],
+16a59989-94d2-4515-8178-d0572c4f9df2,[Données non publiées],Centre Hospitalier de la Côte Basque,Aide-Soignante,
+16b9c070-22b6-4424-a64e-0fe883b20251,[Données non publiées],Conseil départemental de la Savoie,[Données non publiées],
+16ba5199-6220-4cb0-8f79-0db4c3ba5f92,[Données non publiées],[Données non publiées],infirmier,
+16c9a307-f970-4cbb-b4c9-4c053502754d,[Données non publiées],auto-entreprise,rééducatrice au geste d'écriture,
+16c9c662-b425-4a5e-8bc5-db4eb9c397fe,[Données non publiées],quantum,[Données non publiées],
+16ca6ba6-d37b-44a9-8d6c-6cbaa50df793,[Données non publiées],SAS [Données non publiées],SOCIETE DETENANT DEUX OFFICES NOTARIAUX,[Données non publiées] Notaire dirigeant de cette société [Données non publiées]
+16dd4190-b291-486e-af6c-280f7fda05c8,[Données non publiées],Glaz Océan SAS,"Cheffe d'entreprise, [Données non publiées]",[Données non publiées]
+16e5a5d3-ec2b-49b1-bcb9-209da1e69150,[Données non publiées],Aucun,Retraitée,
+16e7a7b4-edd0-4aef-8529-7952052fd9d7,[Données non publiées],Néant,Néant,Néant
+170578fc-dac1-40c4-8aae-1da676a0bf76,[Données non publiées],néant,retraité,
+17066ccc-8f66-4492-acb7-343399604876,[Données non publiées],éducation nationale,professeur des écoles,[Données non publiées]
+170d32a8-580c-4ab7-bab0-e42f2fd6d345,[Données non publiées],Education nationale,Enseignant second degré,
+171ecc23-3725-45c0-9ef6-247d087a389c,[Données non publiées],aucun,néant,[Données non publiées]
+1720e76b-a935-4d88-9b54-a66f127c8bef,[Données non publiées],CCTA,AIDE AUXILIAIRE DE PUERICULTURE,
+17261230-aca5-4c8f-a091-e8b2e67a27b5,[Données non publiées],[Données non publiées] Conseil départemental de l’Orne,caue : [Données non publiées],[Données non publiées]
+17261230-aca5-4c8f-a091-e8b2e67a27b5,[Données non publiées],Région des Pays-de-la-loire,[Données non publiées],
+1736702c-18a2-4f76-87d8-a12461ee65c7,[Données non publiées],à son compte,infirmière libérale,
+174c0693-f199-4ff2-b790-8bc9471edb92,[Données non publiées],Communauté de Communes du Bas Armagnac,"fonction publique territoriale, [Données non publiées] agent technique",
+175352e8-7d55-4921-85bb-54d2f90ff6b6,[Données non publiées],Ministère de l'éducation nationale,Professeur certifié d'histoire-géographie,
+17556934-d31f-48ea-ae92-2c2f07b7241e,[Données non publiées],[Données non publiées],Préparatrice en Pharmacie Hospitalière,
+17636a3b-005d-45e3-95d7-22c96948cf6b,[Données non publiées],néant,néant,
+1772be24-2ec3-49e3-9eda-3cce4d5c13df,[Données non publiées],Educationnationale,professeure,
+17767406-5ec1-4f7f-8434-a1170d3c4478,[Données non publiées],MAIRIE DE SAINT-PIERRE,DIRECTEUR [Données non publiées],
+177faf93-6228-4250-957a-3711ffa386cd,[Données non publiées],CREDIT MUTUEL,CONSEILLERE CLIENTELE,
+1789865e-3dd0-4531-ab4d-5e9eba78c44f,[Données non publiées],Initiative Terres d'Azur,Directrice.,
+178b8f34-fec3-4302-9d71-268f2d420e76,[Données non publiées],[Données non publiées],Psychologue,
+17951079-bd44-475f-aab1-e2711d37622b,[Données non publiées],Brest Métropole Océane,[Données non publiées],
+17966e57-e195-474f-a0e7-7cf1d72b8175,[Données non publiées],Bati 85,Assistante commerciale,
+179ddc67-993f-415f-93e9-8968f5ad41b0,[Données non publiées],Retraitée,Retraitée,
+179edd17-455c-49f7-865f-65ee5ba69a1e,[Données non publiées],Ville de Claye-Souilly,Fonctionnaire territoriale [Données non publiées],
+17b70c9e-a26b-4af1-b8ef-23dbf4bd1c15,[Données non publiées],Météo France,Climatologue,
+17c13750-c10b-4ca9-9f2a-9c5ef2d561dd,[Données non publiées],NEANT,NEANT,Retraitée
+17ca5e99-0d3c-489b-ae7c-e589755ad0c4,[Données non publiées],néant,retraitée,
+17f16664-7a18-4e6d-92ef-2898048884c5,[Données non publiées],[Données non publiées],Avocat,
+17f29683-9d65-4c93-b763-3d37585bfe42,[Données non publiées],Agriculteur,Elevage bovins Légumes plein champs [Données non publiées],[Données non publiées]
+1808a004-a530-40ca-8f13-8e1f306fdd43,[Données non publiées],Etablissement public du musée d'Orsay et de l'Orangerie,Chef de cabinet du président,[Données non publiées]
+181b04c2-77db-49b0-bba4-196db0f36e91,[Données non publiées],Société en nom collectif (SNC),Pharmacien,[Données non publiées]
+181cdeee-a7c6-488d-bc1b-5b2a4f0070f1,[Données non publiées],Mickael Page Interim,Manager de transition,
+18255ca5-22b2-4d90-94cf-760dc4036015,[Données non publiées],CSC Les chemins Blancs,Animateur culturel,
+1828ac05-f2d7-4d0b-b2ba-22b7bac04109,[Données non publiées],Education Nationale,Enseignante de latin et de grec,[Données non publiées]
+1828e3ab-3034-4aac-96a4-c49fa6231b6d,[Données non publiées],SNJH,[Données non publiées],
+182a1167-07af-4d20-8d38-8bd37f93f469,[Données non publiées],NEANT,NEANT,
+1837a1ae-abd8-4c80-a24e-0878ce6e0462,[Données non publiées],néant,néant,
+184d6ecd-084a-4eea-8202-efd8d2b857ac,[Données non publiées],Education Nationale,Auxiliaire de vie scolaire,
+1860f2cc-567a-480f-af2a-9c657fb00a9e,[Données non publiées],"Musicien, Intermittent du spectacle",Musicien - pianiste - accordéoniste,
+18654eb9-4a62-477c-972c-11970cee5223,[Données non publiées],Néant,Néant,
+186effa5-d187-4175-b582-8965cf365397,[Données non publiées],Néant,Néant,
+1871e10a-7a01-46c9-a9f0-ebaa9ac6154d,[Données non publiées],HOLCAR,[Données non publiées],
+18744a6f-a330-42a2-b4bf-6fa0fc5f3d94,[Données non publiées],CH st Yrieix,Medecin [Données non publiées],
+187e86a8-214a-4a98-983e-e7ad5199e310,[Données non publiées],TISSE,Responsable d équipe contrôle,
+188f34b3-b7b0-4660-bc8b-469a327afaa2,[Données non publiées],Laboratoire Serres,laborantine,
+1898a0dd-f428-4f84-ba62-278b923c9409,[Données non publiées],CH de BLAIN - EPSYLAN,Infirmière [Données non publiées],
+189e9671-dbbb-4a6c-96d8-526525bb677d,[Données non publiées],YMCA [Données non publiées],Directrice du Foyer d'hébergement,
+18ade02a-2ce9-4223-9d40-8736ac6069b0,[Données non publiées],CHRU [Données non publiées],Cadre Supérieur de Santé,
+18b1077c-50ef-4e24-ab05-4c165ff11b2e,[Données non publiées],BNP Paribas,[Données non publiées],
+18c8b76f-40a6-40d6-9fe6-6d341dd138a0,[Données non publiées],Neant,Neant,
+18d16b57-98af-41da-a4c0-68e2590d1b17,[Données non publiées],SAS financière de l'achigan,Adjoint administratif,
+18d92df4-af3f-4f3e-919c-6e2d48ca018b,[Données non publiées],néant,néant,
+18f2c6af-d1b0-4d32-bc00-b22bac3c8bb3,[Données non publiées],[Données non publiées],Comptable Taxateur,
+18f4f9fc-d7bc-43f9-aca3-287b10736993,[Données non publiées],NEANT,Retraitée,
+18fa33b1-9546-4bd1-aa59-16e1748fc176,[Données non publiées],Etat,Professeur des Ecoles,
+1902ea6f-437f-4cda-8894-ecd6942448d8,[Données non publiées],Néant,Néant,
+19123d8f-8895-4abe-a12c-ed754bae07cd,[Données non publiées],STMicroelectronics [Données non publiées] SAS,Cadre en Audit interne,
+1914e6fc-8529-4084-be4e-f4303b29b6db,[Données non publiées],[Données non publiées],[Données non publiées] retraitée [Données non publiées],[Données non publiées]
+191ab746-4251-44a4-8a87-da14d2647b36,[Données non publiées],retraitée,néant,
+191c0bd2-ca9d-42ed-8a73-52524bffe5a7,[Données non publiées],Conseil départemental du Gard,[Données non publiées],
+191d17d0-24c0-4fbc-9614-efbc6be22b5d,[Données non publiées],néant,néant,
+193db1c6-24e3-4141-9be0-7f6ed536e071,[Données non publiées],RATP DEV,CONDUCTEUR RECEVEUR,
+19558462-fc90-4e44-acf4-5cdb8b9f2292,[Données non publiées],néant,retraité,
+19573bb3-e67f-407d-af2f-a028012dc631,[Données non publiées],ASSOCIATION ARCHANGE AUTISME,CHARGEE DE MISSION [Données non publiées],
+1969895d-ba65-4364-a34e-6a2aa9421a13,[Données non publiées],[Données non publiées],Directrice des Ressources Humaines,
+19a25667-5b4b-4705-b144-1e117b5074f1,[Données non publiées],ministère éducation nationale,SAENES,
+19a9bee5-2747-4f5c-9b19-f9c22b60efb8,[Données non publiées],Education Nationale,néant,institutrice et directrice d'école retraitée [Données non publiées]
+19aa475a-f19e-4d55-985f-016b1cbb8856,[Données non publiées],[Données non publiées],[Données non publiées],retraitee
+19af4313-9ae3-4278-af75-215f9c4c144f,[Données non publiées],UBIQUS,Rédaction et interprétariat,
+19b2805b-9454-48b2-96ff-b6eb9c524893,[Données non publiées],CNP Assurances,[Données non publiées],
+19b66335-4cc3-4f24-9bb7-75a4e324fd2c,[Données non publiées],néant,infirmière libérale,
+19b78f85-1641-4015-b708-93e258cfa4dc,[Données non publiées],Crédit Agricole,Chargée de clientèle professionnelle,
+19b8d5a3-1c63-4c87-a718-5c5cb72998a9,[Données non publiées],Ministère de l'Intérieur,[Données non publiées] Centre Communal d'Action Sociale [Données non publiées],
+19b977cc-5963-47ce-b3ac-a9b814761916,[Données non publiées],SANITLOC,[Données non publiées] DIRIGEANT,
+19b977cc-5963-47ce-b3ac-a9b814761916,[Données non publiées],SANITLOC,DIRIGEANT,
+19d89e29-4531-4606-924f-09eeaeca6ac4,[Données non publiées],MFR vallée du Lot,[Données non publiées] [Données non publiées],
+19d976d7-9711-4d9a-8ba0-cca4cd7e60ae,[Données non publiées],[Données non publiées],Pharmacien [Données non publiées] officine de Cherveux,
+19db300b-4b31-46a9-90cf-6d72d2f65927,[Données non publiées],[Données non publiées],[Données non publiées] A la retraite [Données non publiées],
+19f08c1d-c03b-4a6e-ae4a-c9468bd13640,[Données non publiées],FUNERAIRES OF,[Données non publiées],
+19f3fe86-2989-493d-929b-5303fe2f034e,[Données non publiées],AP-HP,Cheffe de clinique,
+19fefd76-da41-424d-acf2-5d189638ecdf,[Données non publiées],KEOLIS,[Données non publiées],
+1a03bf9b-d3cd-48cb-b564-3d8350b3819a,[Données non publiées],DRFIP,SIP Agent d'administration [Données non publiées],
+1a072666-2148-4db5-86f9-5e404b6ce86e,[Données non publiées],CRISTEL / GIEN,[Données non publiées],
+1a077420-ab4f-4cd8-9632-c45c11130c35,[Données non publiées],SEMMARIS (Marché international de Rungis),[Données non publiées],
+1a16fbcb-1be5-4d99-8522-97e8199c5a58,[Données non publiées],CENTRE DE GESTION 22,ADJOINT TERRITORIAL [Données non publiées],
+1a2450d8-bcb9-433c-ab5c-22f8cfd1eb82,[Données non publiées],Auto-entrepreneur,Enseignement en centre d'apprentissage,
+1a36ce5f-5c29-45ae-ada1-b9aef842b504,[Données non publiées],Commissariat à l'Energie Atomique,Directrice [Données non publiées] [Données non publiées] .,
+1a409245-57d2-45f0-aa15-af92b892ae2a,[Données non publiées],NEANT,RETRAITE,
+1a44f249-0e93-47ad-a681-07cb0253f062,[Données non publiées],SCP [Données non publiées],Notaire [Données non publiées],
+1a507d7c-d918-4fe0-bce1-e3d45211a5f2,[Données non publiées],Toulouse Metropole,[Données non publiées] [Données non publiées],
+1a5eaa35-2c3d-4079-ae42-8b1bfad0b7b6,[Données non publiées],STAG - Villers Bretonneux,Assistante administrative,
+1a680e95-0259-431c-b886-48a7940f5c77,[Données non publiées],[Données non publiées],Co-gérant de la société- activité façade,
+1a731cc3-00f1-4594-bc00-fd4e24037e80,[Données non publiées],[Données non publiées],Directeur administratif et financier,
+1a73de16-d877-4189-b218-41f080ccf29c,[Données non publiées],SITCOM,technicien supérieur,
+1a795c0d-3b3e-49c9-a854-eb446fac623a,[Données non publiées],Maria Farinha Films,Production cinématographique,
+1a89dc9e-4dcf-4e1d-923f-5919120450ec,[Données non publiées],IGAM,Comptable en association d'expertise comptable,[Données non publiées]
+1a89dc9e-4dcf-4e1d-923f-5919120450ec,[Données non publiées],AURHOM,[Données non publiées],[Données non publiées]
+1a8bbec1-5871-4815-9f13-fd070ecc5f3f,[Données non publiées],Néant,Néant,
+1a901a31-5811-48e2-9c99-86709acda1a5,[Données non publiées],Education nationale,Enseignant,
+1a9651d6-6fef-4215-86a9-46f14e315be2,[Données non publiées],NEANT,NEANT,
+1a9c2ae5-a44d-425b-bc05-e631bcb118a1,[Données non publiées],Groupe Bayard Presse,Attachée de Direction,
+1a9fce87-4271-4e0d-b4b0-64cf7d7446b5,[Données non publiées],Cabinet d'avocat MLB (entreprise individuelle),Avocat libéral,[Données non publiées]
+1aa71509-8a0a-4a71-87ff-ac9f60b203c0,[Données non publiées],[Données non publiées],Ingénieur dans le domaine des technologies médicales,[Données non publiées]
+1ab106a3-0065-41da-9d77-5946ae1393a6,[Données non publiées],Minstere de l'enseignement supérieur et de la recherche,Professeur des Universités [Données non publiées],
+1ab172b6-5c12-4a37-bfd9-a1565437485e,[Données non publiées],BNP Paribas real estate valuation,[Données non publiées],
+1ab976b1-15df-4e67-8488-634a576ef336,[Données non publiées],chef d'entreprise [Données non publiées],patronne et écrivain,[Données non publiées]
+1abb64a6-a14c-408e-9754-0d722e9cadba,[Données non publiées],Conseil Départemental de la Gironde,[Données non publiées],[Données non publiées]
+1abda968-53fa-4adc-acc3-0a87029ca5fa,[Données non publiées],SAS La Canne à sucre,[Données non publiées],
+1aca73a1-a2e1-46ab-9082-5f3feaae7db3,[Données non publiées],France Télévision,Journaliste,
+1accde87-fbc4-4e7d-9d58-c0ad88c67e46,[Données non publiées],Assistance Publique Hôpitaux de Marseille,Chirurgien [Données non publiées],
+1ad77bff-3cd5-4a94-9bc6-8b9c745bb68c,[Données non publiées],Nespresso France,"Cadre commercial, responsable de secteur [Données non publiées] pour les établissements de débits de boissons, hôteliers et de restauration.",
+1adb84ba-237d-481f-9f8d-47ad950017c8,[Données non publiées],professeure des écoles,[Données non publiées] dans l'enseignement privé,
+1add8a72-53e9-4c92-b9ce-c2b2e00abf3f,[Données non publiées],LINDT & SPRUNGLI,Technicien,
+1af4c243-7394-4507-9e19-5751634e95b7,[Données non publiées],SWISS-LIFE Compagnie d'Assurances,[Données non publiées],
+1afab6e3-c5cc-42ef-8369-e29f11a74fe6,[Données non publiées],Néant,Néant,retraitée
+1b07f7b8-0147-43b1-bc3e-8a6d60a59fa1,[Données non publiées],EDUCATION NATIONALE,Enseignante,
+1b09ea68-9df1-4820-8397-ced9f2e5ae02,[Données non publiées],STMicroelectronics [Données non publiées],Cadre [Données non publiées],
+1b0d849f-2659-4678-be50-389d532c55bf,[Données non publiées],pole emploi,conseillère,
+1b0f227c-d98e-4b68-8c92-baf36ef5e296,[Données non publiées],néant,sans,
+1b13d76c-a214-4c6b-a790-48545601c91a,[Données non publiées],GHSA [Données non publiées],Infirmière de bloc opératoire,
+1b1b20ed-d3a7-4688-aafb-310e6438f2ce,[Données non publiées],cabinet dentraire [Données non publiées],Secrétaire médicale,[Données non publiées]
+1b1f3617-0ee6-4ead-ae16-30e218285281,[Données non publiées],Artiste-Auteur,Création d'ouvrages pédagogiques,
+1b249503-81e5-4540-80c3-d1ea2fff1264,[Données non publiées],[Données non publiées],retraite,
+1b2abca1-e579-45ae-949e-ad5de1bc7869,[Données non publiées],retraitée,aucune,
+1b38c920-b2ae-44c9-9f88-579cd6cb74b3,[Données non publiées],Ministère de l'Education Nationale,Professeure d'Histoire-Géographie,
+1b572a8e-6afb-413d-b4df-20a130448ea3,[Données non publiées],LECLERC,Secrétaire,
+1b608fbd-a46b-4026-9219-adaed75c01f1,[Données non publiées],EUROFINS,AUDITRICE QUALITE,
+1b618d61-f4e8-439a-970e-e512cf0bb4da,[Données non publiées],Mairie Le Lamentin,[Données non publiées],
+1b68cfc3-cb74-4742-9710-9c0c7bed7adf,[Données non publiées],Profession libérale,Profession libérale,
+1b69cee9-ed81-4664-b65c-e469a4b3ec74,[Données non publiées],Groupe Saint-Sauveur,DAF,
+1b6a9977-761e-4a67-af49-635c7ff9fdd2,[Données non publiées],Assemblée Nationale,Député du Nord Conseiller régional des Hauts-de-France,
+1b79f008-3250-4995-a38a-bd2a928f7527,[Données non publiées],RIO TINTO par PIMAN,Chef de projet,[Données non publiées]
+1b811f30-c6e0-4d7d-b67e-46644f6aa5f1,[Données non publiées],fromagerie [Données non publiées],commerciale,
+1b95e738-5e0c-4d91-a28b-d45a56fdb804,[Données non publiées],Aucun,Retraitée,
+1b9b190b-1b8b-4ca0-ac27-844de8847a66,[Données non publiées],retraitée,[Données non publiées],
+1ba98f62-a8b2-46d2-90b5-de3fab90d916,[Données non publiées],neant,retraitée,
+1bac2387-c9c3-4f42-a41c-de1ef4d7b30d,[Données non publiées],associations Gymnastique Volontaire,cours de Gymnastique,[Données non publiées]
+1bb81c23-731d-4a37-af46-347810344f7b,[Données non publiées],néant,néant,Retraitée [Données non publiées]
+1bb991f5-fab3-4795-a819-308f3b7f79a5,[Données non publiées],néant,Journaliste retraité,
+1bc19f88-1a39-49b4-8392-dd0f079d1ef9,[Données non publiées],CHEF D'ENTREPRISE INDIVIDUELLE,"Entreprise individuelle de travaux de construction, démolition et terrassement",
+1bc77774-dfce-45b9-a130-b6a027bfa1ea,[Données non publiées],Education Nationale,Professeur des écoles,
+1bcb8a53-e970-4a43-8573-ca7a6a480057,[Données non publiées],Programme des Nations Unies pour l'Environnement,Chargée de Programme - Fonctionnaire internationale,
+1bcc786c-1cf5-4c53-83af-93065c1898bd,[Données non publiées],Education nationale,Professeure des écoles,
+1bd10886-1856-4899-a48b-43a62736f77d,[Données non publiées],GRADE IESS PACA,[Données non publiées],
+1be315a8-639b-4217-a501-c8d470079752,[Données non publiées],education nationale,retraitée,
+1be89d17-ad4f-4825-a572-a1cc1576b006,[Données non publiées],Conseil de l'Europe,Cheffe du service [Données non publiées],
+1bec76db-fba8-48ad-aa27-7f1bfed03c90,[Données non publiées],CEGID,Technicien consultant paie,Secteur privé
+1bf28f8f-3aea-403d-841e-759b2e08a3fd,[Données non publiées],GAN Assurances,retraitée,
+1bfca5b0-eeeb-4ae0-b760-053873be30c8,[Données non publiées],néant,Retraité du régime général de la sécurité sociale,
+1c040b9b-73eb-446b-ae22-f30ff0a5d958,[Données non publiées],GENERALI FRANCE,[Données non publiées],
+1c129602-002c-4755-8190-a7ef367782e4,[Données non publiées],Mairie de Vals les Bains,[Données non publiées] [Données non publiées],
+1c17ea76-0af8-42ed-9a72-6ac76994d9df,[Données non publiées],clinique vétérinaire Saint Roch,[Données non publiées],
+1c1ff0ab-45b9-47c6-9e60-717c9ced76db,[Données non publiées],Caisse des dépôts et consignations,Directrice [Données non publiées] adjointe,
+1c2119ac-60af-4770-a39f-beb0e8fe5066,[Données non publiées],LUNETTES GRASSET,CHEF DE PRODUITS LUNETTERIE,
+1c257612-7eb1-4ccc-b486-4e856290ec8e,[Données non publiées],SAS [Données non publiées],DIRECTEUR GENERAL,
+1c26b128-7dd6-4494-8bbc-041c5810e6c2,[Données non publiées],Elle-même,Viticultrice,
+1c28f6b3-1863-4a00-9f81-faeb6dfaca30,[Données non publiées],activité libérale,medecine générale,
+1c3259b9-5b69-4894-8753-4e396d1b3889,[Données non publiées],mairie d'Eguilles,[Données non publiées],
+1c3259b9-5b69-4894-8753-4e396d1b3889,[Données non publiées],mairie de Ventabren,[Données non publiées],[Données non publiées]
+1c4268b4-b10c-4cf4-a3d9-6c843647b2de,[Données non publiées],Aucun,Consultant,
+1c490a24-90d7-4c17-947d-7eae46119061,[Données non publiées],EUROFINS,AUDITRICE QUALITE,
+1c4c5684-165a-402b-aecb-c9d3f8bb8281,[Données non publiées],[Données non publiées],[Données non publiées],En retraite [Données non publiées]
+1c545aae-eb0c-4dff-b7f7-34415f567691,[Données non publiées],Conseil départemental de Loir et Cher,[Données non publiées],[Données non publiées]
+1c6a993b-d599-4662-98b5-c6b87823820c,[Données non publiées],Néant,Vacataire pour le théâtre de Brest. [Données non publiées],
+1c6b81f8-823f-4000-865b-1676fee45546,[Données non publiées],[Données non publiées],[Données non publiées] retraitée,
+1c700c6e-2b12-426a-a78d-85c11ca04636,[Données non publiées],Néant,Retraité,
+1c7624d8-cd16-46ed-a7ee-5ab31a44e701,[Données non publiées],aucun,pas d'activité,
+1c79c7ee-38f2-4b9a-810f-3134db07fbc7,[Données non publiées],Cave de Labastide de Levis,[Données non publiées],
+1c863f92-6e42-4479-8461-ccb2404ecb7a,[Données non publiées],[Données non publiées],Juriste,
+1c884e70-992f-4c1e-86bf-b752767d4283,[Données non publiées],Retraité,"Retraité, [Données non publiées]",
+1c8e5085-fe21-49ee-b46d-e1bde43c8b0c,[Données non publiées],retraitée,NEANT,
+1c914a66-d34c-4097-9e5c-69dd361338ea,[Données non publiées],Assemblée nationale,Député,[Données non publiées]
+1c929de0-9803-4962-81cd-e2f6920c3e04,[Données non publiées],Assemblée nationale,Assistant parlementaire,
+1ca0a4b4-199e-4c36-8395-22453689ffbf,[Données non publiées],EDUCATION NATIONALE,Enseignant Professeur des écoles,
+1ca6f684-61e3-4393-933a-30522e81e7bf,[Données non publiées],[Données non publiées],Entreprise de Travaux publics Gérant,
+1caab32d-53e1-4b7c-8927-cd56e0f563f6,[Données non publiées],néant,néant,
+1cad37c8-a845-445d-a639-a54b4b544a64,[Données non publiées],[Données non publiées],pharmacien titulaire [Données non publiées],
+1cb010d3-6ffe-4152-87e9-cb6ff3297c42,[Données non publiées],Profession libérale,Masseur-Kinésithérapeute,
+1cb0ecd0-fae7-46fc-bbfa-456c581f2fda,[Données non publiées],NEANT,RETRAITE,[Données non publiées]
+1cb4f1d2-2822-40db-8377-883d8c2328db,[Données non publiées],lui même,journaliste Président et directeur du journal Le petit mag Lens Liévin exploitant agricole [Données non publiées],[Données non publiées]
+1cc1e2e4-c9b6-4cd0-ad5c-2b659dc04e96,[Données non publiées],[Données non publiées],[Données non publiées],Retraitée [Données non publiées]
+1cd96cdb-0307-4329-bff9-1703f8b3dd8a,[Données non publiées],STMicroelectronics Tours SAS,Ingénieur,
+1ce3a02e-547d-4bf5-81c5-b4341a40e667,[Données non publiées],Multiples particuliers employeurs,Assistante maternelle,[Données non publiées]
+1cf6a2df-fcbe-4429-afc6-2f107ffef43d,[Données non publiées],[Données non publiées],pdg,
+1cfde9a5-b89f-4802-9be5-e7c62dbe5ef4,[Données non publiées],Ministère de la transition écologique,[Données non publiées],
+1d03556f-fe3a-404b-afa8-3fb71b9b5c8e,[Données non publiées],[Données non publiées],Gérant,
+1d03849d-9c2a-4e0f-85c3-87fbae2e4b55,[Données non publiées],Mairie de Decize,Agent de maitrise- fonctionnaire territorial,[Données non publiées]
+1d056616-6d43-4e7a-a8ef-0e3be7bea32c,[Données non publiées],[Données non publiées],Retraitée [Données non publiées],
+1d07c707-4686-4110-a819-63114dbd3e0c,[Données non publiées],[Données non publiées],néant,
+1d0ee35c-2bbb-44b1-a08c-6f5224636b5b,[Données non publiées],SAS [Données non publiées],PRESIDENTE,
+1d0ff296-54b8-4e8a-830c-178776b10ac7,[Données non publiées],Eurofins,[Données non publiées],
+1d12fbbd-3237-470b-a3d3-8dad567156e8,[Données non publiées],[Données non publiées],Maison de Tante Bio,
+1d171134-72a7-4fda-ace9-b5653750d526,[Données non publiées],Autoentrepreneur,Chargée d'affaires privé,
+1d23d458-d963-4812-a64b-f473c4f5045a,[Données non publiées],Retraité,"Retraité, [Données non publiées]",
+1d250c7b-68b0-447e-877a-b93b283ea1ac,[Données non publiées],[Données non publiées],[Données non publiées],
+1d250c7b-68b0-447e-877a-b93b283ea1ac,[Données non publiées],retraité,[Données non publiées],
+1d2dc917-cead-4cf0-ad20-5e745e4e0756,[Données non publiées],MERICQ,RESPONSABLE ACHATS,
+1d3fb871-239b-4171-88c7-14b179781ba1,[Données non publiées],Education nationale,Professeur d'anglais,
+1d41d561-3950-48f6-abcb-ebed31705b35,[Données non publiées],[Données non publiées],retraitée,[Données non publiées]
+1d567aa7-2801-4ba5-9957-e15393950dcb,[Données non publiées],CFA des universités de Centre-Val-de-Loire,Directrice - [Données non publiées],
+1d5b1079-ad3a-449a-8e44-81478703415f,[Données non publiées],RETRAITE,NEANT,
+1d5b1079-ad3a-449a-8e44-81478703415f,[Données non publiées],consultant,consultant sous le régime de MICRO ENTREPRISE,[Données non publiées]
+1d709028-901a-42f2-8314-5a86a7ca297f,[Données non publiées],Assemblée Nationale,Député du Pas de Calais et conseiller régional,
+1d75d3cd-8410-42ba-a498-1b35a2dd29d5,[Données non publiées],UCLY,Enseignant-Chercheur Biologie,
+1d7848db-08a6-413c-95ce-04baf698689b,[Données non publiées],VTECH FRANCE,[Données non publiées],
+1d792e76-8165-4844-9d85-d6bf427e282d,[Données non publiées],néant,sans activités,
+1d7e7d0d-d4ec-4b34-b51e-3673f1cf710a,[Données non publiées],CPAM,Cadre Coordonnateur,
+1d88e41b-f350-4fdb-962b-0b91023b8966,[Données non publiées],Chambre d'agriculture de Normandie,Assistante administrative [Données non publiées],
+1d9835a2-19db-4493-bc4d-37e58a14449f,[Données non publiées],centre hospitalier du Mans,chef de projet [Données non publiées],
+1d9d491b-0d9c-45e6-a7a4-0157f4cac87e,[Données non publiées],RETRAITE,Néant,
+1da8f673-f67d-49f1-a1e7-9e0d3ad31618,[Données non publiées],retaite,Néant,
+1dab055b-8a4f-49c1-af61-045d70123d9b,[Données non publiées],Education Nationale,Secrétaire général en Lycée [Données non publiées],[Données non publiées]
+1daccad3-2a56-48fd-82aa-0154714e6e74,[Données non publiées],Mairie [Données non publiées],"rôle d'Atsem, s'occupe du périscolaire, ménage",[Données non publiées]
+1dae8f24-7d6b-4164-a512-830e96b89a45,[Données non publiées],travailleur indépendant,CONSULTANT VITICOLE,[Données non publiées]
+1db1bb51-6d78-4515-92c1-c439ab5d7a44,[Données non publiées],Réseau ecoles montessori [Données non publiées],Directeur du développement et Président [Données non publiées],[Données non publiées]
+1db7d9c4-fa3a-4821-8f6a-ac106154d1b5,[Données non publiées],Ministère de l'Education Nationale,Enseignant,
+1dc44189-1185-4eb7-9892-85e552fa271e,[Données non publiées],L'Oreal,Ingénieur [Données non publiées],
+1ddbdd42-65b7-4c3b-91cc-58f9448f85ec,[Données non publiées],CCI de Meurthe et Moselle,"Formatrice, responsable pédagogique",
+1ddeec95-e566-44d6-8f2c-1f9b8c6b8d94,[Données non publiées],Sanisitt [Données non publiées],Responsable d'agence,
+1df4b648-dbaf-4fb9-aacc-a4c0fe6e55da,[Données non publiées],Société Générale,Cadre supérieur [Données non publiées],
+1df74f39-25c9-4ea4-8f5a-7765326868e6,[Données non publiées],NEANT,NEANT,[Données non publiées]
+1df82e06-d5f0-4061-b95c-364f96484938,[Données non publiées],[Données non publiées],Huissier de Justice,
+1dfa01a0-0a92-49ea-83b3-a70f356860cb,[Données non publiées],Indépendante,Formatrice en communication,
+1e015fa4-bb9c-4d55-bbfe-d7d6d5b51806,[Données non publiées],Earl [Données non publiées],EXPLOITANTE AGRICOLE,[Données non publiées]
+1e154a17-4833-47c5-8954-56fb51349eee,[Données non publiées],Maison de retraite SAS L'Hespérie,[Données non publiées],
+1e2444a9-9464-4d9d-ba9a-06930d2d7b4f,[Données non publiées],Retraité,Néant,
+1e24e5ba-6b23-4c95-88a1-95e14b8df9b0,[Données non publiées],Néant,Néant,
+1e4a4582-0c31-4aaf-9fcf-20229d191694,[Données non publiées],NEANT,NEANT,
+1e54b048-55a4-450e-b3e7-f08a253b5528,[Données non publiées],commerçante,gestion d'hébergements touristiques,[Données non publiées]
+1e563e69-ddbe-4118-aacd-8c651eb7014a,[Données non publiées],Artisan,Menuiserie-- -Ebénisterie,"[Données non publiées] jusqu'au 13 juillet 2021 Fin d'activité enregistrée chambre des métiers et de l'artisanat, et retraité à compter du 15 juillet 2021"
+1e633be9-9e1a-432c-a839-f87485f4a799,[Données non publiées],néant,néant,
+1e639fd1-b7e8-4206-a568-5147083cbd52,[Données non publiées],Education Nationale,Enseignante formatrice premier degrés,
+1e64787d-abc1-4f37-9bdd-2535838735f4,[Données non publiées],Ministère de l'Education,professeur,
+1e7135e3-f8e3-441e-a864-7df48f506227,[Données non publiées],Éducation Nationale,Professeur des Écoles,
+1e81ed08-bcd2-46b4-a931-2b6974612af1,[Données non publiées],CNRS,Chargée de communication [Données non publiées],
+1e890657-49a9-430d-a853-166d8d36926a,[Données non publiées],CEMEA [Données non publiées],Directeur régional [Données non publiées],
+1ea66f32-e9ce-423c-aa7a-3a082ab9de82,[Données non publiées],RETRAITE,retraité,
+1ea7cfa0-efb4-4e2c-9b35-20e789fc0fa6,[Données non publiées],Auto-entreprenneur,"Consultant en communication politique, enseignant dans le supérieur, formateur en communication",
+1ecd6610-f4e6-4e97-adaa-188d5420e0d3,[Données non publiées],néant,néant,retraitée
+1ece8fbd-ae58-4c8c-9b95-7d99c993e8ca,[Données non publiées],neant,neant,
+1ecec70a-0648-4227-b84b-411484217798,[Données non publiées],DEPARTEMENT [Données non publiées],ADJOINT TECHNIQUE,[Données non publiées]
+1ecec70a-0648-4227-b84b-411484217798,[Données non publiées],DIRECTION DES FINANCES PUBLIQUES,AGENT DES IMPOTS,[Données non publiées]
+1eda33af-5086-4610-a704-7a172d9a0303,[Données non publiées],SAS 3F Investissements,[Données non publiées],
+1edb268e-7669-47c7-9361-5900617033f1,[Données non publiées],LE ROUGE,Responsable [Données non publiées],
+1ee2364e-c931-4121-8afc-2997cfa0f1c3,[Données non publiées],Journaliste auteure et conférencière,[Données non publiées],
+1ee9487a-37cf-4cac-8802-1eec193adad5,[Données non publiées],Rectorat de Grenoble,Professeur de lettres modernes,
+1f006448-6841-4c97-98a0-0f783f913218,[Données non publiées],centre hospitalier [Données non publiées],secrétaire médicale,
+1f05681b-cb4e-4fab-9b3f-bd99f934f97b,[Données non publiées],Worldline,[Données non publiées],
+1f05d435-56ad-4477-a741-fbac70adba45,[Données non publiées],LEROY MERLIN,Cadre,
+1f2bbb17-e3d2-41ca-8ca0-0c4e78fd23cb,[Données non publiées],Autoentrepreneuse,Psycho-pédagogue,
+1f2d378c-bc7d-45a4-b180-cd4c4a5a66f5,[Données non publiées],Brest Métropole,[Données non publiées],
+1f3b3115-112c-4197-9115-e32b75a0700a,[Données non publiées],ville [Données non publiées],conseillere socio-éducative,
+1f4b0469-0085-490f-8790-fb35d513f9fd,[Données non publiées],commerçante indépendante,Fabrication de pain et gâteaux bio et négoces de produits régionaux,
+1f4b0469-0085-490f-8790-fb35d513f9fd,[Données non publiées],Sarl Le Poher hebdo,graphiste polyvalente,
+1f5562a3-c739-4c2a-89f1-197766d43c9d,[Données non publiées],auto-entrepreneur,professeure de yoga,
+1f5ee007-41e3-420f-a53e-2259ff8e30d5,[Données non publiées],néant,néant,
+1f5f4fae-4995-4a15-a2b6-06bcb91625c3,[Données non publiées],DIRECTION INTER REGIONALE DE LA MER,Technicien supérieur [Données non publiées],
+1f6c91f8-2b17-459a-bb81-c96866532c77,[Données non publiées],Cour de cassation,Conseiller-doyen [Données non publiées],
+1f858069-d05a-419e-9b45-17eaa50eeb87,[Données non publiées],[Données non publiées],[Données non publiées] [Données non publiées],arret de l'activité profesionnelle [Données non publiées]
+1f8930e4-5bf9-4da5-a30d-f4032c7db49d,[Données non publiées],SDIS 35,[Données non publiées],[Données non publiées]
+1f8d5981-04ba-4f5a-9d5d-f6afc6ccb954,[Données non publiées],Blue enerfreeze,[Données non publiées],
+1f935025-e50a-4a66-a825-2775fcf3ebd1,[Données non publiées],Rio Tinto (Royaume Uni),Président Exécutif - Aluminium,[Données non publiées]
+1f935025-e50a-4a66-a825-2775fcf3ebd1,[Données non publiées],JPCR Conseil SAS,Gérant,[Données non publiées]
+1f935025-e50a-4a66-a825-2775fcf3ebd1,[Données non publiées],John Cockerill (Belgique),Administrateur,[Données non publiées]
+1f9614b4-514c-4dad-9820-4cae43d1fc86,[Données non publiées],Retraitée,[Données non publiées],
+1f991dfd-eebf-4008-9a2b-52a8d42b4082,[Données non publiées],GHER,Psychologue,
+1fb52a18-2a91-42f3-be85-23d3c5058d5a,[Données non publiées],Mairie [Données non publiées],Directrice générale adjointe,
+1fbb96ed-6433-4c27-b173-a65ce49c3f97,[Données non publiées],Sas Fd Arnaud,[Données non publiées],
+1fbdcd89-75c5-4b75-b552-2d6aa7107ea6,[Données non publiées],Ville de Rennes,[Données non publiées],[Données non publiées]
+1fc8894c-8bae-4703-8aba-317796ffde95,[Données non publiées],profession libérale,Orthophoniste,
+1fda843d-ed0c-43e5-be07-0d26b59232ae,[Données non publiées],Education nationale,Enseignante,
+1fdc3c43-f846-4039-a833-11768c09de1a,[Données non publiées],Mairie de Montrabé,Agent territoriale [Données non publiées],
+1fdda6f7-1fd5-40de-86af-fba2e4bf1e99,[Données non publiées],Office National des Forêts,Ingénieur,
+1fde9dd5-a558-4c10-9fb1-ff3de8437560,[Données non publiées],VN Participations,[Données non publiées],
+1fe492d5-fb0d-4634-b72d-c92be32730cc,[Données non publiées],Poissonnerie [Données non publiées],Aide comptable,[Données non publiées]
+1febd73f-1d66-451e-9076-5bfcbf45cabd,[Données non publiées],Education Nationale,Proviseur de lycée,[Données non publiées]
+1ff0548b-f6bb-49e6-865c-191f393df56f,[Données non publiées],Néant,Néant,
+1ff32883-60fa-4b33-92cf-34bf06ed7c56,[Données non publiées],Hôpital [Données non publiées],"Aide soignante, assistante dentaire.",
+1ff32883-60fa-4b33-92cf-34bf06ed7c56,[Données non publiées],retraité,[Données non publiées],
+1ff5aba5-38da-4ad0-9988-352f2816c349,[Données non publiées],Retraitée,Neant,
+20019db4-cbd1-48d8-a333-b5d20e7deae1,[Données non publiées],Groupe ETAM,Directrice Clearance,[Données non publiées]
+200c865e-2be1-4ce7-ac08-c5203e343234,[Données non publiées],Education Nationale,Personnel de direction d'un collège,
+200e25a6-d261-41c4-ac81-c0a384fac991,[Données non publiées],ABL EMPLOI,cabinet de recrutement,
+201a250f-ed22-4890-b579-464c3748549f,[Données non publiées],Education nationale,Enseignante,
+2023c577-0549-4d40-925d-a7d7132432a9,[Données non publiées],auto entrepreneur,peinture,
+2030918b-df33-4d62-b9f1-28d5e682a248,[Données non publiées],eplefpa de [Données non publiées],formatrice,
+2031e786-e919-4a05-beac-f383668745f6,[Données non publiées],ASSEMBLEE NATIONALE,Député,
+2031e786-e919-4a05-beac-f383668745f6,[Données non publiées],METROPOLE DU GRAND PARIS,CONSEILLER METROPOLITAIN,
+203e1230-b6a8-420e-8b3a-d35f9625137e,[Données non publiées],néant,néant,néant
+204b0628-2bd9-47d7-a993-da063b8293c0,[Données non publiées],Metalor,Agent d'exécution [Données non publiées],
+204ca5e8-ebec-40a5-955b-0953997d1403,[Données non publiées],néant,néant,
+206124b6-951a-4ff4-b11e-d03ac81f1795,[Données non publiées],CAPEB Vosges,[Données non publiées],
+2065d809-a092-46a7-a5f4-5ba550e0f294,[Données non publiées],Tout en Vélo Grenoble,Dirigeant,
+2066edad-16e1-416f-b05d-a092c33593fc,[Données non publiées],Fédération de pêche de Seine Maritime,Régisseur de la pisciculture fédérale de Maulévrier Sainte Gertrude (76),[Données non publiées]
+2069ccd8-0cdd-4fca-ba7c-f377987fbb32,[Données non publiées],[Données non publiées],Assistante commerciale [Données non publiées],
+2075e1cf-fb7a-4142-9223-9e47ecb4de1b,[Données non publiées],EBEN,[Données non publiées],
+207ef863-97b3-416c-b683-7ed591658c90,[Données non publiées],[Données non publiées],Notaire,
+208d99b0-b0e2-4072-af22-48dcd4343b03,[Données non publiées],NEANT,NEANT,retraitée
+209b7a46-9c7f-4af0-a0cb-f8c5b2c0c88f,[Données non publiées],en retraite,néant,[Données non publiées]
+209b7a46-9c7f-4af0-a0cb-f8c5b2c0c88f,[Données non publiées],EXPLOITANT AGRICOLE,ELEVAGE ANIMAUX,
+20a09e95-a950-4444-92c8-35f2bfc0092a,[Données non publiées],EPICAP,Directeur,
+20a09e95-a950-4444-92c8-35f2bfc0092a,[Données non publiées],EPICAP [Données non publiées],Président,
+20a09e95-a950-4444-92c8-35f2bfc0092a,[Données non publiées],[Données non publiées],location salle de réception,
+20a09e95-a950-4444-92c8-35f2bfc0092a,[Données non publiées],[Données non publiées],Holding,
+20a48786-d681-4d39-836f-f7092c8cdc53,[Données non publiées],CEGID,Technicien consultant paie,Secteur privé
+20afcb15-76a2-47ec-890b-dd95f000e4a0,[Données non publiées],[Données non publiées],"auto entrepreneur, conseil, vente",
+20c02707-99b1-4d47-a372-235c8b2e07de,[Données non publiées],ARFIS-OI,[Données non publiées],
+20c3ae0f-8656-414c-a5dd-06ab30f86d99,[Données non publiées],la Caisse d'allocations Familiales,Charge [Données non publiées],
+20cb9188-9597-422f-81bd-e68a4ba4e2bb,[Données non publiées],SARL POIRIER [Données non publiées],négoce de porcs,
+20d2e194-48d2-45d4-846f-ad45f3f9c4dc,[Données non publiées],Centre Hospitalier de Mauriac,Praticien Hospitalier,
+20d7c766-449b-4645-bb6e-150068a7faca,[Données non publiées],Conseil départemental de la Seine-Saint-Denis,Attachée territoriale en détachement [Données non publiées],
+20dfcff1-e9c0-47a7-a872-992b508135f9,[Données non publiées],SONEPAR,Cadre commercial,
+20e89ae4-929c-4704-970b-ada03c288c31,[Données non publiées],[Données non publiées],Infirmière libérale Diplômée d'état,
+20ef385d-b226-4f97-b0fd-ea1dbc3c2653,[Données non publiées],ACORUS,Chargé d'étude de prix. Agent de maitrise.,[Données non publiées]
+20f044e8-3430-42cb-a111-cb56f7d2c1b9,[Données non publiées],Repsol,Ingénieur en génie des procédés (pour une usine de gaz),[Données non publiées]
+20f3706c-fe6b-4acc-b846-13d0d3aeafba,[Données non publiées],Néant,Néant,
+20f402f5-aaf1-4a32-9c63-27a1b4eee345,[Données non publiées],néant - retraitée,[Données non publiées],
+20f7d0e4-caff-4f6d-bbaa-7eb800d5b390,[Données non publiées],[Données non publiées],RETRAITEE,
+20fcce85-177f-428d-be09-e86533641115,[Données non publiées],Communauté d'Agglomération Etampois Sud Essonne,Directrice de la politique de la Ville,[Données non publiées]
+20fd2482-774b-495d-b02a-82bb93f9c234,[Données non publiées],Mairie d'Aulnay-sous-Bois,Fonctionnaire territorial,
+21073ea0-eeb5-4078-900a-a0bc00df708a,[Données non publiées],Mairie de Noisy le Sec,[Données non publiées],
+211fd314-3325-443d-91e1-97f3f60a5282,[Données non publiées],Sans emploi,Sans emploi,
+2123f4d7-9155-4d1c-9400-22ecd6529449,[Données non publiées],SA De Giorgi,[Données non publiées],
+212544dd-a973-49ba-9399-da67188f693d,[Données non publiées],Conseil départemental de la Seine-Saint-Denis,Attachée territoriale en détachement [Données non publiées],
+2133d16f-793c-46ee-b167-170d76be25b7,[Données non publiées],Collectivité,Responsable RH,
+213a67a3-f854-42b6-a262-165a7e292937,[Données non publiées],[Données non publiées],Agriculteur,[Données non publiées]
+21477bca-1e9f-4e4e-8787-dcac3e851ad4,[Données non publiées],NEANT,NEANT,EN RETRAITE [Données non publiées]
+214974c2-a260-4c99-81fc-f1cb6c13adae,[Données non publiées],SCEA [Données non publiées],gerant exploitation agricole,gerant
+214974c2-a260-4c99-81fc-f1cb6c13adae,[Données non publiées],SNC Vaucourt travaux agricoles,gerant d'une societé de prestations de travaux agricoles,
+214974c2-a260-4c99-81fc-f1cb6c13adae,[Données non publiées],SAS Theuvy Biogaz,President societé Production de biogaz,
+214fcf9e-36b2-4208-8c35-548d8b23633a,[Données non publiées],GAMA [Données non publiées],directeur [Données non publiées],
+215bb390-96f8-4851-a302-59df1d9d5362,[Données non publiées],NEANT,retraitée,Retraitée
+215f7af3-1bb1-4d65-91a5-298c70718192,[Données non publiées],Aéroport de Paris,Contrôleuse de gestion,[Données non publiées]
+215f7af3-1bb1-4d65-91a5-298c70718192,[Données non publiées],[Données non publiées],entreprise individuelle fabrication et vente d articles de bijouterie fantaisie,[Données non publiées]
+21663605-db52-456c-bd74-1d49b0570234,[Données non publiées],SARL SD CONSULTING,[Données non publiées] société de conseils.,
+216f5d87-1a5d-4ad1-9193-b9152ec81a78,[Données non publiées],Métropole Aix Marseille Provence,responsable de division [Données non publiées],[Données non publiées]
+2173ee4d-175b-45e5-9671-11b741156d45,[Données non publiées],SAFIR Consulting,Chef de projet [Données non publiées],
+217e211e-d3c7-4372-ac98-2d189b403483,[Données non publiées],PPG INDUSTRIES,RESPONSABLE [Données non publiées],
+217ed010-1a2d-4b12-89c5-70d3a1dec8de,[Données non publiées],FPH Centre Hospitalier de Briey,[Données non publiées] Adjoint Administratif [Données non publiées],
+2184798a-9239-4c9e-a67f-4c878644a149,[Données non publiées],NEANT,néant,seulement élu local
+2188e303-2e69-4cdf-b812-682d99dbed92,[Données non publiées],CPAM de l'Eure,[Données non publiées],
+218cef97-4ae9-4ded-b52c-78ed3e48a39b,[Données non publiées],AUBAY,[Données non publiées] Cadre,
+218e9f5f-2a1e-4930-8c6e-bb7288a6a370,[Données non publiées],AIRSPIRE,[Données non publiées],
+219b4348-5573-453f-b0fa-7df657b97b23,[Données non publiées],VNF,Technicien,
+219f53e3-b0ba-4ab1-a34e-b16526a28357,[Données non publiées],Entreprise individuelle,Attachée de Presse,
+21a877f9-df32-4f46-9cd8-c6e9e1b9658b,[Données non publiées],néant,néant,
+21a9307c-8b9d-47c9-ab65-8e5b877a7927,[Données non publiées],Institut Lumière,Responsable de [Données non publiées],
+21b43c3a-faa0-4637-be4f-6cea7deebe62,[Données non publiées],SDIS [Données non publiées],Sapeur Pompier,
+21babc6d-6a2c-4ef5-bffe-765cdda19107,[Données non publiées],[Données non publiées],Services à la personne,
+21babc6d-6a2c-4ef5-bffe-765cdda19107,[Données non publiées],[Données non publiées],Service à la personne,
+21babc6d-6a2c-4ef5-bffe-765cdda19107,[Données non publiées],[Données non publiées],Services à la personne,
+21bf4f2c-9ce4-4436-8927-887385c3d2ab,[Données non publiées],CPAM 93,Cadre de la fonction publique,
+21c3ac20-8952-48b4-8b54-027ef0a2b58f,[Données non publiées],Agence nationale de rénovation urbaine (ANRU),Urbaniste,
+21d213e8-41e0-4ac2-ae9f-1dff030009f1,[Données non publiées],Centre Hospitalier [Données non publiées],Directrice des Affaires médicales,
+21d34a53-e866-48e1-a8bb-7b3aeb277346,[Données non publiées],Retraité,Retraité,
+21d4f5a2-85f1-4ca5-8a1d-f2dbf4dfc766,[Données non publiées],[Données non publiées],sans profession,
+21d8a2af-6aec-4787-a64d-5038bd6803f1,[Données non publiées],Sas monin sports,Presidente,
+21e11eca-4280-4d13-a1fe-e6787fde0176,[Données non publiées],Franchise McDonald's [Données non publiées],Salariée,
+21f77a77-9a92-43c4-9854-7e674d260a04,[Données non publiées],[Données non publiées],Clerc de notaire,
+21fb5201-f8c0-4447-a7da-2c969bba0d95,[Données non publiées],Hôpital Louis Pasteur 28000 Chartres,Infirmier en soins généraux [Données non publiées],
+2201bc43-d973-4fd4-811a-5f6879780fb0,[Données non publiées],Libérale,Infirmière,
+2202475e-e247-47cc-ad5f-692e54e0f561,[Données non publiées],DGFIP,Contrôleur des finances publiques,
+22147ab1-c121-4d92-8794-38a34cb0fe87,[Données non publiées],[Données non publiées],Agriculteur,
+2215a5fa-bac6-4aaf-8d13-0142a3bb6fb7,[Données non publiées],Education nationale,Professeur d'Histoire-Géographie,
+22179289-46fe-495a-982d-9ab3a2ecb549,[Données non publiées],[Données non publiées],Société d'Investissement,[Données non publiées]
+221e9995-0704-402f-84c6-e9bf0c59ef00,[Données non publiées],[Données non publiées],assistante maternelle à domicile,[Données non publiées]
+22204364-edb6-4e3c-9cb9-505f408a9f1f,[Données non publiées],PHARMACIE DES COMBRAILLES,[Données non publiées],[Données non publiées]
+2228305e-de69-4426-9212-704b1bf3c227,[Données non publiées],Retraitée Education Nationale,[Données non publiées],
+222c2a74-98c9-4413-954c-874754b2b068,[Données non publiées],Néant,Membre du conseil de surveillance de UNIBAIL RODAMCO WESTFIELS Vice-présidente du conseil d'administration du groupe BANIJAY Membre du conseil d'administration de la SA GOODGROWER,
+22355bec-07df-46bd-a7b5-41da667d9936,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+22355bec-07df-46bd-a7b5-41da667d9936,[Données non publiées],Autoentrepreneur,Développement informatique,[Données non publiées]
+223bc5be-710d-4f41-92f3-624a65e6acec,[Données non publiées],neant,sans objet,
+22428a05-a76d-4ec3-b746-53a6f219cee3,[Données non publiées],EPCI,Attachée territoriale,
+224a061b-c806-4efd-9eff-ddacbb7b4a8a,[Données non publiées],RUAG MRO,Sénior Compliance Officer [Données non publiées],[Données non publiées]
+224a7a8a-811b-4874-b948-c6565779e487,[Données non publiées],EARL [Données non publiées],Agriculteur,
+22511f93-ad99-471f-92a3-eba2409cc3ef,[Données non publiées],TSO,Directeur commercial,
+22545209-0221-4e4c-8b7b-eca38c9bd519,[Données non publiées],Lui même,Auto-entrepreneur en location de meublés,
+22593385-baf7-40fb-b9c4-a4621912fb33,[Données non publiées],MTD Pure Water,Plombier [Données non publiées],[Données non publiées]
+2265ed20-1add-4c30-a1b8-5411a1f6e3a1,[Données non publiées],Conseil Départemental du Pas de Calais,[Données non publiées],
+2268bf10-66da-4789-9d6f-859156c26bbc,[Données non publiées],NEANT,NEANT,RETRAITE
+22695712-1ea8-4840-a306-baf2414c480f,[Données non publiées],NEANT,NEANT,[Données non publiées]
+226a52e1-afb3-499c-a054-9920e0eee4ba,[Données non publiées],[Données non publiées],COIFFURE,
+227777b7-63a7-4c94-92ec-997f0919753b,[Données non publiées],[Données non publiées],conseil gestion administrative,[Données non publiées] autoentrepreneurs [Données non publiées]
+227a7073-7e0e-4697-b656-b76b70c2ff9e,[Données non publiées],Associée - EURL,[Données non publiées],
+227cfbd3-34d7-4678-a412-6e96f6a645dc,[Données non publiées],Les Transméduses,Chargée de projet,
+2281158b-f99e-4575-bf79-04b55924f7c4,[Données non publiées],CNFPT INET,Elève conservatrice territoriale des bibliothèques,
+2284f5ac-b711-41b0-9710-16da62a22c9c,[Données non publiées],NESTLE PURINA,Salariée en R&D,
+22889783-f080-48c8-b271-231e4e96ee89,[Données non publiées],[Données non publiées],Retraitée,
+229538ad-882f-463d-ba22-017592cef526,[Données non publiées],[Données non publiées],Cadre administratif dans une école d'architecture,
+22af99e8-8f0c-4810-95cf-cb3812e0f7a8,[Données non publiées],profession libérale,Medecin pneumologue,
+22b2438a-405e-485e-8804-57fbba5fba60,[Données non publiées],SCC,Ingénieur commercial,
+22b812ae-e760-4461-808a-16e4efb10cf7,[Données non publiées],NEANT,NEANT,
+22c34d11-74dc-4412-b159-982ade31cd94,[Données non publiées],SorbonneUniversité,[Données non publiées],
+22c702f5-eea4-4a95-a8e9-ab7220c54174,[Données non publiées],Demandeur d'emploi,Sans emploi,
+22cf2b4b-fdcc-4908-a9e1-0611e0c5503a,[Données non publiées],éducation nationale,infirmière scolaire,
+22d671ae-4d9b-4cc5-941e-3fb4995f3a98,[Données non publiées],[Données non publiées],[Données non publiées],Retraite
+22e6f834-932b-43e8-83a4-9efa070dcb97,[Données non publiées],Education Nationale,Professeur des écoles,
+22f04448-5656-461c-a182-5b61e4f4d8b6,[Données non publiées],Mairie de Villeurbanne,[Données non publiées],
+22f54221-c11f-4f0a-8327-6ef4bb0e3d2c,[Données non publiées],Département de la Charente,[Données non publiées],
+22f6d27e-a63f-4c0d-9bd7-16037219330e,[Données non publiées],AUBAY,[Données non publiées] Cadre,
+22f9a2d3-3a75-4e8a-9596-ec0c2122c41e,[Données non publiées],[Données non publiées],[Données non publiées] EXPLOITATION AGRICOLE EN CAPRIN LAIT,[Données non publiées]
+22faff91-650a-4b4e-be0a-d8dc690143c8,[Données non publiées],Côté déco [Données non publiées],Employé,
+230b4cdd-4993-4ec8-b0c5-de7817193889,[Données non publiées],NEANT,NEANT,
+230e1b0b-1c29-4d21-821d-3d5933970084,[Données non publiées],SAS Quali Investissements,Comptable,
+23162920-7ff2-4d15-abd2-b2d94ee60c6c,[Données non publiées],Centre Hospitalier de Cayenne,ASH,[Données non publiées]
+23164f60-7d84-45d3-bb58-0d8fa312ba4d,[Données non publiées],DAIICHY-SANKYO [Données non publiées],Laborantine,
+232aade8-de36-480f-8b55-55eba0bba4e5,[Données non publiées],Scholz and Friends,Chargé de clientèle [Données non publiées],
+233cc84c-d41b-4d04-a097-3a8f2eb897c6,[Données non publiées],education nationale,directrice d'ecole,
+234eb111-0193-476e-acc6-b41f22696d4e,[Données non publiées],Education nationale,AESH [Données non publiées],
+235de47b-10a3-45e5-bb18-0dad31dd1a7d,[Données non publiées],Syndicat mixte du Parc naturel régional du Morvan,[Données non publiées],[Données non publiées]
+236b3699-4bd1-4af7-858e-8a24d5fd23ff,[Données non publiées],Commune de Blaye-Les-Mines,Directeur Général des Services,
+23710255-afb3-4b86-af8e-2bd0a4d19d22,[Données non publiées],Saint Nazaire Agglo,Responsable du service [Données non publiées],
+23779283-4de9-400a-9446-4dfef184a6fd,[Données non publiées],MSA GRAND SUD,Expert [Données non publiées],
+237aa0e8-712f-424c-b66f-6bb24a0e9aee,[Données non publiées],[Données non publiées],ENTREPRISE DE SERRURERIE METALLERIE,
+237d3ff3-a124-4ded-8c8d-4d915fbed459,[Données non publiées],Université de Strasbourg et Hopitaux Universitaires de Strasbourg,Professeur des Universités - Praticien Hospitalier,
+23827c33-ef36-429a-8905-269e03c440c3,[Données non publiées],Néant,Néant,
+2388ad20-cb56-4cdd-973d-6d8e3a549b58,[Données non publiées],Centre Electrique Entreprise,Animateur Prévention Sécurité,
+238c235c-c84e-478a-b4c3-6d2301430a43,[Données non publiées],Hopital St Marie Nice,Infirmière,
+238c9ca2-44cb-4e52-8756-2402c347a788,[Données non publiées],Airbus,[Données non publiées],
+23913018-5c58-444b-b517-3231e3cfd0d2,[Données non publiées],Ville d'Etampes,néant,[Données non publiées]
+2399e716-3b17-45b9-849a-5dc4761ffd36,[Données non publiées],Néant,Néant,
+23a024dd-21a6-46b6-89e2-1ec6f9ab2d71,[Données non publiées],APHM & Aix Marseille Université,Maître de Conférence et Praticien Hospitalier [Données non publiées],
+23a5cae8-aa8c-4c59-8364-0814b87659a3,[Données non publiées],avocate associee,Avocate,
+23a8169d-9efe-49e1-9b02-cfb02c4895f3,[Données non publiées],CIST [Données non publiées],Médecin de travail,
+23a8169d-9efe-49e1-9b02-cfb02c4895f3,[Données non publiées],AGESTRA [Données non publiées],medecin du travail,[Données non publiées]
+23a9bb48-2d1d-4536-8060-be199c5a2738,[Données non publiées],CDC DE SABLE SUR SARTHE,[Données non publiées],[Données non publiées]
+23ac4610-7234-486a-810f-2121b8443239,[Données non publiées],Education nationale,Adjointe admnistrative,
+23b7a568-04bc-4a50-a78f-1e17ca7f4df7,[Données non publiées],Alstom,Retraité,"plus d'activité, en retraite"
+23c140f3-a369-4efe-9ab0-857f0e7b3699,[Données non publiées],exagrid,Ingénieur informatique [Données non publiées],
+23c1c21f-9128-4419-9d3f-894ee64ba460,[Données non publiées],activité libérale,Avocat [Données non publiées],[Données non publiées]
+23cbcbde-1564-49a1-98da-84faea6bb834,[Données non publiées],Artiste-Auteur,Création d'ouvrages pédagogiques,
+23cdc079-fafb-4bb5-856b-44aacfbae9d2,[Données non publiées],Mairie [Données non publiées],Assistante de direction,[Données non publiées]
+23d7c8f3-726d-4e21-9609-d32c264ccf4f,[Données non publiées],EDUCATION NATIONALE [Données non publiées],AVS,
+23d9cace-1000-4256-9081-344094a06073,[Données non publiées],Ville de Calais,[Données non publiées],
+23e7dc38-a21f-4270-b956-d4f70232c299,[Données non publiées],ADAMEden,[Données non publiées],
+23ea1a7a-e0c4-4d01-93f3-16fcdcd0b440,[Données non publiées],EDF,QSE /Chargé d'affaires,
+23fcf2a4-e820-4513-b011-0a8dcbabfa1a,[Données non publiées],CINEBOOK Ltd,Editeur de bande dessinée,[Données non publiées]
+23fe1e80-8d39-44ff-a540-833d9daf8ce4,[Données non publiées],Ministere de l' économie et des finances - Ministerede l' action et des comptes publics,contrôleur général économique et financier [Données non publiées],
+2412d14c-c3d5-417d-b19c-7211d47c6b19,[Données non publiées],SAFER [Données non publiées],Directrice generale,
+242551c1-566e-467e-a25f-1a21e2b28069,[Données non publiées],CAMG,[Données non publiées],
+242791e4-ed0d-4968-99c3-df5c6e1e626d,[Données non publiées],BanquedeFrance,Agent d'atelier,
+242e3fe3-db92-4de9-8a5f-c955ee2b97ee,[Données non publiées],SPB,DRH,
+24326019-dc77-4b56-9373-4ec30a764ac3,[Données non publiées],LES JARDINS DE FLORENCE,Employé polyvalent [Données non publiées],
+2438e429-6258-4a58-9198-f4bb5c92ba3d,[Données non publiées],CHR [Données non publiées],Infirmière anesthésiste,[Données non publiées]
+243a1b40-4236-4e82-90b0-3ee3df550a34,[Données non publiées],OGEC [Données non publiées],Responsable de la pastorale,
+243ffb1a-9385-4330-aff6-1074016752b9,[Données non publiées],Ville de FOSSES,Fonctionnaire [Données non publiées],
+245a1c7f-eb82-4b68-94c2-c6e66e37b505,[Données non publiées],éducation nationale,professeur des écoles,
+245b4538-55d7-4bac-ad9b-5f3d1d246d44,[Données non publiées],Centre Hospitalier de Mauriac,Praticien Hospitalier,
+245f12b6-9c19-43e7-afa9-08cf3e4b32bf,[Données non publiées],Université [Données non publiées],enseignante,[Données non publiées]
+2470f905-40b8-4a64-9f28-ee13b2083144,[Données non publiées],[Données non publiées],conseil en gestion de patrimoine,
+24750c55-4c49-46f2-a120-60872b8a570f,[Données non publiées],Korn Ferry,[Données non publiées],[Données non publiées]
+247c9ff8-b09c-41a1-a9c5-f762f684bc7c,[Données non publiées],La Poste,Responsable commercial,
+2485f2b1-4410-4b2a-a82e-0fb7d6bdd71a,[Données non publiées],CDG76,Secrétaire médicale [Données non publiées],
+248c432b-78f3-4efa-8be1-9949120ea9c8,[Données non publiées],C2RP Nord,Directrice,[Données non publiées]
+248ccc24-7f4d-481f-8712-df2a6ad83854,[Données non publiées],Education Nationale,Professeure,
+248ccc24-7f4d-481f-8712-df2a6ad83854,[Données non publiées],[Données non publiées],Autrice,
+24964881-00e9-4f93-9075-d4ffb8c94961,[Données non publiées],El One Production,Gérante,
+2497a97a-1b5c-4d51-aab7-f8f65900d7cd,[Données non publiées],Clinéa,Psychologue clinicienne [Données non publiées],
+2497a97a-1b5c-4d51-aab7-f8f65900d7cd,[Données non publiées],La Croix rouge : Hôpital [Données non publiées],Psychologue clinicienne,Outre son activité salariée à temps partiel [Données non publiées] exerce également une activité de psychologue en libéral.
+2498bca3-e458-437e-9ae5-c79b6e713916,[Données non publiées],Education nationale,Enseignante a la retraite [Données non publiées],[Données non publiées]
+24998da4-c716-4cdc-a3f3-8c3d7cd104e8,[Données non publiées],Néant,Néant,Retraitée
+249aeb9a-cebf-430d-a1c7-497b9ecc791a,[Données non publiées],Conseil Régional de Bretagne,[Données non publiées],
+24af38d3-bcdc-47d1-a19c-3adaa6caf7bf,[Données non publiées],DIOCESE [Données non publiées],animatrice en pastorale,
+24b009eb-5401-421c-850f-5d31faf0e49f,[Données non publiées],neant,[Données non publiées],[Données non publiées]
+24bba6a4-755f-4ac0-bd70-552672e1e136,[Données non publiées],Conseil départemental de la Mayenne,Directeur [Données non publiées],
+24bd640c-f8f0-4cd1-bec4-07032a7ef129,[Données non publiées],EIRL,DEBITANT DE TABAC,
+24c3d2f0-6352-42b6-a92b-32991fbec26a,[Données non publiées],Caisse d'épargne,Gestionnaire de comptes,
+24c9a9db-c037-482b-a9fe-6907ffd3f7c8,[Données non publiées],Ville de Saint-etienne,[Données non publiées],[Données non publiées]
+24cecca2-8c7b-4aa2-9f48-278f32377aa3,[Données non publiées],retraité,Cadre France Télécom,[Données non publiées]
+24d525f3-f8cc-458c-bfa1-3c01565c967b,[Données non publiées],NEANT,NEANT,
+24d56eb4-ad48-4caf-a2cd-23976fb8bb1e,[Données non publiées],Hopital St Marie Nice,Infirmière,
+24ee1144-81cc-4b4a-b32c-eb0f7b6561c2,[Données non publiées],Ministère Education Nationale,Professeure des écoles,
+25001f30-ccfc-467b-93ab-afcb92b60614,[Données non publiées],COMPTOIR AUTO [Données non publiées],ASSISTANTE DE DIRECTION [Données non publiées],
+250782ea-df9d-4fba-8f7a-3f5658dae5e6,[Données non publiées],neant,neant,
+251a0438-94f9-4c02-84ef-91430a14648f,[Données non publiées],Conseil Départemental des Vosges,[Données non publiées],
+2526e33a-fc66-40fb-98a6-65b59d830fea,[Données non publiées],sides,magasinier SAV,
+252ad499-52da-45e8-9913-94739e48a8d0,[Données non publiées],Kim Executive,Présidente,
+2534f0c8-81eb-4104-8148-d3d546ded260,[Données non publiées],APHM,[Données non publiées],
+25383276-3d61-4891-ad38-88703d6c3b48,[Données non publiées],[Données non publiées],DIRIGEANT D ENTREPRISE,
+2539f629-dbf0-428b-a8ac-75630cdc112c,[Données non publiées],Macocco Ouest,Assistante commerciale,
+253ff5cd-21e4-40e7-89c0-16c2b19fdb56,[Données non publiées],Centre hospitalier [Données non publiées],Psychomotricienne,
+25422e3f-224d-4df6-a5e4-33534453c207,[Données non publiées],Néant,Néant,[Données non publiées]
+2543302f-b75b-4570-a9d0-b36cf6703405,[Données non publiées],France Télévision,Journaliste,
+2545d500-3764-4c6a-8811-999d06c8a038,[Données non publiées],Retraité,Néant retraité,
+2545f3b6-8c73-486a-8ddd-5887bb330de1,[Données non publiées],SPL [Données non publiées],Directrice,[Données non publiées]
+254b6181-7e41-4e57-afbf-b632ee15dd12,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+254b6181-7e41-4e57-afbf-b632ee15dd12,[Données non publiées],sans emploi,[Données non publiées],
+254e1f57-a492-4683-b69b-20da8c571984,[Données non publiées],Néant,Néant,
+2550530d-c87c-4ce0-84c8-bec4cc72c3f5,[Données non publiées],Gérant,SAS Courtin [Données non publiées],
+255b4669-defb-4398-af81-c0c34da4eb91,[Données non publiées],Néant,Retraitée,
+255e25e5-e28a-4b5f-b555-de166aeddc15,[Données non publiées],Libéral à son compte,Chirurgien Dentiste,
+2581039d-51b7-48a7-910e-ee5c5d2d7ace,[Données non publiées],néant,néant,néant
+25822544-916a-4639-834f-fe55ffdba38d,[Données non publiées],Neant,Retraite,
+2583363b-6def-41a6-8935-634f9cb839ba,[Données non publiées],Hilti France,Directrice [Données non publiées],
+2585511e-51f2-4579-a992-cf66d7b2007d,[Données non publiées],SAS [Données non publiées],Président de cette société qui a pour activité le Conseil en Gestion de Patrimoine,
+2589cd0d-7ef3-4f55-82c2-8eb0014c8be7,[Données non publiées],PAYPERWEAR,COMMERCIALE,
+259211ab-beb1-4242-a448-45dd980d83de,[Données non publiées],Néant,Néant,[Données non publiées]
+259612fa-2c9c-4f3b-9570-e41db2f08ce9,[Données non publiées],clinique vétérinaire,docteur vétérinaire salariée,
+259e858f-aa5f-48be-9330-7177dee9c450,[Données non publiées],"Direction des Solidarités, de l’as famille et de l’Egalité Polynésie Française",Secrétaire Rédactrice,[Données non publiées]
+25b23d27-24cd-4afd-916f-7a8614d792da,[Données non publiées],Conseil Départemental Gironde,[Données non publiées],[Données non publiées]
+25c5ee52-b371-4e41-89df-c303522e795f,[Données non publiées],MAIRIE DE BAILLEUL,ANIMATRICE,
+25ce7397-0af7-4908-a19a-4209fccd9eb8,[Données non publiées],RETRAITEE,retraitée,
+25cfd28f-6c7e-4c57-b34e-b9f15d3d683e,[Données non publiées],CHU [Données non publiées],Chef d'unité fonctionnelle,
+25cffbed-3ff6-420b-b659-336a6f8ffa8f,[Données non publiées],Education Nationale,Professeur des Ecoles,
+25dd5256-5465-49b2-9c13-6b3cbd678972,[Données non publiées],GRAND REIMS,Responsable [Données non publiées] - [Données non publiées],
+25e25a7e-2efb-4af7-baf6-24264fb9c599,[Données non publiées],STANHOME,VRP,
+25e5a085-484d-4522-bda8-360e6e02ebd2,[Données non publiées],[Données non publiées],[Données non publiées] télésecrétaire,[Données non publiées]
+25ed1f4e-7c7c-4b53-9ad9-768fa4946fba,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+25ed1f4e-7c7c-4b53-9ad9-768fa4946fba,[Données non publiées],JNM Concept SASU,Bureau d'études économie de la construction,[Données non publiées]
+25ee6ad6-f30a-455e-a420-001d655184b9,[Données non publiées],Habitat audois,"Office public HLM de l’Aude, [Données non publiées]",
+26019b33-2e44-4ccd-ae15-faf6137ec182,[Données non publiées],Groupe VYV,Président,
+26027fbb-e2d5-47ea-b7af-6cc0fe6f75b9,[Données non publiées],CPAM [Données non publiées],Chirurgien Dentiste,
+26027fbb-e2d5-47ea-b7af-6cc0fe6f75b9,[Données non publiées],[Données non publiées],Gérante,
+26054b00-178f-4ec2-8143-33c886a74deb,[Données non publiées],[Données non publiées],Médecin Généraliste,
+2605812e-1614-42cf-87d1-d8724af893de,[Données non publiées],Auchan [Données non publiées],Assistante de direction,
+260f0800-b767-4142-8b1a-95d5029b456b,[Données non publiées],Selarl [Données non publiées] Avocats,Avocate collaboratrice libérale [Données non publiées],
+26139537-34ca-45f1-a1f9-13363ee36133,[Données non publiées],neant,sans,
+26188c78-dc26-489c-9552-0c9fb3ed5d7b,[Données non publiées],CCAS [Données non publiées],Directeur de crèche,
+2621ae75-2310-453e-b449-01e0db53f33a,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+2621c94e-c9d5-420c-bbdd-79a6c4607e1d,[Données non publiées],education nationale,prof de lycée pro,
+26253653-eef0-42fa-a0c1-5c9ded54a478,[Données non publiées],Mairie [Données non publiées],Agent Territorial Spécialisé [Données non publiées],
+263436d3-2da4-4119-99fe-6018a15a7e7c,[Données non publiées],Victory,Président de la société Victory,
+26369772-d95a-42df-a9b3-3516eabbf334,[Données non publiées],RETRAITEE,Fonctionnaire territoriale en retraite [Données non publiées],[Données non publiées]
+263956ae-95a9-4b05-ad46-000c7e6b80f8,[Données non publiées],HOPITAL [Données non publiées],INFIRMIERE,
+2639b47a-44f8-479d-8928-2ad58e92b6cd,[Données non publiées],[Données non publiées],professeure des Universités en histoire contemporaine [Données non publiées],
+263d2b71-15c6-4559-b686-c03ea9436839,[Données non publiées],Ministère de l'Intérieur,retraité,
+2659d12a-7f48-4e5b-9297-4b163879ef13,[Données non publiées],SA [Données non publiées],directeur général / démolition automobile,
+26667e12-d723-479e-b06f-1630924056e3,[Données non publiées],autoentrepreneur,Professeur de yoga,
+2666cf93-aa26-41c0-9695-1d0373b2b86a,[Données non publiées],intermarché,manutentionnaire,[Données non publiées]
+267269a5-9645-4f33-b0b9-0d9a43c21d31,[Données non publiées],CPAM [Données non publiées],Responsable [Données non publiées],
+2677d296-e9d2-497c-967d-635730ea32e9,[Données non publiées],FERRO,RESPONASBLE DE MAINTENANCE ET DE TRAVAUX NEUFS,
+2679b48d-c202-4949-86d5-789d30fba05a,[Données non publiées],CD23,Technicienne de laboratoire,
+26823b1f-b246-4077-bf67-63db07eec801,[Données non publiées],sas centre recyclage auto,assistante de direction,
+268545dc-d6ba-4a6c-b908-284057050c31,[Données non publiées],Education Nationale,Professeur des écoles,
+268e6b4b-dd88-4fdc-8d41-d6e22002c02d,[Données non publiées],Keolis Lyon,[Données non publiées],
+269085a4-c73d-455c-b2a1-05962db2c8de,[Données non publiées],NGE,Chef de secteur,
+269e431e-7c8a-474b-937e-c1a1722ff83e,[Données non publiées],Arlim Prestige,[Données non publiées] agent immobilier [Données non publiées],
+26a50209-47d0-43e0-810d-9373ae7b8ba2,[Données non publiées],néant,retraité,
+26b1b783-a5c0-4bd9-8118-a9017f17ca9f,[Données non publiées],Maison Rochas,Agente administrative,[Données non publiées]
+26b740cc-f4dd-4279-a093-8e3fe3aed52e,[Données non publiées],[Données non publiées],RETRAITEE,
+26c6e777-f2d2-4027-9c5d-6d47ccae155e,[Données non publiées],EDUCATION NATIONALE DE LA REUNION,ENSEIGNANTE,[Données non publiées]
+26ca75a5-8e7b-4498-9745-2f7b87df3235,[Données non publiées],Ville de CHERBOURG-EN-COTENTIN,ATTACHÉE TERRITORIALE PRINCIPALE,
+26db0302-d953-4275-9889-e9a1cb01507b,[Données non publiées],Ministère de l'Education Nationale,Professeure des écoles,
+26e020ba-1c40-4538-820d-0d8482c55d56,[Données non publiées],SEMPRO et SPL 92,Aménagement et promotion immobilière,
+26e29b87-7962-42c5-b846-87da8ae6fa12,[Données non publiées],NEANT,NEANT,[Données non publiées]
+26e2fdb1-6333-4956-998e-5cdc0567af51,[Données non publiées],CIAS,adjointe administrative,
+26e9893d-07a3-4955-9e44-749ead122a2c,[Données non publiées],AUCUN,[Données non publiées],
+2705ee40-e1a9-497e-a756-b7c166c95021,[Données non publiées],SA GERFLOR,[Données non publiées],
+270dd8fd-f8d8-46ed-9baf-259c3e6f3964,[Données non publiées],Crédit Mutuel,[Données non publiées],
+27125650-0280-426b-a0a9-4e55f50840b7,[Données non publiées],Profession libérale,Kinésithérapeute,
+271f7bbe-56c2-402b-a76c-851da674e224,[Données non publiées],villeguingamp,[Données non publiées],
+2720088d-2ccc-4052-ba25-ff5813df56fb,[Données non publiées],[Données non publiées],Exploitant agricole,
+27293e8b-5c20-4af8-928d-8fc9197aa7d0,[Données non publiées],Education Ntionale,Professeur de français en collège,[Données non publiées]
+27357efe-44f9-4c4b-81ab-c6c79ee070e9,[Données non publiées],TEHOGIHIA,Commerce d'alimentation générale,[Données non publiées]
+27461e90-a666-4561-b2b8-9672b2d3d8dc,[Données non publiées],COLLEGE [Données non publiées],Professeur Certifié,
+27594afb-c01c-41a9-905a-c2737ac67e62,[Données non publiées],Sénat,[Données non publiées],
+275a3887-f0c1-45f9-a0e9-ac67a8989f88,[Données non publiées],[Données non publiées],OPTICIENNE-DIRECTRICE DE MAGASIN,
+2770ff62-fbbb-4231-95d6-cad894d99688,[Données non publiées],retraitée,néant,
+27746089-cd99-47d6-b420-e06528be84c1,[Données non publiées],Neant,Neant,Retraitée
+277e7d5a-7325-4f84-9c34-e6a34d5f2537,[Données non publiées],Gérante sarl,Administration de biens,
+27845fef-f45d-41fa-b105-cb38d9174473,[Données non publiées],cabinet dentraire [Données non publiées],Secrétaire médicale,[Données non publiées]
+278f0906-4aaa-4219-83b5-8bbd12dcefaf,[Données non publiées],néant,Adjoint au Maire de Reims et conseiller départemental de la Marne Auto-entrepreneur dans la vente de champagne,
+2790751a-1912-4997-ace5-35376abbc2ec,[Données non publiées],CHU Dijon,psychologue,
+2790b129-d22b-4446-8b2b-14830726582d,[Données non publiées],Assistante maternelle,Garde d'enfants [Données non publiées],
+2799bbc4-b38a-4b22-9ec1-a56dffb83fec,[Données non publiées],A.M.J.P. (L'ATELIER D'YVONNE),Chef de rang,
+279a042d-c918-403b-b88a-267b645e7d59,[Données non publiées],STAG - Villers Bretonneux,Assistante administrative,
+27c6140e-2095-450f-9703-6ec6ebc983c1,[Données non publiées],Alto OnSite,[Données non publiées] [Données non publiées],[Données non publiées]
+27d7fc71-89e7-4efb-ad7a-2fa777ec922e,[Données non publiées],Préfecture [Données non publiées],Chargé de mission [Données non publiées],
+27dc7306-7bf0-44b6-8696-f697764267c2,[Données non publiées],PUBLICIS CARRE NOIR,[Données non publiées],
+27dca0b6-f5e9-4214-9415-1d68cdde4dee,[Données non publiées],CNP ASSURANCE,Cadre supérieur [Données non publiées],
+27e1e729-909f-4ee1-ab12-9bb88ecf1bf8,[Données non publiées],SNCFConseil,[Données non publiées],
+27e58d20-2842-4b58-8400-7f5b92cdcf91,[Données non publiées],Hynamics,[Données non publiées],[Données non publiées]
+27ec313c-0235-459d-8095-fc506edf57f5,[Données non publiées],VILLE DE NIMES,[Données non publiées],
+27f47b11-93b5-4bd9-b68a-474478dfcdb4,[Données non publiées],Mairie de Mandelieu,[Données non publiées],
+28002411-cb10-457c-8afa-05931db90a5c,[Données non publiées],Médecin spécialiste libéral puis hôpital [Données non publiées],Spécialiste en endocrinologie installée en libéral et hospitalière,[Données non publiées]
+280220c0-a9c1-444d-9bc8-7f36fe48f91e,[Données non publiées],[Données non publiées],infirmière libérale,[Données non publiées]
+28092441-f782-4c52-935d-a70610dfeeed,[Données non publiées],Education nationale,Enseignant (Professeur d'EPS),
+280a739a-6432-4801-a36b-556d8c5c54ee,[Données non publiées],CNFPT,Formatrice,
+280ada94-e65c-4c1f-adb9-dd411e203934,[Données non publiées],[Données non publiées] Gérante,Conseil en Communication,
+280e770d-7269-4cb3-9260-7edd837a8a6c,[Données non publiées],Député,[Données non publiées],
+281e55f7-f56c-4c8a-b20e-9f4c09bd8c2b,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] retraité [Données non publiées]
+281e7bdc-7028-41ed-9871-98eb376714f4,[Données non publiées],MICRO ENTREPRISE,COIFFURE A DOMICILE,[Données non publiées]
+283a35c3-cd38-48d2-8027-ac99219af3cd,[Données non publiées],SNCF,Conducteur de train,
+283ce334-b440-4e90-b8ce-fa8fb986c896,[Données non publiées],Profession libérale,Podologue,
+283cf789-ba8c-4942-92de-5544e0748dd4,[Données non publiées],Université du Mans,Secrétaire administratif [Données non publiées],
+2850dec1-0cb6-401e-8498-339461c2f98d,[Données non publiées],AKZO NOBEL DECORATIVE PAINTS FRANCE,Responsable [Données non publiées],
+285325fc-e774-4503-875c-e4589115535f,[Données non publiées],auto entrepreneur,Achats ventes antiquités brocante,
+285b346e-9eb8-40bf-ac97-b657ffb718e1,[Données non publiées],Néant,Néant,
+285b346e-9eb8-40bf-ac97-b657ffb718e1,[Données non publiées],Néant,Néant,
+285f27a4-bdb1-4c7a-91a9-7efd233c3c15,[Données non publiées],BRUN SA,[Données non publiées],
+2865328b-2e6a-4ebd-92cd-38cba35d4d55,[Données non publiées],Alto OnSite,[Données non publiées],[Données non publiées] )
+28672698-4a44-4454-9bec-c5a596ea117c,[Données non publiées],GROUPAMA [Données non publiées],Technicien [Données non publiées],
+28683585-5f6f-48bc-9075-bd1d5bdb44d9,[Données non publiées],GHEF,Pédopsychiatre praticien hospitalier,
+2874e47c-ffad-44a8-97f6-c95448a82373,[Données non publiées],Dirigeante de la SARL Atelier Sardane,[Données non publiées] agence de communication,
+2875f817-dff3-4eab-b2cd-706fda74f4c2,[Données non publiées],auto entrepreneur,professeur libéral de yoga,
+2889cdcc-3bfa-4717-b686-9f5b2750da09,[Données non publiées],SNCF,Retraité,
+2892c0bb-f2d9-435f-a2ef-1ddff10c0b53,[Données non publiées],GAEC [Données non publiées],Agriculteur,
+289abd1c-e000-4708-b359-ceeea570d364,[Données non publiées],mairie de Saint laurent du var,[Données non publiées],
+28aa84de-9d34-487c-b870-fea384348469,[Données non publiées],CMA France,Directeur des relations institutionnelles,
+28b3f747-f4e7-4f17-8403-24f1c30fe3d4,[Données non publiées],Fonction publique,Magistrat administratif,
+28b9f3f9-33bd-4d36-831e-123059e11d4f,[Données non publiées],aucun,aucune,Aucune rémunération
+28bc6673-2f62-4989-8ad3-a83470ebbc6f,[Données non publiées],Institut Montaigne,Chargé d'études,
+28d84cec-31e4-4042-9f3b-3aa3c77fd09e,[Données non publiées],ANGERS LOIRE METROPOLE,[Données non publiées],
+28da9984-918b-46b6-a4fd-b1c83d0f175b,[Données non publiées],IDEFHI,Ingénieur hospitalier [Données non publiées],
+28e78c65-88c3-45f6-890e-884a4f5b29f8,[Données non publiées],France Télévision,Journaliste,
+28f26d18-a3a6-40d9-beb9-ef7135146e63,[Données non publiées],Ministère de la Justice,Magistrate,
+28fde713-c01b-48ea-a418-0ae4872eb767,[Données non publiées],SARL [Données non publiées],Gérant du garage,
+290587a3-343e-43c1-8045-51fed8c8c4eb,[Données non publiées],Néant,Néant,
+290c67f1-0c4f-44bc-988c-2490f10ad996,[Données non publiées],mairie de Bégard,[Données non publiées],
+290deb0f-f417-4d26-b82b-d1ae4caef15c,[Données non publiées],Assemblée_Nationale [Données non publiées],Attachée_Parlementaire,
+2913b8ac-9228-44ed-85e1-c04e9bd9faaf,[Données non publiées],TILLY LOCATION,CHEF D'EQUIPE MECANICIEN,
+29191907-413c-4412-bf69-0988c71f9d91,[Données non publiées],[Données non publiées],DIRECTEUR DE CONCESSION AUTO,
+29261bc9-601b-4b5e-948e-500b5d99486f,[Données non publiées],[Données non publiées],[Données non publiées] retraitée [Données non publiées],[Données non publiées]
+292af528-328a-45be-a10f-8da23712cc9a,[Données non publiées],Néant,micro entrepreneur,
+2933d3ec-01c4-48e1-8a03-57968a9b8af0,[Données non publiées],néant,néant,
+293433ed-f9c7-454c-9f23-7c646cf501c7,[Données non publiées],CHRU LIMOGES,Agent administratif,
+29354efc-115c-4505-930a-8e4f4d620f85,[Données non publiées],SNC [Données non publiées],Co-Gérance,
+2949dbad-82f8-4bed-8892-a9af8a033737,[Données non publiées],OGEC [Données non publiées],Responsable APS Collège,
+295fc805-e8dd-4198-9fb4-a851b9ae6a52,[Données non publiées],Armony Saveurs,[Données non publiées],Restauratrice indépendante. [Données non publiées]
+295fc805-e8dd-4198-9fb4-a851b9ae6a52,[Données non publiées],L'Accorderie,Coordinatrice [Données non publiées],[Données non publiées]
+297a9acf-f0a4-48c0-86fd-3f19564130c7,[Données non publiées],Viticulteur ( son propre employeur),Viticulteur,
+298f9e2e-0285-4d53-9ca2-77f8690c3b92,[Données non publiées],retraité,néant,
+299c4381-367d-469a-a3dc-1c6a948ce37f,[Données non publiées],EPLEFPA [Données non publiées],animateur financier,
+299f78e5-1d19-4964-a5c9-73a979c3c2fa,[Données non publiées],honewell aérospace toulouse,responsable [Données non publiées],
+29b0b088-de7e-4594-ba6f-64315592e9fc,[Données non publiées],Université de Tours,Professeure agrégée du second degré [Données non publiées],
+29b24e42-9937-488e-abb8-774a6521f9f3,[Données non publiées],RETRAITE,NEANT,
+29b554a1-a187-43a3-a854-4a4ead477a69,[Données non publiées],[Données non publiées],[Données non publiées],retraité [Données non publiées]
+29c4e87d-c1a3-425b-89c8-12b665d04b8b,[Données non publiées],Conseil départemental du Nord,[Données non publiées],néant
+29d0634e-cc31-4f6b-a80c-fbe2fb1bc3ca,[Données non publiées],GEIE GECOTTI-PE,Chargée de mission [Données non publiées],
+29d0f539-aecc-4637-adcf-7edbb1a195d0,[Données non publiées],[Données non publiées],Responsable accueil,
+29d9c759-c02a-429b-b96f-c64bfbac9fba,[Données non publiées],[Données non publiées],Infirmière Libérale,
+29e0a24e-414d-4359-bb6f-2141bf8ac8fe,[Données non publiées],CGO (Comptabilité Gestion Océan) [Données non publiées],Juriste,
+29e24943-9e00-4afc-b761-928c986940ac,[Données non publiées],[Données non publiées],Dirigeante de la société (SASU),
+29e717fa-e4a5-49cd-b043-dad5f4f975c3,[Données non publiées],OT Engenery,Responsable Achats et parc matériel,
+29e8f997-0f49-4357-96cc-76d58f9ce952,[Données non publiées],Néant,Retraité,[Données non publiées]
+29ea6738-f79d-4f92-a0ad-12b8817a1b54,[Données non publiées],Profession libérale,Avocate,
+29ebec07-1a9b-4892-90fc-c4b10cba3549,[Données non publiées],Education nationale,CPE retraité de l'Education nationale,
+29f8cc4d-9e7c-4463-bbf7-ad6c837c9512,[Données non publiées],palais des congrès,directrice [Données non publiées],
+29fa39e0-2f96-43aa-8bda-c2ec99344935,[Données non publiées],HP,Ingénieur - [Données non publiées],
+29fa70cf-5530-40fc-bb29-184a7f9d8a79,[Données non publiées],GEODIS,contrôleur de gestion TAC,
+2a15a967-60e1-4918-a915-d0875c92e24c,[Données non publiées],Evolis,technicienne qualité,contrôle d'imprimante pour carte plastique
+2a2fac73-22f4-4d51-8161-b4a9b4c1ab7b,[Données non publiées],[Données non publiées],Agriculteur,[Données non publiées]
+2a338dfe-d0af-4126-a9d1-7229bc3c7184,[Données non publiées],GERANT,gérant d'une société dans la restauration (brasserie traditionnelle),
+2a37bbd3-955f-4e70-be90-043d3a1432ae,[Données non publiées],NEANT,NEANT,
+2a3c24f4-2268-4441-8cc7-f518c8afef23,[Données non publiées],Néant,Néant,En retraite [Données non publiées]
+2a3c460a-db41-4538-9d04-13786218078e,[Données non publiées],Auto-entrepreneur,Conseil en communication et aux entreprises,
+2a3e69a1-5574-4302-be75-b8b50eabfaa7,[Données non publiées],Lee Hecht Harrison France,"Consultante senior, salariée",
+2a453acb-8eaa-43b3-967b-98f4f8ee9c58,[Données non publiées],Education nationale,Professeur d'anglais,
+2a4bdcfc-6b22-4efa-8c9e-6a138a868917,[Données non publiées],neant,neant,[Données non publiées]
+2a4bf090-ea41-4123-992b-27db77572521,[Données non publiées],Conseil régional d'IDF,élue,
+2a53aa5d-557d-4442-8b2c-5dcb0e8a7bd5,[Données non publiées],SCHNEIDER ELECTRIC,HOTESSE ACCUEIL,[Données non publiées]
+2a5cddd7-87bc-4978-8657-4c66dba40038,[Données non publiées],Hôpital Yves Le Foll,Psychologue,
+2a5e144f-0652-4209-af05-e4a864ea2593,[Données non publiées],FLANDRES OPALE HABITAT,[Données non publiées],
+2a5eda88-3ed0-4a7b-a770-360267311a93,[Données non publiées],Collectivités locales,"Attachée principale (FPT, catégorie A) [Données non publiées]",
+2a5f4a35-cb56-451e-83fe-ce2b1e25602e,[Données non publiées],DIVERS,MUSICIEN,
+2a607f71-d35b-42f7-bec9-4a1c365bb26d,[Données non publiées],Communauté Urbaine du Grand Reims,Directrice de la communication [Données non publiées],
+2a61fec5-5152-496b-a5c5-c710316015ef,[Données non publiées],UBAF (Banque),Cadre [Données non publiées],
+2a631262-23f8-4f39-b341-4b0c249ed9d9,[Données non publiées],Néant,Néant,
+2a6f7d84-e96c-43fe-9fb6-9639ede0d403,[Données non publiées],Néant,Agriculteur-Eleveur retraité,[Données non publiées]
+2a7805c8-f039-48e9-9da8-e636a8583b18,[Données non publiées],[Données non publiées],Architecte,
+2a7c4cfd-b931-472a-abbb-f680a5ad7936,[Données non publiées],Rectorat de Nantes,Enseignant,
+2a7c4cfd-b931-472a-abbb-f680a5ad7936,[Données non publiées],OGEC [Données non publiées],Coordinatrice,
+2a7de5dc-9dd2-477c-abf7-1c0d1edb6a71,[Données non publiées],éducation nationale,professeur d'EPS dans un collège,
+2a7fc6a8-7355-410a-8f43-ffade5774932,[Données non publiées],ABL EMPLOI,cabinet de recrutement,
+2a7fcf1b-7485-47c2-b794-0409240cf5ac,[Données non publiées],Profession Libérale,Notaire,
+2a8e4e70-d8ff-4b0a-b814-ea53f768a046,[Données non publiées],Conseil général,Secrétaire,
+2a951685-9645-4c83-96bb-39063bedb2f0,[Données non publiées],Education Nationale,Directrice d'école,Retraitée
+2a98859c-788e-4a70-a334-8be5d526a5fa,[Données non publiées],EDUCATION NATIONALE,PROFESSEUR,RETRAITEE [Données non publiées]
+2aa1ea5c-35a1-425f-96c5-398f5b7d5479,[Données non publiées],Parlement européen,[Données non publiées],
+2aa42814-8a39-4bd4-af49-e0c43e58d994,[Données non publiées],Notaire associé,[Données non publiées],
+2aa6599c-879e-4cac-9e8b-72e5618a3874,[Données non publiées],Ministère des Finances,Directeur centre informatique [Données non publiées],
+2ab94e5b-dc81-45d8-9f48-9bd575086032,[Données non publiées],Rectorat de Versailles,Professeur [Données non publiées],
+2abc11ee-f174-41a5-8a4a-f68f60d1635d,[Données non publiées],Néant,Néant,
+2acba623-6508-4b7f-af08-1fa7ef7932fa,[Données non publiées],retraité,Cadre France Télécom,[Données non publiées]
+2ad61df4-31b9-47ed-8b5c-d06edf2092a3,[Données non publiées],CH [Données non publiées] + activité liberale,Chirurgien,PH temps partiel
+2ad6585e-5f8d-4045-9b9f-ef59073d7d1f,[Données non publiées],CCI de [Données non publiées],Enseignante vacataire à l'école hôtelière de la CCI,[Données non publiées]
+2adb7647-3fcd-4497-ba53-84dfd9a8a7bb,[Données non publiées],[Données non publiées] [Données non publiées],Vendeuse,
+2ae0247d-ec81-4f34-9ffd-38401271dc0b,[Données non publiées],Aucun,Pas d'activité professionnelle,Gérante de la SCI [Données non publiées]
+2b005619-cb21-4610-aabd-a1736825df90,[Données non publiées],néant,néant,
+2b134bda-554e-4735-ab3e-659d122a1749,[Données non publiées],néant,néant,
+2b1c6ffc-31bf-4950-bbd3-45781945fceb,[Données non publiées],[Données non publiées],Assistante de vie,
+2b26edfb-5c13-4a3f-8f96-81ca0d562f11,[Données non publiées],NEANT,RETRAITE,[Données non publiées]
+2b37d4b6-b0fe-40d2-9e7e-7421a828374c,[Données non publiées],Conseil de l'Europe,Cheffe du service [Données non publiées],
+2b3c23ee-fc52-4f4b-a708-9f1cafc13f64,[Données non publiées],REGION REUNION,FONCTIONNAIRE TERRITORIAL,
+2b400dc4-d939-4600-930e-d1af311b9e57,[Données non publiées],Gifi,Responsable [Données non publiées],
+2b413de5-7385-443b-8f8f-f5808946be9a,[Données non publiées],neant,retraitee,
+2b4ad7ff-8cf4-4d67-ba25-0800ff832f34,[Données non publiées],Ehpad [Données non publiées],Art therapeute,
+2b57f4a8-b251-48f7-aba8-56f8407509d1,[Données non publiées],Google,Membre de l équipe des affaires publiques chez Google France.,
+2b58f55d-461a-43cf-9e72-9deb1cc085ed,[Données non publiées],fonction publique hospitalière,aide soignante [Données non publiées],[Données non publiées]
+2b649b09-cb74-47b6-a67e-d63f4abd0eda,[Données non publiées],SDIS de l'Ardèche,Chef de service [Données non publiées],[Données non publiées]
+2b69cdbd-4f4e-42f2-a94f-c8c00b4184f3,[Données non publiées],[Données non publiées],Infirmière DE,
+2b6ab86a-1cd2-4f85-b74b-7c75fc08d695,[Données non publiées],Erudis formation,conseiller en formation,
+2b6acb50-232c-4a27-ad74-763c87082b5f,[Données non publiées],DRIEAT d Île-de-France,Instructrice [Données non publiées],
+2b6de318-bfd5-421f-8507-6951d2ef4bbe,[Données non publiées],DIVERS,MUSICIEN,
+2b6fcb8c-fe28-429e-9ad0-5eb219107304,[Données non publiées],Banque Rhône Alpes,Employee de banque,
+2b703568-797e-4e23-a68e-fe8b6a2b5b2f,[Données non publiées],Conseil Départemental Gironde,[Données non publiées],
+2b70ef7e-39d4-41ff-9ecf-b351b782bf04,[Données non publiées],neant,neant,[Données non publiées]
+2b84f32a-0f58-4316-bac6-322d6ae43337,[Données non publiées],Ministère de l'Agriculture,Directeur régional [Données non publiées],
+2b916b06-d2ea-4a8a-84d8-0040a35b0649,[Données non publiées],SIVOS [Données non publiées],Directrice,
+2b934219-1f37-4a4e-b341-a775a6a4b415,[Données non publiées],LOXAM,Technico-commercial,
+2b94a49e-ee17-4807-8d34-1c61a954f7d6,[Données non publiées],Gauthier Fils [Données non publiées],[Données non publiées],
+2baab872-4e57-4040-a592-e636a6d0ad9a,[Données non publiées],CAF de Loire Atlantique,Conseillère technique,
+2bab6461-60e8-442f-8fe8-f29922e9da80,[Données non publiées],Ministère de la santé et Ministère de l'enseignement supérieur et de la recherche,[Données non publiées] au CHU de Caen. Praticien hospitalier [Données non publiées],
+2bb4ff32-4342-4f9d-a85d-430674470b9d,[Données non publiées],Education Nationale,Enseignante,
+2bb7d5df-98f5-4e42-ad28-0cbf2445c9e8,[Données non publiées],CEA,Ingénieur chercheur au GANIL,
+2bb7d5df-98f5-4e42-ad28-0cbf2445c9e8,[Données non publiées],Pole formation UIMM Normandie,Professeur vacataire à ENSICAEN- ITII24H de cours par an en école d'ingénieur,
+2bb7d5df-98f5-4e42-ad28-0cbf2445c9e8,[Données non publiées],Association sportive de Tae Kown Do de Bayeux,Trésorière bénévole,
+2bbaf448-92c4-4f53-96bd-efb9b881b3f1,[Données non publiées],Néant,[Données non publiées],
+2bbc3957-ca4f-45ac-b840-8f8db1debd3e,[Données non publiées],FERTÉ PARE BRISE,[Données non publiées],
+2bcfc18f-e8c6-44b8-8493-cfed185029a4,[Données non publiées],Education nationale,Enseignant,
+2bd0261f-0501-4a02-b535-b9e660551b57,[Données non publiées],[Données non publiées],Dessinateur industriel [Données non publiées],
+2bd66925-0e02-4e5f-9953-00c509b8fc0f,[Données non publiées],ELIOR ENTREPRISES,Responsable [Données non publiées],
+2bdcc419-f8a4-4a17-854f-afb4e6bf6d03,[Données non publiées],[Données non publiées],Ingenieur,RETRAITE [Données non publiées]
+2be34c41-e83d-4889-bc9c-335342454a3c,[Données non publiées],[Données non publiées],Agentd'école,ATSEM
+2be6dc55-5321-4a5a-ac8a-fe069ecc6305,[Données non publiées],Habitat audois,Office public HLM de l’Aude [Données non publiées],
+2bf0aae4-6e72-400f-a9d9-9e0644f6ec2f,[Données non publiées],Etablissement,Commerciale,
+2bf8c378-1238-436f-8ac3-1522c53363c4,[Données non publiées],CIAS,adjointe administrative,
+2c0d00ff-d9b6-4d74-992b-2dcec45e2699,[Données non publiées],néant,Retraité,
+2c10e5a3-2ed9-4542-b938-e2bff9788bbc,[Données non publiées],EDUCATION NATIONALE,Professeure des Ecoles,
+2c19ef1b-3740-4a05-b37a-f058cf8bcc29,[Données non publiées],[Données non publiées],architecte,[Données non publiées]
+2c1e8c63-bf7f-4d9a-b3e6-79d4198ad25c,[Données non publiées],SNCF Sécurité sociale cliniques privées et maisons médicales,- Cabinet de médecine générale [Données non publiées],
+2c38e24b-87d1-407f-8172-ed6df185745d,[Données non publiées],De l'Oust à Brocéliande Communauté,[Données non publiées],
+2c3ae83d-ec9b-49fa-91ca-593df677c04b,[Données non publiées],néant,néant,
+2c4533a9-420e-47be-8c44-bd242d36bcbd,[Données non publiées],COLLEGE [Données non publiées],Professeur Certifié,
+2c491b13-0c51-45cd-9e0e-7b2892528d70,[Données non publiées],CCAS ville de Boulogne sur mer,responsable du service [Données non publiées],
+2c4bed61-e84a-4e92-a7ac-723d0db1cdef,[Données non publiées],Groupe CISN,[Données non publiées],[Données non publiées]
+2c535aa5-83bb-4d33-a885-50ca0720c5c9,[Données non publiées],Clermont Auvergne Métropole,[Données non publiées],
+2c5476f1-5e89-40cb-8c2e-6f5755595be3,[Données non publiées],Centre Hospitalier de Brive,Médecin hospitalier,
+2c583351-5e92-4379-a082-7ae9d0452190,[Données non publiées],AFLD Paris,[Données non publiées],Infirmier préleveur
+2c5f03ba-2baf-4ed5-af38-ccdbc1cda1bd,[Données non publiées],Mairie de Cannes,dgs,
+2c625cdc-8680-494b-bcff-fac5c96100e4,[Données non publiées],nom propre,Auto école,
+2c655f9d-76b7-4703-a40d-990de5f4efa4,[Données non publiées],Education nationale,AESH [Données non publiées],
+2c664c06-469c-4772-8bd9-5c08543d35da,[Données non publiées],CNRACL,Retraite,
+2c83f68c-9dff-4201-8258-219087788d98,[Données non publiées],[Données non publiées],cabinet d'orthophonie libéral,
+2c8cba25-e132-424d-add9-73fc27b2c322,[Données non publiées],Néant,Retraité,
+2c91646b-c65b-457b-8fa5-33bb9a31d2eb,[Données non publiées],EDUCATION NATIONALE,PROFESSEUR DES ECOLES,
+2c9e36bd-1173-4df1-9704-e9e6d099520c,[Données non publiées],travailleur indépendant,"prestations dans le domaine culturel : cours de théatre, metteuse en scène et aminatrice culturelle",
+2c9e36bd-1173-4df1-9704-e9e6d099520c,[Données non publiées],Maison de la jeune fille Jane Pannier,Salariée [Données non publiées],
+2cadb59d-55f4-4655-ac86-ec3fdc6d9d09,[Données non publiées],LIBERAL,HUISSIER,
+2cb4ec2c-ae9f-4ac3-bff3-ae4e543b893b,[Données non publiées],Icadémie éditions,formatrice [Données non publiées],
+2cc4d0bc-8aec-4d4e-999e-d6bebfb847ca,[Données non publiées],néant,néant,[Données non publiées]
+2ccf6120-4c4b-4105-8615-de5410cd2bd0,[Données non publiées],[Données non publiées] CONSULTING SAS,Chef d'entreprise salariée,Agence de communication
+2cd4d7dc-0875-4d78-9a39-0099612ddc96,[Données non publiées],Université de Caen Normandie,Maîtresse de conférences,
+2ce19731-a546-4381-966e-616228b9880c,[Données non publiées],Ecole,Enseignante,
+2ce9ae91-1bfa-45ee-acb0-dec3ac730c53,[Données non publiées],neant,retraite,
+2cefd098-52fc-436c-9038-9dfbe14d8cd1,[Données non publiées],Artisan - Individuel en nom propre,Plombier-Chauffagiste,
+2d022f25-9182-4590-ad11-8a12e6f0e0f7,[Données non publiées],aucun,[Données non publiées] sarl maki papier recyclé confection artisanale articles papeteries,
+2d02820c-a477-4f74-be2f-d052f4f4048b,[Données non publiées],Bourse de l'immobilier,Chef d'agence [Données non publiées],
+2d08a7a7-43a5-49a9-b582-01d04073032f,[Données non publiées],La Poste,"Fonctionnaire, chargée de clientèle",
+2d0a3e63-8d11-4f1c-8b0e-acf311b6e9c2,[Données non publiées],cr occitanie puis cd 31,[Données non publiées],[Données non publiées]
+2d0e6f00-f37f-4dcd-8b19-75ce0b9348e4,[Données non publiées],Mairie de Draguignan [Données non publiées],[Données non publiées],
+2d10e553-bce3-4796-a158-977673dae056,[Données non publiées],HLI,CADRE,
+2d114c02-c29d-4892-aa84-ef87c4a0c2bd,[Données non publiées],APHM,[Données non publiées],
+2d1fbce4-47a6-448d-8539-786cc12d378e,[Données non publiées],MAERSK FRANCE,EMPLOYE DE CONSIGNATION,
+2d2294cf-85e1-471b-9cc1-9d13f5f0e9b5,[Données non publiées],CO GERANT,AGRICULTEUR en GAEC,
+2d2e72a0-f9e9-4db6-abc0-b3eea24e7845,[Données non publiées],SARL SD CONSULTING,[Données non publiées] société de conseils.,
+2d33e62f-06bf-4e86-9bc8-758011bfd730,[Données non publiées],néant,[Données non publiées],[Données non publiées]
+2d3e8549-d000-4984-bc02-456563368211,[Données non publiées],INRAE,Technicienne [Données non publiées],
+2d40cf42-2775-47d9-8ade-959cf15ed26b,[Données non publiées],retraite,retraiténeant,
+2d49be19-db92-4c5f-9dc0-ab11d52b4ec1,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+2d49be19-db92-4c5f-9dc0-ab11d52b4ec1,[Données non publiées],Auto entrepreneur,Conseil en relations publiques,[Données non publiées]
+2d4e734e-5523-489f-8934-0293beec76e4,[Données non publiées],néant,néant,Retraitée [Données non publiées]
+2d503399-5270-46ac-9bc8-a3fdde201b28,[Données non publiées],SARL [Données non publiées],Gérant d'une agence immobilière [Données non publiées],
+2d507de5-d312-4bb9-8963-6295b9da974c,[Données non publiées],[Données non publiées],Exploitante agricole,Horticultrice
+2d54b03a-71cf-4683-91ca-2c8f778ecff4,[Données non publiées],néant,néant,[Données non publiées]
+2d5c3314-2d48-4a91-b867-a75bc73c968b,[Données non publiées],De l'Oust à Brocéliande Communauté,[Données non publiées],
+2d61dd8c-14c5-4ec9-b946-b27f026c4312,[Données non publiées],Daimler Trucks,Responsable [Données non publiées],
+2d832a7b-1f94-45ce-84e0-7392c01a4c01,[Données non publiées],Education nationale,Professeur vacataire,
+2da6143c-d100-481c-b4f7-bb6e92e4064f,[Données non publiées],DELPHARM,directeur [Données non publiées],[Données non publiées]
+2da72a89-5af4-4131-8dd8-3967f2ccf47d,[Données non publiées],Groupe LEGENDRE,[Données non publiées],
+2dab825d-5220-4cf0-a40b-9088fe33c756,[Données non publiées],[Données non publiées],PRESIDENT DU CENTRE SCIENTIFIQUE [Données non publiées],
+2db5adca-c2b2-4981-a6a9-e7e77fc71d71,[Données non publiées],Le Livec,Coiffeuse,
+2db686e6-ef9f-46b7-8778-f970c921f307,[Données non publiées],Assemblée de la Polynésie Française,Représentant,
+2db686e6-ef9f-46b7-8778-f970c921f307,[Données non publiées],Sénat,Sénatrice,
+2dbc93bb-d3c3-4e52-9553-4d5338cd98ae,[Données non publiées],RSM,CHEF DE MISSION,
+2dc182b0-b5e3-47fa-8441-58e5ec5b3594,[Données non publiées],Education nationale,enseignant [Données non publiées],
+2dc182b0-b5e3-47fa-8441-58e5ec5b3594,[Données non publiées],Mairie d'Unieux,[Données non publiées],
+2dc182b0-b5e3-47fa-8441-58e5ec5b3594,[Données non publiées],Saint Etienne Métropole,Conseiller communautaire,
+2dc287a5-c3c5-443f-be8b-b7138505a069,[Données non publiées],[Données non publiées] [Données non publiées] [Données non publiées],Dr Vétérinaire,RAS
+2dc93a46-0e03-4709-9332-9f9ac554dd10,[Données non publiées],Office du Tourisme des rives de l'Aa,[Données non publiées],
+2dda69b9-ff36-4a24-a198-06d90352165d,[Données non publiées],travailleur indépendant,"prestations dans le domaine culturel : cours de théatre, metteuse en scène et aminatrice culturelle",
+2dda69b9-ff36-4a24-a198-06d90352165d,[Données non publiées],Maison de la jeune fille Jane Pannier,Salariée [Données non publiées],
+2ddf23e6-5fef-4870-ad21-eb7973ebcb12,[Données non publiées],Greta de l'Aisne,Formateur en formation continue,
+2de20291-65bf-43c9-9e83-320c2f3dac22,[Données non publiées],profession libérale,Infirmière libérale,[Données non publiées] [Données non publiées] activité d'hypnothérapeute en auto-entreprise [Données non publiées]
+2de50ef9-32a7-4345-bc5c-04aefd0d2615,[Données non publiées],LCL ANTILLES GUYANE,EMPLOYEE DE BANQUE CHARGE DE LA CLIENTELE DES PROFESSIONNELS,
+2de7d0f2-8dbb-44fe-9360-4ecf7200f074,[Données non publiées],RETRAITE,NEANT,
+2df4a993-3bc7-458b-9e5f-71b4f16f3e69,[Données non publiées],Voisins et soins,Accompagnement à domicile des personnes en fin de vie.,[Données non publiées]
+2e046ca4-b015-4d9a-9ecd-cbac3bb13fb2,[Données non publiées],Campus France,Chargée de mission auprès de la directrice de Campus France,[Données non publiées]
+2e0ca554-841c-4e2e-a2e0-a5cf33b0e26e,[Données non publiées],palais des congrès,directrice [Données non publiées],
+2e105733-c9fb-4f2a-a947-f3ced029947d,[Données non publiées],SA GERFLOR,Directeur commercial,
+2e14bbbd-e26f-4ed1-8e06-676eff0254a4,[Données non publiées],Plantations Weisen,Secrétaire,[Données non publiées]
+2e14bbbd-e26f-4ed1-8e06-676eff0254a4,[Données non publiées],EARL DE BELLEFONTAINE,Secrétaire,[Données non publiées]
+2e14cf86-e6bd-4bf3-8e70-2def5caca996,[Données non publiées],Conseil Départemental du Val d'Oise,Conseillère en gérontologie [Données non publiées],
+2e1813be-7d2a-4987-9fb5-0d4275a52ac0,[Données non publiées],A COMM,Cabinet d'Expertise comptable,
+2e242aeb-3616-4c8f-853b-6e586c55929d,[Données non publiées],Bureau VERITAS,[Données non publiées],En retraite [Données non publiées]
+2e2bbec2-221a-43fb-8b85-5396aafb5b0d,[Données non publiées],Education Nationale,Professeur des écoles [Données non publiées],
+2e2ce8eb-8bb1-4616-a253-f498fd3a7034,[Données non publiées],SARL [Données non publiées],GERANTE,
+2e2d8d10-c351-4c5e-8504-f9f60f0b6336,[Données non publiées],La Poste,salarié,
+2e3c6998-a764-40f3-ab65-30e9c8204e2d,[Données non publiées],Crédit Agricole Centre France,salariée,
+2e3c798d-2703-480c-b0cb-90895050a24e,[Données non publiées],[Données non publiées],Architecte Freelance,
+2e43a937-9512-463c-a114-919b5d4138d8,[Données non publiées],Profession libérale,Masseur-Kinésithérapeute,
+2e4da3cf-fb74-4041-a9d0-e58748267fc2,[Données non publiées],SASU,Commerce de vetements pour hommes,Présidente d'une SAS Unilaterale
+2e5aa451-bfef-48a7-ac9d-759ee38587cc,[Données non publiées],entreprise individuelle,avocate,
+2e5aa451-bfef-48a7-ac9d-759ee38587cc,[Données non publiées],entreprise individuelle,avocate,
+2e5f0d00-8f4f-4836-bc57-bc834677f04c,[Données non publiées],Education nationale,enseignante en collège,
+2e682af1-cc14-45a6-9960-25a01ac53108,[Données non publiées],WILL&CIE,Evénementiel professionnel Accompagnement en stratégie de communication Formation en relations publiques,cessation d'activité au 30 juin 2021/ [Données non publiées]
+2e682af1-cc14-45a6-9960-25a01ac53108,[Données non publiées],Dialogues et Solutions,salariée depuis le 1er avril 2021,
+2e6e551c-2151-42cb-b96e-bd24f7135de7,[Données non publiées],EDT-ENGIE,"Electricité de Tahiti, Chef d'exploitation [Données non publiées]",[Données non publiées]
+2e6e551c-2151-42cb-b96e-bd24f7135de7,[Données non publiées],Armée [Données non publiées],Retraité [Données non publiées],[Données non publiées]
+2e719183-52e6-48d0-801a-6c891606835a,[Données non publiées],Alteia,Chef de projet logiciel [Données non publiées],[Données non publiées]
+2e7ab254-3d5d-49d0-a28d-f3c2cc712450,[Données non publiées],Néant,Néant,
+2e7f2e34-9d3a-4a2d-ae89-93ada3ce8abd,[Données non publiées],[Données non publiées],Directeur de maison de retraite,
+2e7f2e34-9d3a-4a2d-ae89-93ada3ce8abd,[Données non publiées],[Données non publiées],Gérant,
+2e7fcd04-3be2-4b94-9efd-9abdc8ebddec,[Données non publiées],Département 13,Fonctionnaire en détachement.,[Données non publiées]
+2e8d70d7-0996-455f-a63b-1c9939caab4b,[Données non publiées],MMA IARD,Responsable Conseils juridiques. [Données non publiées],
+2e8eb3d0-f25f-414f-9717-fcddeb5a5a5a,[Données non publiées],Ville de Hautmont,Directrice Générale des Services,[Données non publiées]
+2e94d60d-91b4-4ef6-ae1d-70a0080abb3a,[Données non publiées],PHARMACIE [Données non publiées],PHARMACIENNE,aucun changement à la date du 23 octobre 2020
+2e94f6cb-ae22-4d64-beb4-87902b38736c,[Données non publiées],courtier,assurance,[Données non publiées]
+2e963e44-b234-478f-8b50-a4d200f64394,[Données non publiées],[Données non publiées],Auto entrepreneur : prestations d'animation de réseau,
+2eaa1aa0-85d3-4694-a2d1-d421f63621f0,[Données non publiées],[Données non publiées],Entreprise individuelle d'expertise naturaliste,
+2ebca398-9e67-4900-a921-27e005ec9fbe,[Données non publiées],APHP [Données non publiées],médecin,
+2ec4b092-b2ba-4bd4-8942-e98142c36352,[Données non publiées],Retraitée Renault,néant,
+2ec7c973-44a3-43f2-8c3c-fd7302b9c5a8,[Données non publiées],Mairie d'Oloron Sainte-Maire,Chargé de projet [Données non publiées],
+2ec825e5-e1e4-4427-a0ee-f84e18da75a3,[Données non publiées],province nord,collaboratrice,
+2ed3161a-b509-476a-b951-7893d086e9a2,[Données non publiées],cabinet dentraire [Données non publiées],Secrétaire médicale,[Données non publiées]
+2ef9459d-b7d1-46af-a7fe-b82854dfb7ed,[Données non publiées],Université du Mans,Secrétaire administratif [Données non publiées],
+2f021b40-8885-4857-b70e-a7eaf108c1cd,[Données non publiées],néant,néant,[Données non publiées]
+2f1d3f76-a45b-41a4-90d2-a854aa444e51,[Données non publiées],Ministère de l'Education Nationale et de la Jeunesse,Inspecteur [Données non publiées],
+2f2520e6-e1d4-4989-836b-3ece05843b5f,[Données non publiées],AM Conseil,Assistante,
+2f31c41d-665a-44fe-9ef3-0c347254d625,[Données non publiées],Entreprise individuelle,Infirmière Diplômée d'Etat Libérale,
+2f360b6c-957f-4b91-a9c4-5625a880bed3,[Données non publiées],[Données non publiées],[Données non publiées],En retraite [Données non publiées]
+2f3bd18f-bf48-40b3-a443-1e65c7b4396e,[Données non publiées],Ministère de l'Agriculture,Enseignante en lycée professionnel,
+2f3bd18f-bf48-40b3-a443-1e65c7b4396e,[Données non publiées],AGECE [Données non publiées],Responsable encadrement pédagogique,
+2f3d31e3-ccea-4cd2-a5b0-fd1f1619e095,[Données non publiées],Ministère des finances,Inspectrice des finances publiques,retraitée [Données non publiées]
+2f3fdf10-45cc-430d-835f-878bfbd10a72,[Données non publiées],SOFRECOM,Consultant [Données non publiées],
+2f47fecf-5adf-443a-b56e-7eb60aa4944d,[Données non publiées],Neant,Neant,
+2f57560b-4f84-49f2-9ef5-b15c96c506f3,[Données non publiées],METROPOLE AIX MARSEILLE PROVENCE,[Données non publiées],
+2f5ab48a-89ae-49f6-a493-59933d6e0da5,[Données non publiées],Ministère de l'intérieur,Gendarme,
+2f6317d4-e6a0-4d10-9a84-c5eee6ba3d59,[Données non publiées],Etat: DIR [Données non publiées],Contrôleur principal de travaux,
+2f7ae799-1b88-4276-88ce-f8433f6046be,[Données non publiées],Natixis,[Données non publiées],[Données non publiées]
+2fa03215-0c9a-41a3-9d54-0ece952303df,[Données non publiées],Sans employeur,Gestion de meublé de tourisme,
+2fa0f3b9-9328-49b5-aae2-1a87b85160b1,[Données non publiées],retraite,retraite,
+2fa1d8f1-3578-4db7-8e72-0a9c88ef2846,[Données non publiées],GENDARMERIE,Gendarme,
+2fa31d34-ec1e-46ef-86ad-e44a7bbf6ecd,[Données non publiées],CAMG,[Données non publiées],
+2fa91192-6e37-49ea-9bf5-b0ce94df87d5,[Données non publiées],cabinet dentraire [Données non publiées],Secrétaire médicale,[Données non publiées]
+2fc274aa-b047-4d1c-aadd-461a3ff71194,[Données non publiées],Ville du Plessis-Robinson,Chirurgien Dentiste [Données non publiées],"Conseillère régionale d'Île-de-France membre du groupe ""Ile-de-France Rassemblée"" [Données non publiées]"
+2fc67a8a-dabc-455e-bd2c-709cf19753c7,[Données non publiées],Nouvelle Région Aquitaine,[Données non publiées],
+2fc78f27-072e-4952-a583-4d3182a344fe,[Données non publiées],Centre des Monuments Nationaux,Directrice des Ressources humaines,
+2fd99aac-780c-497b-a494-cdefa5d51eec,[Données non publiées],Conseil départemental des Deux-Sèvres,[Données non publiées],
+2fe031a6-489b-41ac-a99b-cca98a72be00,[Données non publiées],Centre Gestion fonction publique,[Données non publiées],
+2fe09579-b426-454c-bf7a-ac69d788e061,[Données non publiées],Néant,Néant,
+2fe151b5-078a-4418-b9d5-a310ab89c597,[Données non publiées],RTE,[Données non publiées],
+2fe54e6a-12eb-4253-90b9-26759a686474,[Données non publiées],SIAVED,[Données non publiées],
+2fe8f35b-e26e-4c57-bb34-6217ba4ca6c7,[Données non publiées],NEANT,NEANT,[Données non publiées]
+2ff091a4-2f46-47e1-823d-a38cac292dc8,[Données non publiées],[Données non publiées],Directrice des Ressources Humaines groupe,
+2ffedac6-33cf-46ff-9eb2-107c2fb9dcfc,[Données non publiées],arc france,Responsable [Données non publiées],
+30048dab-8859-46aa-aa97-7c58dd2e5760,[Données non publiées],Néant,Néant,
+30051d58-175f-44ba-830f-81d6d8de2b3a,[Données non publiées],Sécurité sociale,agente de sécurité sociale,[Données non publiées]
+3017e3ec-a926-4aaa-8113-2b8258a0a35d,[Données non publiées],fromagerie [Données non publiées],commerciale,
+30197815-b8d7-4f35-9d5a-255c13ab9891,[Données non publiées],Nestlé France,Technicien méthode,
+30299f0a-bdb0-4ea2-87b4-0896bc443d18,[Données non publiées],Groupement Hospitalier [Données non publiées],Aide-soignante,
+302aeac8-5b4d-4f89-87a1-5f9527cca5e0,[Données non publiées],CNFPT [Données non publiées],Formatrice,
+302aeac8-5b4d-4f89-87a1-5f9527cca5e0,[Données non publiées],Institut d'2tude Politiques [Données non publiées],Formatrice,
+302b0716-609c-43b8-8a4d-6d322d8e900e,[Données non publiées],ghbs centre hospitalier,Infirmière,[Données non publiées]
+30328260-e607-439f-930c-f9f562729b40,[Données non publiées],VILLE DE MAMOUDZOU,RESPONSABLE MEDIATHEQUE,
+30390c89-2b91-4230-ac92-26af0946e434,[Données non publiées],Mairie de dijon,[Données non publiées],
+304b8fbe-657c-4139-b20a-95d2b95df332,[Données non publiées],GEIQ EPE [Données non publiées],Assistante R H,
+304d2e13-3f44-4ba4-a539-858d71586fa6,[Données non publiées],Activité libérale (BNC),Psychothérapeute,
+304e6846-2fd5-4b36-b4e7-a2a405d742a4,[Données non publiées],groupama,cadre,
+30512580-a2e7-4c48-9c90-631ce57a54c9,[Données non publiées],autoentrepreneur,psychologue,
+3053228b-6b58-4aee-b087-d1afddbff4ee,[Données non publiées],Communauté d'agglomération bergeracoise,[Données non publiées],
+3058047c-0c0d-45ca-96e9-9fdc9c8691e5,[Données non publiées],LA POSTE,Facteur,
+305a6d66-a3c1-4f4f-b74f-1d840b8b395f,[Données non publiées],[Données non publiées],Directeur Technique adjoint,
+305aa4f3-c4f1-4dbc-9e17-ba1319e6d88d,[Données non publiées],Éducation nationale,RETRAITEE,
+3061f661-8db4-484a-ab2b-a7c39456dd1c,[Données non publiées],in-Store Media,Directeur Général,
+307835ff-78c4-4586-948a-0b11661eccf8,[Données non publiées],néant,néant,
+3082a788-709d-4e1a-8bca-75d0cc5a79c7,[Données non publiées],néant,exploitante agricole,[Données non publiées]
+30a29640-648a-44cd-b8f8-50d8a00220eb,[Données non publiées],néant,néant,Retraitée
+30af3706-81f5-4141-bcf6-d51216105313,[Données non publiées],auto-entrepreneur,Conseil en marketingFormation,
+30b8e0ad-c376-4b58-8c0e-71bd84093d7a,[Données non publiées],SCP INFIRMIERS,INFIRMIERE LIBERALE,
+30bb338c-abd8-4c84-af3a-2104ac1a0828,[Données non publiées],Département,Adjointe technique territoriale,[Données non publiées]
+30bcca0c-d92b-401f-a836-8fa4b7ab6b3f,[Données non publiées],France Télévision,Journaliste,
+30c3245b-de40-47ac-a653-054b6054f71e,[Données non publiées],[Données non publiées],CONJOINT COLLABORATEUR,[Données non publiées]
+30c77f74-1f91-4ca1-b368-76f4fe399167,[Données non publiées],Retraitée,[Données non publiées],
+30ccc5e7-2bdc-4ee9-9f8d-016041ecc1c4,[Données non publiées],[Données non publiées] A la retraite depuis le 1er août 2023.,[Données non publiées],[Données non publiées]
+30d455dc-02a3-4b15-8924-601eea848bad,[Données non publiées],MISSION LOCALE REGIONALE DE GUYANE,[Données non publiées],
+30e85cc4-1c48-4b46-9e82-507bec5e68d0,[Données non publiées],Profession libérale,Avocate,
+30f900b4-53a8-4534-a6db-94ce6f5cc159,[Données non publiées],Chambre de Commerce et d'Industrie des Deux-Sèvres,[Données non publiées],
+30fe42d1-16e2-41d8-9986-43217c9cefa5,[Données non publiées],Des-Ca EURL,[Données non publiées],
+30fe42d1-16e2-41d8-9986-43217c9cefa5,[Données non publiées],Région Réunion,Fonctionnaire Territorial / Agent Technique,
+310742af-c444-4828-a0a5-3b29ef46fa05,[Données non publiées],Education Nationale,Secrétaire,Retraitée [Données non publiées]
+310dd5cf-a12e-4329-b937-255e0dedbb2c,[Données non publiées],Mairie de Clermont-Ferrand,[Données non publiées],
+310e37d6-1719-4fb1-b1e3-2d2b747a11d4,[Données non publiées],néant,néant,
+31108f76-7f0d-43d0-bc6b-a9ba06f48c4d,[Données non publiées],FODENO [Données non publiées],directrice,
+312a7804-659b-45e5-acf6-4d7e301bd630,[Données non publiées],néant,néant,
+312d9b1c-7b95-4863-ba01-fea378a7384f,[Données non publiées],[Données non publiées],emploi familial,
+312d9b1c-7b95-4863-ba01-fea378a7384f,[Données non publiées],[Données non publiées],emploi familial,
+312d9b1c-7b95-4863-ba01-fea378a7384f,[Données non publiées],[Données non publiées],emploi familial,
+312d9b1c-7b95-4863-ba01-fea378a7384f,[Données non publiées],[Données non publiées],emploi familial,
+31375c72-1be0-40fd-8314-d4f5000b7265,[Données non publiées],Néant,Néant,
+31384903-96f2-40bd-a242-a5ec050ffbe1,[Données non publiées],Initiative Terres d'Azur,Directrice.,
+3138a534-7cfb-4985-b670-bcc544f33229,[Données non publiées],Retraitée,Retraitée,
+3142d416-f962-4fca-ab3c-db72e099ac02,[Données non publiées],CAFPI,COURTIER EN PRET IMMOBILIER,
+31495383-4535-4c60-a5ce-e768586944d2,[Données non publiées],[Données non publiées],Formatrice,
+31495383-4535-4c60-a5ce-e768586944d2,[Données non publiées],Institut d'2tude Politiques [Données non publiées],Formatrice,
+314d1dad-c599-432a-9341-42f02a00e82d,[Données non publiées],divers,assistante maternelle,
+314e5d1f-5285-4b7c-85b5-468756c46a85,[Données non publiées],[Données non publiées],[Données non publiées] Commerce de détail alimentaire sur éventaires et marchés,[Données non publiées]
+314e5d1f-5285-4b7c-85b5-468756c46a85,[Données non publiées],[Données non publiées],[Données non publiées] Aquaculture en mer [Données non publiées],[Données non publiées]
+31514d25-9e4e-475b-b283-d3a3be7a9e24,[Données non publiées],[Données non publiées],chirurgien [Données non publiées],
+3151507c-0e59-43b5-98bc-65275c1cb6ac,[Données non publiées],Cité internationale universitaire de Paris,[Données non publiées],
+3153ed50-1b6f-4732-be09-8d8ddbae949b,[Données non publiées],Communauté de Communes ACVCVI,[Données non publiées],[Données non publiées]
+315d1677-3e09-4c04-b06c-dd25288076de,[Données non publiées],VICAT BETONS,[Données non publiées],
+315d5f8a-e4ea-463f-a2f2-8ecfba176ff5,[Données non publiées],LINKT,Développeur informatique,[Données non publiées]
+315e45b0-a550-488b-a414-2f12d439c19d,[Données non publiées],Ministère de l'Education nationale,Professeure des écoles,
+3161d786-13ba-47e7-9f48-9716770fc1b6,[Données non publiées],Ville [Données non publiées],assistante maternelle en crèche [Données non publiées],[Données non publiées]
+316949d5-f36e-4720-b814-3ee2063c7068,[Données non publiées],neant,retraité,
+3178a124-8c32-485f-b6f3-e06bfddcb22f,[Données non publiées],Profession libérale,Infirmière,
+317e14b4-725f-40bd-a560-c2770b96d9e8,[Données non publiées],ORSADE,Co-gérant associé de la société ORSADE,
+317e14b4-725f-40bd-a560-c2770b96d9e8,[Données non publiées],Mairie de Saint-Maur-des-Fossés,Maire,
+31817d64-8c2a-4abc-9960-c91eef5d5cd3,[Données non publiées],Néant,Néant,
+3182ad16-30f4-4d4f-9d53-37053160e173,[Données non publiées],RETRAITEE,RETRAITEE DE L'EDUCATION NATIONALE,[Données non publiées]
+3187dfad-6fbb-4078-8cdf-260c72734f30,[Données non publiées],[Données non publiées],Société d'Economie mixte,Emploi d'assistante [Données non publiées]
+318aff41-93b1-4820-8e25-c6666ae62e54,[Données non publiées],Education national,Professeur,
+318c4370-169f-4e52-9c86-cf9532ae4a7d,[Données non publiées],SARL MELAND,RESTAURANT MC DONALD RESTAURATION RAPIDE,[Données non publiées]
+3197f90d-186b-4268-8d72-8a3086d779cf,[Données non publiées],ACOLEA,[Données non publiées],
+31ab391a-0969-4381-8bf1-79db9fd42c90,[Données non publiées],MC CAIN,CONTROLEUR DE POMMES DE TERRE,
+31ac111d-91f5-42f3-a743-c8e38d756a41,[Données non publiées],LIBERAL,MEDECIN GENERALISTE,
+31b0ad00-6a12-4fb9-b5f9-b91fe4381a19,[Données non publiées],retraité,retraité fonction territoriale,
+31b8ac15-0ce9-43b4-a594-dd16201a31a6,[Données non publiées],SOLARINOX,COMMERCIAL,
+31bed273-b9ec-4bcb-8746-037d27509361,[Données non publiées],lui même,journaliste Président et directeur du journal Le petit mag Lens Liévin exploitant agricole [Données non publiées],[Données non publiées]
+31cf615a-0ce3-4dc0-9b17-b4caaa4df8df,[Données non publiées],ETABLISSEMENT FRANCAIS DU SANG,LOGISTIQUE,[Données non publiées]
+31d2faf5-ce26-4b9e-b4d8-36e8893aa1aa,[Données non publiées],ETAT,PROF DE SVT,
+31d5765a-c4bc-4a5e-b1b2-0c74b70c7857,[Données non publiées],[Données non publiées],Agriculteur,
+31dc2226-8bb4-4b20-a563-baa4d8978563,[Données non publiées],SYADEN,CONSEILLER ENR,
+31e1e764-3717-401e-b303-b76fcfd8d97b,[Données non publiées],Mairie de l'hay les roses,[Données non publiées],
+31ec595c-c2fe-41ab-bbac-840a9f81b299,[Données non publiées],ENGIE,cadre développement clientèle,
+31ef32da-713b-48bb-a01b-3a03fc3f9919,[Données non publiées],Avocate/ Centre de Formation,AvocateEnseignante,
+31f14cd3-8c42-490b-af73-66c0970f56c5,[Données non publiées],néant,néant,
+320264a1-e3a4-4d74-a531-3533ff76b007,[Données non publiées],Chef d'entreprise,Dataanalyste,
+320a99db-d966-40fa-848c-675eb5b24b2e,[Données non publiées],assemblée nationale et sénat,collaboratrice parlementaire,
+320c97de-2ff4-4012-9136-8432756388b9,[Données non publiées],néant,néant,
+3215e033-b97b-4d2a-b8be-f13e7aa0d4d9,[Données non publiées],[Données non publiées],[Données non publiées],Retraité [Données non publiées]
+3217e12c-95ef-4a40-9d0a-71b962980a3a,[Données non publiées],NEANT,NEANT,
+32190e29-e424-4353-8b49-084d6a6e8f03,[Données non publiées],CHU de nantes,[Données non publiées],
+32236e5e-3f43-4200-9daa-c77414bdf553,[Données non publiées],AUCUN,AUCUNE,
+3228277e-db6e-4d6f-a308-6349445cf205,[Données non publiées],Société [Données non publiées],Responsable magasin prêt à porter [Données non publiées],
+322a15a5-e5a8-4049-9ba0-b22724f0c459,[Données non publiées],SO SAVEURS,[Données non publiées],
+3243906d-3b60-483d-a4a7-2f02b34cffc5,[Données non publiées],néant,néant,
+3245e90f-23a6-4025-b956-dd06cb7aef0d,[Données non publiées],retraitée,retraitée,
+32467731-caa0-4c48-b2cf-331ff86e8133,[Données non publiées],SELARL PHILIPPE CLERC,JURISTE,[Données non publiées]
+324b28b8-1d74-404b-8f2c-96db396520ed,[Données non publiées],BMI Group,Directeur Maintenance - Cadre,
+324b5b46-09b7-45e6-9b6a-6e9ee7350a24,[Données non publiées],Education Nationale,Gestionnaire Comptable du Lycée [Données non publiées],[Données non publiées]
+324df540-73fd-4a45-bcf0-0db4ee3a2ee6,[Données non publiées],Fountaine Pajot,[Données non publiées],
+324e5a76-eb4c-4aaa-bbe2-c322c8371016,[Données non publiées],abbvie,Visiteuse médicale,[Données non publiées]
+3250c07d-0975-42aa-82df-d4561d950ab1,[Données non publiées],NEANT,[Données non publiées],[Données non publiées]
+32542dba-43d6-42fc-baa9-388d530f2c10,[Données non publiées],SANS PROFESSION,NEANT,[Données non publiées]
+325892c7-5e25-41bb-977c-070e29968735,[Données non publiées],Conjointe collaboratrice d'exploitation agricole,[Données non publiées],
+325bfebb-b9b8-40bb-afe0-acf380a40c57,[Données non publiées],EDF [Données non publiées],RESPONSABLE D EQUIPE,
+32607d8b-c89f-47d3-95a6-2184ed806a86,[Données non publiées],Theis Avocats,Avocat,
+32728728-0630-4577-9d51-1f0260cda5e2,[Données non publiées],Education Nationale,Professeur retraitée,
+327533d5-ddfe-48a8-bdcb-54bcf322e503,[Données non publiées],Retraitée,[Données non publiées],
+3285444d-1394-4083-90a8-86b674f1ba0a,[Données non publiées],BANQUE POPULAIRE,CHARGE D'ETUDE,
+328e697a-b3b1-41c2-9586-726513bd6dca,[Données non publiées],irsn,chimiste,
+3290b4ca-4c3c-44e7-8b24-776a00c7ae20,[Données non publiées],INSEE,[Données non publiées],
+329635cc-fde1-4dc7-9562-37ccd8a74f46,[Données non publiées],AP-HM,PUPH radio-pédiatrie [Données non publiées],
+3296c037-f583-47a2-a6af-ec23185ba484,[Données non publiées],Hôpital de [Données non publiées],Pharmacien des hôpitaux,Salariée de l'hôpital
+329f83f5-dfad-4edd-ac39-9e5892ec6e22,[Données non publiées],bioMérieux,[Données non publiées] Cadre [Données non publiées],
+32a4d250-7d2b-4168-a434-5c17913e6493,[Données non publiées],SAS [Données non publiées],[Données non publiées],
+32b2c6a6-ef0c-4167-b808-1e5f7c88314f,[Données non publiées],EDUCATION NATIONALE,Professeure des écoles,
+32cdd9ec-146b-4b60-8013-022c110042c2,[Données non publiées],[Données non publiées],Directrice du Service des Transports,[Données non publiées] Des mesures préconisées [Données non publiées] avaient été prises pour éviter une situation de conflit d'intérêt entre l'activité professionnelle [Données non publiées] et mon mandat de Président de l'agglomération. Ces mesures ont été reproduites pour Vienne Condrieu Agglomération
+32dac745-6a18-4ea3-a965-9c4321dc4c1b,[Données non publiées],air france,cadre,
+32e4e929-d7e5-4eec-99ce-0b383162c7eb,[Données non publiées],Néant,Retraitée de l'Education Nationale,
+32ece592-00dd-4990-ab91-5ae084092e73,[Données non publiées],Tennis Club Dijonnais,Responsable [Données non publiées],
+32ece592-00dd-4990-ab91-5ae084092e73,[Données non publiées],micro entreprise,prestation d'enseignement de tennis,
+32ecfd5c-1d77-4c51-9667-7bf09925a5d4,[Données non publiées],Inspection académique,Enseignante,
+32f31e1d-6f50-4260-83f1-750d4bda85dd,[Données non publiées],Retraité,NEANT,
+32f3caf2-11a7-4aba-93dc-65fc3fee9371,[Données non publiées],Elu de la Ville de Marseille,[Données non publiées],
+330379d8-1d5b-4350-b41c-ec59c068eea9,[Données non publiées],neant,neant,[Données non publiées]
+33108801-c430-4f63-995b-3386f93575f9,[Données non publiées],néant,néant,
+331dc4db-88c7-4b4c-ac8d-46bfac692a05,[Données non publiées],néant,retraitee,[Données non publiées]
+3327ba33-be69-4ec5-8577-65a82cb3159d,[Données non publiées],Maison de Santé [Données non publiées],Assistance Médicale,
+3327ba33-be69-4ec5-8577-65a82cb3159d,[Données non publiées],GERANTE,[Données non publiées] entreprise individuelle de coaching,
+332acc13-3469-4948-8f70-ada9501be85d,[Données non publiées],[Données non publiées],[Données non publiées],Associé gérant
+3330b43a-b4a2-4682-825a-7e44db3b096e,[Données non publiées],retraite,retraité neant,
+3330b43a-b4a2-4682-825a-7e44db3b096e,[Données non publiées],néant,néant,[Données non publiées]
+333f59a1-e1ce-4049-ac37-e7fe622e580f,[Données non publiées],Résidence [Données non publiées],Directrice depuis 2003,
+33404103-1910-4838-b1a8-1be8bc8f3298,[Données non publiées],SCEA [Données non publiées],Exploitante agricole,
+33475210-2718-4c7f-aff0-519f8a04f64e,[Données non publiées],Ehpad [Données non publiées],Art therapeute,
+3353cb22-5c34-4e7b-aef7-1884ebb7fd0b,[Données non publiées],Néant,Néant,
+3359c428-e98c-4758-9b68-04102ba1b300,[Données non publiées],Côte d'Azur Habitat,Cadre,[Données non publiées]
+336862ba-4dca-42fe-ab97-801505ae52ae,[Données non publiées],mairie [Données non publiées],DGA,
+336c0e13-c183-4933-a61a-d7ef4d479a6f,[Données non publiées],VNF,Technicien,
+336e5bc6-07a7-49e6-b4de-907633147d90,[Données non publiées],[Données non publiées],Dr Vétérinaire,RAS
+33795464-f227-4dff-a0ce-6146b524d8c2,[Données non publiées],Mairie de Chanceaux-sur-Choisille,Directrice [Données non publiées],
+337a3e9e-6e20-4eb3-8cb8-225baf868589,[Données non publiées],ENEDIS,Responsable d'équipe,
+33913226-89d8-497d-9768-b033eec06aaa,[Données non publiées],[Données non publiées],CLERC DE NOTAIRE,
+339175c2-e8f0-4568-9bc8-9dfd13710261,[Données non publiées],Education Nationale,Professeur des écoles,
+3391b20f-795f-45e1-b70d-822abc6a7675,[Données non publiées],Mairie de NIORT [Données non publiées],Assistante de Direction,
+3393089a-d5fd-4fce-acb3-23337e24ffb3,[Données non publiées],Nantes Métropole,[Données non publiées],
+33a4894a-7dc0-47b1-a56c-c2b66e88114b,[Données non publiées],CENTRE HOSPITALIER DE SAINT BRIEUC,ATTACHEE D'ADMINISTRATION HOSPITALIERECONTRACTUEL,
+33a65880-975b-4553-baf8-d717ff76d94b,[Données non publiées],villeguingamp,[Données non publiées],
+33b2fa3e-913e-45a3-a2eb-80eb5122ffdf,[Données non publiées],Ministère de l'Education Nationale,Enseignant,
+33b5eb2e-7f0a-4b5d-96ad-32440867893a,[Données non publiées],retraitée,Néant,Gérante [Données non publiées] SARLE DEWEZ [Données non publiées] [Données non publiées]
+33ce55a2-433d-4a09-a2fb-5fba581a7eae,[Données non publiées],Néant,Néant,
+33e493b1-0c52-46e7-8cc7-b63a197b0ffb,[Données non publiées],LUI MEME,CONSULTANT INDEPENDANT,ACTIVITE DE CONSEIL AUX ENTREPRISES SUR LE MARCHE ALGERIEN
+33eb3ab5-bd05-409a-ac1f-2d99502374f5,[Données non publiées],Communauté de commune Rhôny-Vistre-Vidourle,Agent territorial contractuel [Données non publiées],
+33ec742f-4898-4eea-b0bd-f690e1015e35,[Données non publiées],[Données non publiées],[Données non publiées] Commerce de détail alimentaire sur éventaires et marchés,[Données non publiées]
+33ec742f-4898-4eea-b0bd-f690e1015e35,[Données non publiées],[Données non publiées],[Données non publiées] Aquaculture en mer [Données non publiées],[Données non publiées]
+33fd4c09-7ab1-4156-923d-6bbe895cbff8,[Données non publiées],Wivoo,Consultant senior,
+340fe982-6957-4bbc-afab-7320af7bbb2e,[Données non publiées],Néant,Néant,
+341d7383-5e70-41e6-a590-b65294b60894,[Données non publiées],néant,néant,
+34270320-1a40-43c3-af27-a78e5da98292,[Données non publiées],Education nationale,Professeur des écoles,
+3429bb40-7d0c-4aaa-9e3b-dfd8f60e0bfa,[Données non publiées],REGION REUNION,FONCTIONNAIRE TERRITORIAL,
+342c9cb8-790b-4c58-a156-150da8fd3713,[Données non publiées],Néant,Néant,[Données non publiées] retraite [Données non publiées]
+343c61ac-bc3d-4fcb-89ae-b35e29486f9d,[Données non publiées],aucun,auto entrepreneur en reconversion professionnelle,
+343cb19e-1425-4778-a7f1-0d00f9bd6b26,[Données non publiées],EURL Transport Genest,Gérant,
+343e3970-35f9-4cac-bb84-9917e5306f4e,[Données non publiées],Sanisitt [Données non publiées],Responsable d'agence,
+3454f3e4-affe-4b46-acfb-09b26c473bb3,[Données non publiées],DIVERS,MUSICIEN,
+3456c3d2-bb36-49cf-b9e1-95e8f7ef2a00,[Données non publiées],CARSAT [Données non publiées],[Données non publiées],
+346a1698-932d-4470-9354-beedbb59c2d8,[Données non publiées],Association Francaise des Pôles de Compétitivité (AFPC),Déléguée générale,
+347d32c1-7711-4b58-b7bf-b6713451215a,[Données non publiées],Cistude Nature,Responsable administratif et financier,
+348f1c5a-47be-4860-adcc-f47957f4d757,[Données non publiées],Neant,Neant,
+34964111-9b3f-4e13-8f3f-19bee5a19b72,[Données non publiées],Retraitée,Retraitée,
+3496a04c-b003-4817-8c49-63ab224c2037,[Données non publiées],SANS PROFESSION,NEANT,[Données non publiées]
+34a4a6d5-a73d-49b8-bc1c-bb2085fb81ac,[Données non publiées],1001VIESHABITAT,BAILLEUR SOCIAL,
+34ae39cf-6c7c-4e3c-bbc5-19ad624c4d0f,[Données non publiées],Chef d'entreprise,Gérant,
+34ca0d17-543d-4c9c-a871-8bdb306a419d,[Données non publiées],Sarl SADP,importation et distribution en cote d'ivoire de produits de para pharmacie,[Données non publiées]
+34d00658-709a-4a75-951f-878d9968e926,[Données non publiées],Hopital Beauséjour,Médecin [Données non publiées],
+34d2fa35-9df9-4be1-a539-93a8635aae57,[Données non publiées],[Données non publiées],Maison d'hôtes,
+34d96a77-0503-4deb-a077-367f0da2badd,[Données non publiées],Cave POULET et Fils,Aide comptable,
+34dc2e83-d2bf-4237-bb46-2fcb140b77ee,[Données non publiées],Ville de CHERBOURG-EN-COTENTIN,ATTACHÉE TERRITORIALE PRINCIPALE,
+34e04b11-9416-4706-b32e-5619487028cd,[Données non publiées],MTES DTAM SPM,Secrétaire administrative de classe normale,
+34e05404-5081-442f-b04e-6a88b70783f9,[Données non publiées],Centre Départemental de Gestion de la Fonction Publique Territoriale du Gard,Cadre de la fonction publique territoriale.,
+34e49b42-9011-4ba9-b8bb-6b337eb15e42,[Données non publiées],DGFIP,Contrôleur des finances publiques,
+34e9facd-a761-40be-936a-af32707bd81f,[Données non publiées],NEANT,RETRAITE,
+350a762b-d8a3-45ef-a11a-f8c8f66340c7,[Données non publiées],SCRIB',COMMUNICATION FORMATION,[Données non publiées]
+35141ecd-6bac-4f20-a31e-bfef06c4fded,[Données non publiées],liberal,medecingeneraliste,
+352aa42e-5809-408c-843f-f62315d41bde,[Données non publiées],SA [Données non publiées],directeur général / démolition automobile,
+353b69c8-91eb-48e6-80c5-84467653e8ff,[Données non publiées],Auto entrepreneur,auto entrepreneur dans l'art,
+353c8cf6-cc75-41cf-8e9c-40bcdab562ec,[Données non publiées],bureau des guides,monitrice de ski (hiver) accueil bureau des guides (été),
+35418718-8ffc-46f3-97d3-09b72ec1e044,[Données non publiées],néant,néant,néant
+3541a9ec-1c94-43d6-9420-aaaa3e3130fb,[Données non publiées],SANS,AUCUNE,[Données non publiées]
+35486ff4-b326-4c45-8fc2-507862ea4cdb,[Données non publiées],France Télévision,Journaliste,
+354f7ae7-d06c-49b7-b384-376a8fc64939,[Données non publiées],AISMT36,[Données non publiées],
+35511c89-8b9a-4bf7-b6e1-5501e6742cd5,[Données non publiées],Alteia,Chef de projet logiciel [Données non publiées],[Données non publiées]
+3563543b-bd98-46ad-9e2d-bfabdeb97975,[Données non publiées],MUTUALITE RETRAITE,Femme de service en EHPAD,
+357c8648-7683-45ad-ab46-79f4833f7b73,[Données non publiées],Conseil départemental - [Données non publiées],[Données non publiées] Service Informatique,
+357fb2fe-6e9c-42f7-b3d6-5a8f0443eb92,[Données non publiées],Retraitée,[Données non publiées],
+3598cf42-5cf2-4b00-8ad9-7a636a0b778b,[Données non publiées],NEANT,NEANT,[Données non publiées]
+359de417-fa6d-4ea2-9623-2f97e74ae6b1,[Données non publiées],[Données non publiées],[Données non publiées],En retraite [Données non publiées]
+35a3ccf8-7447-4402-8408-61e88f7ad3e2,[Données non publiées],Université Jean Monnet,[Données non publiées],
+35a4521d-2637-4d57-8aaf-1ca80d403688,[Données non publiées],Groupe CISN,[Données non publiées],[Données non publiées]
+35ac5aa0-03b8-4d3b-a12f-d0451dedcd05,[Données non publiées],Nantes Saint-Nazaire développement,Chargée de mission,
+35ad10a8-ca84-4b83-95e2-6bea68402c7e,[Données non publiées],Médecin libéral,Médecine générale,
+35b0cfef-16b4-46cd-a7fb-7c0f7c445a83,[Données non publiées],Atelier Paysan,Animatrice nationale,
+35b50821-7e49-48c9-8d46-026b92d4a9bf,[Données non publiées],AUTO / LIBERALE,KINE,
+35b7c1cf-1690-409f-85b2-b3a6420017fe,[Données non publiées],Ministère Education nationale,Enseignant,
+35c6f723-f026-4408-ad88-2e8c133cb441,[Données non publiées],Centre Hospitalier [Données non publiées],infirmière,
+35c91a0a-990a-427a-bb2b-4219106a9774,[Données non publiées],GSK,Délégué médicale,
+35caf3c1-b3e2-4824-8838-1fedafc12ebc,[Données non publiées],GROUPAMA [Données non publiées],Technicien [Données non publiées],
+35d4d4b6-706a-4e77-82c6-260ed5c7f5d6,[Données non publiées],intermittent du spectacle,comédienne,
+35dfd2f3-0868-4326-831f-2412e4b311b4,[Données non publiées],ville de Sainte Adresse,directeur général des services,
+35e6bae4-1d26-4af1-8aa5-617d26726b02,[Données non publiées],METROPOLE NCA,[Données non publiées],
+35ee1859-9770-4c82-983b-033987b3497d,[Données non publiées],DEPARTEMENT DU HAUT RHIN,ASSISTANTE SOCIALE [Données non publiées],
+35f599be-ecb6-4f34-bb84-3e3063f99a49,[Données non publiées],Département de la Gironde,Gestionnaire ressources humaines,
+35f6868e-1d0c-48a6-842d-44f36c982616,[Données non publiées],auto entrepreneur,négociatrice immobilier,
+360b47c2-ff38-4c0e-98f2-7e36abd9a403,[Données non publiées],[Données non publiées],[Données non publiées],retraité
+3613d05b-6f0b-4de9-8cf7-be51a38e7a05,[Données non publiées],Syndicat mixte Ardèche Drôme Numérique,[Données non publiées],
+361a5fde-9d3c-4272-95f5-45b64132fbdf,[Données non publiées],Éducation nationale,Enseignant,[Données non publiées]
+361f1d6c-a35d-4a0f-b12b-307f40e29284,[Données non publiées],SARL [Données non publiées],Gérant d'une agence immobilière [Données non publiées],
+3629da3f-9b16-4a57-b7f3-7b89a80eb2bc,[Données non publiées],Spie ICS,Ingénieur Télécom,
+362b01b9-79f8-4a67-88a0-8a19728b2e61,[Données non publiées],Ministère de la Justice,Greffière des services judiciaires,
+362b7281-9e7e-4a14-bc41-c4e366e5587c,[Données non publiées],Département,Adjointe technique territoriale,[Données non publiées]
+3631cf42-c1e5-4984-84a4-8667f3f9a98c,[Données non publiées],Centre hospitalier de Carcassonne,Infirmière,
+363bce58-0006-4328-a607-96e183ba1f64,[Données non publiées],roc eclerc,[Données non publiées],
+36428635-369e-41e7-87c2-40961df67bb1,[Données non publiées],Ministère de l'éducation,Professeur des écoles,[Données non publiées]
+36460410-9487-4755-8465-9b6cba8c92a9,[Données non publiées],RSM,CHEF DE MISSION,
+3650a355-69bc-4826-9e59-ae39de903dd4,[Données non publiées],[Données non publiées],Gérant d'un commerce de bouche/bar,Activité qui a pris fin en date du 1er septembre 2020
+365916b8-48ec-4b59-8e07-f4d56aef3cba,[Données non publiées],[Données non publiées],Directeur Technique adjoint,
+365a74fb-0afc-4ed1-ba7e-eeb4a44c1496,[Données non publiées],Education nationale,Professeure,[Données non publiées]
+36635ee0-9601-4534-a810-c320e3c67e74,[Données non publiées],[Données non publiées] Entreprise d'électricité plomberie,Artisan,
+36653980-84ca-49bf-b440-e1f8b3f124c5,[Données non publiées],CCVS,Agent d'animation périscolaire,
+367364a6-77c4-42e7-9527-66b7be5f31db,[Données non publiées],TAXI [Données non publiées],Artisan Taxi,
+3689e1ee-f4a0-4348-a043-bb3a2cf10d9a,[Données non publiées],La Paillette,[Données non publiées],
+36a0305e-374c-4d77-b34c-8dfa570b01f1,[Données non publiées],Autoentrepreneur,Chargée d'affaires privé,
+36a9d8dc-7dc1-4297-825f-b41bb4784b91,[Données non publiées],Orchestre Philharmonique [Données non publiées],musicien [Données non publiées],
+36aae7c7-7f82-4ac2-a4bd-00b3692c6270,[Données non publiées],éducation nationale,directrice d'école maternelle,retraitée [Données non publiées]
+36abd52d-d71f-4de7-bb69-71d49b44b1f6,[Données non publiées],SSM (sécurité sociale des mines),[Données non publiées],
+36b63e12-8a1d-4a0a-b401-4edbc48d957c,[Données non publiées],FREKENCES,Chef de projet [Données non publiées],
+36bc32fc-24bc-404f-920e-5979bc619860,[Données non publiées],Retraitée,Néant,
+36bc9e0f-9f32-4722-9ed1-2dccc91bbe56,[Données non publiées],Rectorat Aix-Marseille,Professeur de lycée,
+36c34bf5-fdae-4b7c-b546-af15ddef303a,[Données non publiées],Nespresso France,"Cadre commercial, responsable de secteur [Données non publiées] pour les établissements de débits de boissons, hôteliers et de restauration.",
+36d67da5-dd91-492e-ab1a-c5aae6d8169e,[Données non publiées],Caisse d'Epargne [Données non publiées],conseil en gestion de patrimoine,
+36d8f846-8acf-403c-8cd3-4a40b0f36057,[Données non publiées],NEANT,NEANT,[Données non publiées] élue [Données non publiées]
+36d9b488-ba33-4de6-905c-3175eeec8aee,[Données non publiées],[Données non publiées],Retraité,[Données non publiées] [Données non publiées]
+36dd9f2f-c274-44f4-9f06-04ecc1ff315a,[Données non publiées],Clinique [Données non publiées],Pharmacienne,
+36df1848-ff1b-4254-b8ec-876e9cc7d537,[Données non publiées],retraitée,retraitée,
+36e95661-2106-4628-8cd1-4dccbf1870fa,[Données non publiées],SASU [Données non publiées],Directrice financière [Données non publiées],[Données non publiées]
+36f727a1-9a0e-41d0-9117-54079e429b64,[Données non publiées],CARSAT,Retraitée,
+36fc64b6-8ada-44d9-a9c7-46c37fff6654,[Données non publiées],NEANT,formation soins infirmier à l'ifsi [Données non publiées],ECOLE DE SOINS INFIRMIER
+37052340-b850-4de8-b333-96b92e84e900,[Données non publiées],SARL SPORTIMMO,[Données non publiées],
+3719bdcf-acd0-44d2-8d51-01d20989d9d1,[Données non publiées],Conseil Départemental de l'Ain,Assistante sociale,
+371ea75f-964b-444c-859b-aed635a02815,[Données non publiées],SARL [Données non publiées],secretaire de direction,
+37205364-a767-496e-b08a-2d6ebb72ff87,[Données non publiées],PRO SERVICES,Technicien de stand,
+3729e050-64ce-4b37-ad11-79afdea2279e,[Données non publiées],SOROFI,[Données non publiées],
+37306f97-5021-447e-ab17-26ca07fc7925,[Données non publiées],[Données non publiées],"entreprise individuelle, réflexologue",
+3733fd5b-87ce-497e-bd97-b578a32cc49d,[Données non publiées],Néant,Retraité,
+3735739e-8b23-44d2-8034-8d47995e8d72,[Données non publiées],[Données non publiées],Gérant majoritaire (non salarié) de la société [Données non publiées] Bureau d'Étude en Thermique du bâtiment.,
+3739571b-0b2a-4e2c-807f-3d72048202ec,[Données non publiées],néant,Retraité,
+37399c51-b3b8-4157-ae3b-b6f604f11919,[Données non publiées],Ville de Cherbourg-en-Cotentin,Directrice [Données non publiées],
+373dd04f-323f-4774-9021-5bde45c17ec3,[Données non publiées],neant,neant,[Données non publiées]
+3744462a-6211-40a6-9c1d-4e33ff3fc41b,[Données non publiées],CARSAT,RETRAITE,
+3744462a-6211-40a6-9c1d-4e33ff3fc41b,[Données non publiées],MAIRIE DE PORTES LES VALENCE,DELEGUE,
+3744462a-6211-40a6-9c1d-4e33ff3fc41b,[Données non publiées],GARAGE PIETRI,DEPANNEUR,[Données non publiées]
+3746762d-b5c7-463e-81fa-215ce3035b36,[Données non publiées],NEANT,NEANT,AUCUNE ACTIVITE
+3748ce75-82c5-4927-997c-12fcad3928c6,[Données non publiées],Travailleur indépendant,Gérante de chambres d'hôtes,
+374da2ae-4112-48a8-a2f9-b6852e23c5b3,[Données non publiées],NEANT,retraitée,Retraitée
+3750bea5-2915-4ed0-982b-1c5e01eab443,[Données non publiées],Education nationale,Enseignant certifié hors classe en fonction [Données non publiées],aucun
+375a5471-9c3d-46a5-a2da-b7b7082401cf,[Données non publiées],Pole Emploi,[Données non publiées] SIMPLIC,[Données non publiées]
+375cda24-3746-40fe-8810-e5f17bba8be2,[Données non publiées],MEI,conseil juridique,[Données non publiées]
+375cda24-3746-40fe-8810-e5f17bba8be2,[Données non publiées],Mauresterel transactions,Activités d'agence immobilière,[Données non publiées]
+375cda24-3746-40fe-8810-e5f17bba8be2,[Données non publiées],Mauresterel invest,Holding Société de marchand de biens,
+375f635d-c597-4580-be04-00c6e13b1142,[Données non publiées],[Données non publiées],[Données non publiées],
+3760d3d2-aa13-4f40-9068-0aa2f710b789,[Données non publiées],Néant,Néant,[Données non publiées]
+376579f3-f55d-4700-87ec-0f93e1593b1c,[Données non publiées],MAIRIE DE SARAN,[Données non publiées],
+37686a78-af2a-4be1-8b0c-648de493bc67,[Données non publiées],EKIP'ELEVAGE [Données non publiées],Commercial,
+3772b972-4b2c-4043-bedd-bebc8b1feb77,[Données non publiées],retraitée,néant,
+3775a2b4-b8cd-49b4-9126-eef85dcc5a81,[Données non publiées],Chef d'entreprise,Entreprise de consulting en santé et biotechnologies + entreprise de textile spécialisée pour les diabétiques,
+37768d8b-b11f-4449-a5b8-de91a0394fee,[Données non publiées],Education,Professeur,
+37822ee0-5ec0-491e-a916-9bbf60f40d83,[Données non publiées],association [Données non publiées],Infirmière,
+378e992a-958d-40f8-b580-b5bb531eeb57,[Données non publiées],Education nationale,directrice d'école maternelle,
+378ff210-2038-45bd-a9cc-9da11bf07040,[Données non publiées],General Electric,Ingénieur,
+3791dff4-3e21-497d-aa4b-4232ee13c889,[Données non publiées],Ministère de l'Education Nationale,Professeur des écoles,
+37950721-f6a7-4e3a-863e-01f083167c91,[Données non publiées],[Données non publiées],Pharmacien titulaire d'une officine de Pharmacie,
+379b8315-4276-4f0d-934f-4505a48ff1ce,[Données non publiées],Vetea Conseil,[Données non publiées],
+379b8315-4276-4f0d-934f-4505a48ff1ce,[Données non publiées],Open Lande,[Données non publiées],
+379d891f-32ec-43ed-a978-e1d9697d5296,[Données non publiées],COMUTITRES,Responsable Achats,[Données non publiées]
+37b07baf-d95e-4841-aa0e-035f7f491779,[Données non publiées],retraité,néant,[Données non publiées]
+37bfe136-8cc4-4429-8e8a-e9a987537abd,[Données non publiées],Education nationale,Professeur d'histoire - géographie,
+37c3389d-473a-4029-9fdf-61086516cf96,[Données non publiées],NEANT,NEANT,
+37c75d96-20b3-493a-b851-7bf25792e893,[Données non publiées],Néant,Retraitée,Retraitée
+37c75d96-20b3-493a-b851-7bf25792e893,[Données non publiées],Neant,Retraitée,Retraitée
+37cba251-29c6-46e2-9c9a-2a3646941244,[Données non publiées],NEANT,NEANT,[Données non publiées]
+37cc1f19-48b2-4386-942f-9a66e4aba2ff,[Données non publiées],entreprise individuelle,avocate,
+37cc1f19-48b2-4386-942f-9a66e4aba2ff,[Données non publiées],entreprise individuelle,avocate,
+37dd2dbd-3539-43f3-92a9-a806f6ab34c2,[Données non publiées],Selarl [Données non publiées],Avocate collaboratrice libérale [Données non publiées],
+37f0222a-8193-4505-be38-53433a921e5b,[Données non publiées],Territoires Formation et Conseil TFC,Dirigeant [Données non publiées],
+37f17b2d-be39-43dd-8743-bfab4d892832,[Données non publiées],retraitée,aucune,[Données non publiées]
+37fea80a-7a14-4079-94ff-226e370c5911,[Données non publiées],NEANT,NEANT,
+3800cf3f-0c05-421d-9ab2-b07e1c135d54,[Données non publiées],RETRAITE,DIRECTEUR IMMOBILIER,NEANT
+3800d948-0a02-41f5-955c-0b92f231c125,[Données non publiées],CHU,Laborantine,
+3804dd43-78cf-4aca-ba92-7dd164244782,[Données non publiées],néant,[Données non publiées],retraité
+380c9115-1fff-483e-87ad-5e7e0af6829b,[Données non publiées],Assemblée nationale,[Données non publiées],
+3818d1f7-8a61-4c9c-87c6-24725a7bee71,[Données non publiées],néant,néant,[Données non publiées]
+38211457-f3bf-4584-9308-a283064f6f32,[Données non publiées],NEANT,RETRAITEE,
+3822a7c9-b0a6-4097-a446-d754644bd912,[Données non publiées],Pole Emploi,[Données non publiées] SIMPLIC,[Données non publiées]
+38310b2d-2b30-41bb-be78-b43b24188398,[Données non publiées],GRENOBLE ALPES METROPOLE,[Données non publiées],
+38376f82-c1ce-43ad-a934-63123bd59b0c,[Données non publiées],retraitée,retraitée,Activité antérieureDirection générale de la santé.
+383ca423-792a-4105-aac0-30ce06c97740,[Données non publiées],Tam montpellier,[Données non publiées],
+384ce812-646a-4792-9aee-e59bdc7878c5,[Données non publiées],Association diocésaine d arras,[Données non publiées],
+385dc873-1668-4a12-982d-9636c2c5ed5c,[Données non publiées],Entreprise individuelle,Commerçant - Agence de Publicité,Arrêt de son activité au 31/07/2021 [Données non publiées]
+38617d96-7351-4617-958d-320b4431782a,[Données non publiées],retraite,neant,
+3867bf83-d45a-436b-a320-e58f245368b5,[Données non publiées],retraitée de l'éducation nationale,retraitée,
+38763307-d016-4921-8318-7aee74c579ee,[Données non publiées],EDUCATION NATIONALE,ENSEIGNANTE EN ANGLAIS,
+387929d3-aaaa-42d4-b530-ae352e62b96a,[Données non publiées],ACJ ELECTRONIC,[Données non publiées],
+387d7741-2685-4381-8f65-98700ec29cfb,[Données non publiées],neant,Neant,
+387e9282-afae-41a1-b3c1-647120cdf689,[Données non publiées],CCAOF -Confédération des Coopératives Agricoles de la France,Juriste Auditeur Réviseur Réalisation d'audit de révision dans les sociétés coopératives Statut Cadre,[Données non publiées]
+387e9282-afae-41a1-b3c1-647120cdf689,[Données non publiées],Mairie de Noyal Chatillon Sur Seiche,[Données non publiées],
+3882b82b-f595-463f-9eb4-a89dd3fcce39,[Données non publiées],[Données non publiées] [Données non publiées],[Données non publiées],
+3882b82b-f595-463f-9eb4-a89dd3fcce39,[Données non publiées],NEANT,ADJOINTE AU MAIRE DE BORDEAUX [Données non publiées],
+389ca768-552e-4eb5-b719-e7aee7ef8255,[Données non publiées],Néant,Néant,
+389fca3e-3c52-4e1f-b87b-a823fcb877ce,[Données non publiées],Constructions Idéale Demeure,[Données non publiées],depuis le 1 septembre 2020
+38a39531-7f57-465e-b0a4-0a800b359211,[Données non publiées],AP-HP,Interne en médecine,
+38a65983-ec82-4b46-bb19-0d91882bc91c,[Données non publiées],La Poste,Directrice de secteur,
+38a6a2f3-490a-4143-a960-2d97c857113f,[Données non publiées],Education nationale,Professeur des écoles,Actuellement directrice de l'école [Données non publiées]
+38a8d99e-3a74-478a-a522-e17115cff932,[Données non publiées],UGECAM [Données non publiées],Directeur SSR,
+38ac113c-ad21-448d-8f09-a795da0fa0f0,[Données non publiées],Région Auvergne Rhône Alpes,[Données non publiées],
+38ace762-2097-4fa3-b4e3-efb7b43e0f1e,[Données non publiées],SARL SOCIETE DES TRANSPORTS [Données non publiées],[Données non publiées],
+38b6223c-652c-40bc-afde-08263d18a3e0,[Données non publiées],[Données non publiées],[Données non publiées],Retraitée [Données non publiées]
+38ba2c9b-4742-4d15-a04d-61805b34a5d3,[Données non publiées],Education Nationale,Professeure des Ecoles,
+38c78c9c-7514-48e9-9063-35ba136fdb6e,[Données non publiées],AGRI BOUCHET,COMPTABLE,
+38c78c9c-7514-48e9-9063-35ba136fdb6e,[Données non publiées],RELAIS ACCUEIL PROXIMITE,SECRETAIRE COMPTABLE,
+38d3eff9-2e51-430b-9585-3479ccbc1c0a,[Données non publiées],Hopital,Retraité,
+38dc5732-64b8-4da6-abaf-18d74a88d42d,[Données non publiées],Parfum Christian Dior,Responsable de Laboratoire,
+38e0e4aa-322d-45e1-a588-a77d5810422a,[Données non publiées],Exploitant individuel,Sophrologue,
+38e8c5d9-b17b-4630-8d33-96e91054fc3c,[Données non publiées],Conseil Départemental de la Charente,[Données non publiées],
+38e9c751-16f9-42b5-877a-849fdf8e5a56,[Données non publiées],Auto entrepreneuse,Traductrice Psychothérapeute,[Données non publiées]
+38f29394-863f-4493-96c1-d42ee921f31e,[Données non publiées],[Données non publiées],[Données non publiées],Sans emploi aujourd'hui [Données non publiées]
+38f3d46f-ee3c-4a60-9343-08493564fc76,[Données non publiées],RETRAITEE,Fonctionnaire territoriale en retraite [Données non publiées],[Données non publiées]
+38f6165f-1167-4cd1-9a3b-d5c15010c29f,[Données non publiées],Conseil de l’Ordre des médecins,[Données non publiées],Retraitée active [Données non publiées]
+38fb894f-fcf5-483c-bed8-354932e48d41,[Données non publiées],SOITEC,Ingénieur,
+390926db-59ba-4faa-808a-24a6434f956a,[Données non publiées],neant,neant,
+390a38a3-8160-4e78-ad05-a4d0de7bbd8a,[Données non publiées],megagence,[Données non publiées],
+390a38a3-8160-4e78-ad05-a4d0de7bbd8a,[Données non publiées],valorège,société d'investissements et de participations,
+390a8d89-4076-435f-9f80-ea7c34e3c0f5,[Données non publiées],HOPITAL [Données non publiées],TECHNICIENNE EN RADIOLOGIE MÉDICALE,
+3911b503-e22d-4416-a480-81e8ca5724b1,[Données non publiées],Delfie Plus Coaching SARL,Gérante [Données non publiées],
+39128e41-2a8d-4867-9b01-68c219430419,[Données non publiées],[Données non publiées],OPTICIENNE-DIRECTRICE DE MAGASIN,
+391b5cfc-b36b-4902-9a8f-e2754bd3184e,[Données non publiées],La Poste,cadre,
+391e499b-b518-4669-b8cd-03dcdb982c54,[Données non publiées],GM PARTICIPATIONS,GERANTE,
+393c3b66-9b6d-484f-a2d8-5f3a930708a3,[Données non publiées],RETRAITEE,NEANT,
+39483939-a0a4-420f-8db8-aa0c68e3145a,[Données non publiées],retraitée,Néant,Gérante [Données non publiées] de la SARLE DEWEZ [Données non publiées]
+394b036a-1f0e-4e86-bb94-b1a6c2a48fe3,[Données non publiées],Hôpitaux [Données non publiées] /profession libérale,Sage-femme,
+39500326-44be-4b3d-8233-6f0a750b1857,[Données non publiées],Météo France,Climatologue,
+39545b8c-3ada-4b45-bb33-2b30f8f1b93a,[Données non publiées],Entreprise individuelle,Infographiste,
+39550eeb-0c13-40e5-8e18-f8658aa11437,[Données non publiées],ADS LORRAINE,EMPLOYEE ADMNISTRATIVE,
+39591772-c891-4259-b246-77030e26f256,[Données non publiées],néant,Retraité,
+395a29f4-7c94-4ef9-832d-0cee2db6c0cb,[Données non publiées],Profession Libérale,Médecin spécialiste Gastro-entérologue,
+39622040-8435-49a6-b24b-1e6705530048,[Données non publiées],[Données non publiées],Assistante parlementaire,[Données non publiées]
+396f4401-00a1-4fe9-81dc-298ddd98af07,[Données non publiées],Hopital Beauséjour,Médecin [Données non publiées],
+3976cdae-9d18-4698-a206-60a476748fea,[Données non publiées],neant,neant,Retraité [Données non publiées]
+397dc6f0-66dd-4205-b924-77c44d2deadd,[Données non publiées],CAMG,[Données non publiées],
+3980a420-c439-4f44-bdb3-a57e4c07ddd6,[Données non publiées],Drees&Sommer,Project Manager,
+398366d8-887f-46ca-b433-b9066970ccc8,[Données non publiées],Commune Terre de haute Charente,Chargée de communication,[Données non publiées]
+39853484-8120-445b-a657-67a197ca9bee,[Données non publiées],Education Nationale,Enseignante,
+398837dd-6618-4cbf-9f6b-7d608d5b1a29,[Données non publiées],Fonction publique territoriale,secrétaire administrative,
+3996467b-8d33-4fe2-9cda-97cf9be24352,[Données non publiées],sans,Activité libérale AVOCAT,
+39a08405-de50-4d82-87d8-7c644b5c4b65,[Données non publiées],GROUPAMA GRAND EST,ASSISTANTE [Données non publiées],[Données non publiées]
+39a3546f-24e5-41d0-88e3-fbaab76c0175,[Données non publiées],EDT-ENGIE,Electricité de Tahiti Chef d'exploitation [Données non publiées],[Données non publiées]
+39a3546f-24e5-41d0-88e3-fbaab76c0175,[Données non publiées],Armée [Données non publiées],Retraité [Données non publiées],[Données non publiées]
+39ba54fa-a646-4c55-8295-1874a417f015,[Données non publiées],Néant,Néant,
+39bfd582-5e36-4cb6-9014-d3fd9ba25e93,[Données non publiées],[Données non publiées],[Données non publiées],Retraitée [Données non publiées]
+39c1212b-e2d9-4d8c-8b5c-b66fb6bf014d,[Données non publiées],Travailleur indépendant,Gérante de chambres d'hôtes,
+39c23b41-0232-4773-9aab-fcc9780a3ff9,[Données non publiées],Societe generale,Cadre bancaire,
+39c3cd31-b8d2-49c2-982e-2abcaa07e7a0,[Données non publiées],hopital de St-Lô,orthophoniste [Données non publiées],
+39c43fb0-e4ad-41ff-90ec-8eccd4a82c4a,[Données non publiées],Cabinet dentaire [Données non publiées],Cabinet dentaire,Assistante dentaire
+39dead91-13a2-4956-bf5c-ea3552f56396,[Données non publiées],La Poste,Directrice de secteur,
+39e12464-38ea-4856-8e44-87445b1422d6,[Données non publiées],TSA Elec [Données non publiées],Commercial,
+39e5d64c-0998-4e4b-bd1f-78cf053f04c4,[Données non publiées],Sans employeur,Retraitée,
+39ee7ffe-c350-464a-b49b-f396a2a0b4ed,[Données non publiées],NEANT,NEANT,
+39f2d8ab-74da-4084-800d-32d690e71f8c,[Données non publiées],[Données non publiées],[Données non publiées],En retraite [Données non publiées]
+39f7ef5a-46d0-4012-bdcc-3d64d234fc68,[Données non publiées],[Données non publiées],Salariée cabinet d'avocat,[Données non publiées]
+39ff1cb7-c4d0-4225-86be-55d167289b06,[Données non publiées],Soufflet Agriculture,Cadre [Données non publiées],
+39ff31bf-5367-469b-b639-bd4c0f8decf0,[Données non publiées],selarl [Données non publiées],Auxiliaire spécialisée vétérinaire,
+3a003852-ab1a-4edc-bdc4-359f6c58d62b,[Données non publiées],Education Nationale,néant,
+3a08abac-9b19-42ed-b170-402756832560,[Données non publiées],NEANT,NEANT,
+3a121699-aa59-42b2-a120-6f23f980c5f1,[Données non publiées],APHM,Cadre superieure de santé aux hopitaux publics de Marseille,
+3a127f89-260c-4c62-9f10-7630f2d99bf8,[Données non publiées],Neant,Neant,
+3a1aecdd-6456-46ba-81bf-de3ac21dccc2,[Données non publiées],Suchi Daily,Cuisinière,
+3a1db288-1b68-4b1a-b1e4-38f876708ad1,[Données non publiées],[Données non publiées],AVOCAT,
+3a481230-5fd5-4bff-a500-60e8502c1a6c,[Données non publiées],[Données non publiées],[Données non publiées],En retraite [Données non publiées]
+3a51d05b-2641-48df-9780-d3f6f48fa393,[Données non publiées],Gérant,SAS Courtin [Données non publiées],
+3a536794-2cd3-4ae8-a3da-c6e39bc60dff,[Données non publiées],Néant,Retraitée,
+3a642bbf-c7aa-436e-b1fe-a9a961ec0e70,[Données non publiées],Retraité,Retraité,
+3a659578-f230-491f-9ccd-0469aaf7b3dd,[Données non publiées],CD [Données non publiées],[Données non publiées],
+3a6966eb-71ec-4e3e-8dfc-9ece99c4f1d4,[Données non publiées],[Données non publiées],Releveur de compteurs,
+3a7e2d48-7996-4452-83ca-91ba9e093583,[Données non publiées],SCP [Données non publiées],Avocat aux Conseils,
+3a7e32df-5b55-4246-b6f8-5fe0a582f36c,[Données non publiées],[Données non publiées],directrice maison de retraite,
+3a7e32df-5b55-4246-b6f8-5fe0a582f36c,[Données non publiées],[Données non publiées],directricemaisonderetraite,
+3a810c7b-5bc9-4494-8382-141355aa14d8,[Données non publiées],CentraleSupélec,Enseignant-Chercheur,
+3a8ea452-e1c4-4a29-8f28-b9ccc79efc8f,[Données non publiées],lui même,conception graphique,
+3a8ebd15-103b-4a4f-a614-2797f540d91f,[Données non publiées],Mairie d'Hénin-Beaumont,maire et conseiller départemental,
+3a921902-1fb9-4840-9c43-1862efe811c0,[Données non publiées],Mairie de Besançon,Directrice adjointe [Données non publiées],[Données non publiées]
+3a971fd4-15a3-4736-82f0-11293357ab8c,[Données non publiées],Fondation COS Alexandre GLASBERG,Directeur d'établissement de santé privé non lucratif. [Données non publiées],
+3aabb11a-5f62-4f93-bfa8-ae4d68fcd736,[Données non publiées],Néant,Néant,
+3ab31c34-49f4-4147-9d47-2f2071d89fc2,[Données non publiées],Néant,Néant,[Données non publiées]
+3ab8a94b-1191-4f7e-ba4e-74cf0a5daa1a,[Données non publiées],CLINIQUE CLAUDE BERNARD,Secrétaire médicale,
+3abc4d28-3bc8-4881-be87-ddaf6bf41a73,[Données non publiées],[Données non publiées],gérante de [Données non publiées] société Immobilière [Données non publiées],
+3ac25058-f5e1-4e73-b16e-7894df80f59e,[Données non publiées],Commissariat à l'Energie Atomique,Directrice [Données non publiées] [Données non publiées],
+3ad0b05a-cda7-4d2b-a2d7-789fadebcf85,[Données non publiées],[Données non publiées],notaire assistant salarié,
+3ad50dc4-ba18-45b0-9d62-625dde766a0e,[Données non publiées],mutualité Française VYV3,Responsable du service [Données non publiées],
+3ae36566-cd81-4029-895a-f56cf6d44e51,[Données non publiées],CSP,Directrice [Données non publiées],
+3ae537b2-6ae8-4fe0-95b8-6230b662d03b,[Données non publiées],NEANT,NEANT,NEANT
+3aea81f4-7388-44bc-bcdb-1532be373b76,[Données non publiées],NANTES METROPOLE,agent,
+3aebb09d-cb04-4e50-9b63-9a5a85d60a67,[Données non publiées],Fondation Aung San Suu Kyi (Fondation de droit américain),Secrétaire générale bénévole,
+3aebb09d-cb04-4e50-9b63-9a5a85d60a67,[Données non publiées],Comptoir nouveau de la Parfumerie (Hermes Parfums),Membre du Conseil d'Administration,
+3aebc529-dd12-4685-8a30-b571d4f3268a,[Données non publiées],FSEF,[Données non publiées],(infirm psy)
+3af58a53-b934-4fdc-a306-bd4fc6197e92,[Données non publiées],Credit Agricole,Employée de banque,
+3af7d7dc-8cf2-4296-9b02-b7fdc0a97c81,[Données non publiées],France Television,Rédacteur en chef adjoint [Données non publiées],
+3afb7fc3-488b-4a32-b075-059d58e26d69,[Données non publiées],Polyclinique [Données non publiées],Médecin spécialiste,[Données non publiées]
+3afda49a-d79b-4973-9f1f-5ae4f2bb32a7,[Données non publiées],néant,Néant,Retraité du BTP
+3b1b41f2-d288-4a01-ba80-1d54431847ac,[Données non publiées],SEISAAM,Infirmière sociale,
+3b221aa4-6bbe-47e9-b125-e296a0c5d3cc,[Données non publiées],Groupe Thivolle,[Données non publiées],[Données non publiées]
+3b24c740-546a-409b-879f-6e250b255520,[Données non publiées],NEANT,NEANT,
+3b2eece7-903d-4bdc-b9d8-05d8739faaa2,[Données non publiées],CEPAC,employée de banque,
+3b36e36e-fec7-40f9-8034-182e71a1e6ab,[Données non publiées],Néant,Retraitée,
+3b401d98-c85d-4dbd-911d-ab4a6542e7bb,[Données non publiées],[Données non publiées],[Données non publiées],
+3b40249f-0d6d-4299-941c-37c36434d626,[Données non publiées],TEHOGIHIA,Commerce d'alimentation générale,
+3b4b7b84-2b95-418e-8172-d90a84f17630,[Données non publiées],GROUPE SEB,TECHNICIEN DE LABORATOIRE [Données non publiées],
+3b5bfa43-cea1-461e-9eac-b429b6c7fe06,[Données non publiées],LOXAM,[Données non publiées],
+3b76ec35-f700-4c4d-a501-bdbc9ac2be87,[Données non publiées],néant,néant,
+3b7b86be-81e6-4dac-9147-9b44ec085557,[Données non publiées],Musée des Arts Déco - Ecole Camondo,[Données non publiées],
+3ba3834f-e418-49bb-b24f-26e2f64fbc76,[Données non publiées],NEANT,retraitée,[Données non publiées]
+3ba463fa-244d-4305-9416-3f3c53eabddc,[Données non publiées],NEANT,NEANT,[Données non publiées]
+3baa0727-1779-4ba2-8437-b0caf217e0bb,[Données non publiées],Banque LCL,assistante administrative,[Données non publiées]
+3bb2ca29-5b89-436d-ae54-154ec1ba16d6,[Données non publiées],DGDDI,Controleur Principal des Douanes,
+3bbbc553-4bbb-494b-bfcf-9c7452ed310b,[Données non publiées],PPG INDUSTRIES,RESPONSABLE [Données non publiées],
+3bc1da81-a7a7-4e12-91d7-a2b2fc59f8c3,[Données non publiées],Syndicat mixte Ardèche Drôme Numérique,[Données non publiées],
+3bcce82f-0d0f-44b7-b05f-90ccc3293b9c,[Données non publiées],AFPA,Responsable d'affaires [Données non publiées],
+3bdc8943-5989-46a9-8429-7f8c926c57e2,[Données non publiées],Ville de Hautmont,[Données non publiées],- Attachée principale en détachement du Conseil Régional. - Prise de Fonction le 15/02/2022
+3be22afc-05cc-4cda-92ab-320fa3657987,[Données non publiées],NANTES METROPOLE,agent,
+3bed5d36-ce9a-4369-b40d-d158801bbb42,[Données non publiées],Canal Plus,Journaliste,
+3bef6291-2095-477d-9f2d-29e634c1f57e,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+3bef6291-2095-477d-9f2d-29e634c1f57e,[Données non publiées],Auto entrepreneur,Conseil en relations publiques,[Données non publiées]
+3bf2a8f5-1f1d-4b8d-9f67-0f0fe96f3304,[Données non publiées],Altarea Cogedim,[Données non publiées],
+3bf4b151-d471-42db-b928-8e5c82b91cd1,[Données non publiées],SARL PIERROT SPORTS,Responsable de magasin,
+3c039ab1-342a-4180-9bcf-91cd017cdcff,[Données non publiées],commune Ribeyret -Sigottier,secretaire de mairie,
+3c1d7fda-cf52-411f-96f8-cd2b90e31877,[Données non publiées],MFR vallée du Lot,[Données non publiées],
+3c1d85ad-2790-4e58-a985-4a51207bce55,[Données non publiées],SARL MPC,Gérante de SARL [Données non publiées],mandat électif Conseillère Régionale Nouvelle-Aquitaine
+3c253922-8f43-482a-bff7-f4543d9cca73,[Données non publiées],travailleur indépendant,DPO,
+3c2a3379-5a6f-4ac8-bf8b-29fd572a18ed,[Données non publiées],Education Nationale,Professeur de Lettres,
+3c33417f-99af-482e-93b2-3f4c49be9066,[Données non publiées],Metalor,Agent d'exécution [Données non publiées],
+3c3473ab-ad3f-4785-9739-0985c96ca4e7,[Données non publiées],néant,sans,
+3c4f4999-a26f-4c89-9ebc-a34d896bd890,[Données non publiées],néant,Retraitée de l'Education Nationale,[Données non publiées]
+3c5b8fed-250d-431a-938c-0d96d6b8620a,[Données non publiées],Rectorat de Lyon,Professeure des écoles,
+3c62e260-c11d-4969-9edd-9ea5c0e13a36,[Données non publiées],DHL,Responsable du service après vente [Données non publiées],[Données non publiées]
+3c62e260-c11d-4969-9edd-9ea5c0e13a36,[Données non publiées],Tous ensemble pour Lucas,Présidente de l'association,Association caritative basée dans la ville de Mions (Métropole)
+3c668801-98a8-417d-90c8-c5a069120668,[Données non publiées],RTE,[Données non publiées],
+3c70a02e-9466-4096-8364-e44e8bf5289a,[Données non publiées],Education/nationale,[Données non publiées],[Données non publiées]
+3c764fc8-3238-43f4-b67b-449ca352b1fe,[Données non publiées],"Musicien, Intermittent du spectacle",Musicien - pianiste - accordéoniste,
+3c7aede4-66f4-4413-b255-ed7883d5723f,[Données non publiées],sans objet,prestations de traduction,
+3c7b6132-1b95-46f3-b7ec-d11f9d72fb41,[Données non publiées],[Données non publiées],ANIMATEUR SOCIO CULTURELLE,[Données non publiées]
+3c7befab-b5d3-4fbd-9eef-d2dfa962ce7f,[Données non publiées],Co-gérante,Co-gérante de la SARL HAVAIKI [Données non publiées],[Données non publiées]
+3c92b6bf-c357-4bd1-bf94-b4ae7760f2b0,[Données non publiées],Ministère de L'Europe et des Affaires Etrangères,[Données non publiées] Ambassadrice [Données non publiées],
+3c94ce51-f22e-458d-9525-aafce606ecd0,[Données non publiées],0,0,0
+3c961e94-b717-4084-9051-d302f8d0177f,[Données non publiées],Education Nationale,Enseignante,
+3c9d0fdc-41e6-44ac-9851-d06999bb9b29,[Données non publiées],Aucun,Pas d'activité professionnelle,Gérante de la SCI [Données non publiées]
+3ca0dce1-b4de-4460-996c-45320579a0b4,[Données non publiées],ASLRA Grenoble,Cadre [Données non publiées],
+3ca5089c-ca6d-46cb-9a7f-ca9c6322e403,[Données non publiées],[Données non publiées],Responsable administrative Gère l'administratif et les RH Statut cadre,
+3ca91256-25aa-4be0-b55d-85d8108341bc,[Données non publiées],éducation nationale,enseignante en collège [Données non publiées],Aucun
+3cab322e-e284-46a2-8604-b858165bba1e,[Données non publiées],[Données non publiées],[Données non publiées],Retraitée
+3cb1c890-7001-447e-a838-0542c300a453,[Données non publiées],travailleur indépendant,Docteur en medecine,
+3cb7186d-5441-466d-9c20-25dd1b513b69,[Données non publiées],néant,néant,retraitée
+3cbda12e-01da-4c19-bb69-167b799ded1b,[Données non publiées],[Données non publiées],ANIMATEUR SOCIO CULTURELLE,[Données non publiées]
+3cc24242-7b2a-4b1e-946e-e87c86a9a643,[Données non publiées],bioMérieux,[Données non publiées] [Données non publiées] Cadre [Données non publiées],
+3cc5de4b-cd0e-4e46-ae9e-46f6eb7e47dd,[Données non publiées],SCIC Boulogne-Billancourt Sport Développement,[Données non publiées],
+3cc5de4b-cd0e-4e46-ae9e-46f6eb7e47dd,[Données non publiées],SPL Val de Seine Aménagement,[Données non publiées],
+3cd285ac-06ed-4b05-b8af-1e641a073e28,[Données non publiées],NEANT,NEANT,
+3cd2acdf-498d-4f53-9019-96b9be546f7d,[Données non publiées],CCAS EDF,[Données non publiées],
+3ce067f6-6fe2-4bfc-af26-47debfd21262,[Données non publiées],Mairie de Rosières (43),Adjoint technique [Données non publiées] Fonctionnaire territorial,
+3ce2abd7-a971-4686-9f28-2b0869e445b0,[Données non publiées],néant,néant,néant
+3ce96721-307c-48b2-afbb-a7f6174534da,[Données non publiées],Gérant de la Sarl Panonacle Immobilier,[Données non publiées],Retraité [Données non publiées] Poursuite de l'activité en qualité de gérant majoritaire.
+3cf7e293-41f1-4a34-8914-9fce9d959312,[Données non publiées],Conseil départemental des Landes,[Données non publiées],[Données non publiées]
+3cfe7d3d-1cdc-4450-bcbb-e2e4866865cb,[Données non publiées],Communauté de communes [Données non publiées],Directrice générale des services,
+3d025620-03fd-4620-9810-bffe0909fc91,[Données non publiées],Région Grand Est,Chargée de mission,[Données non publiées]
+3d032a39-d2c1-44dd-8597-8181719679d9,[Données non publiées],BNP PARIBAS,CHARGEE DE CLIENTELE ACCUEIL,
+3d032d43-fdbb-4f8a-805e-5dd7c683acf4,[Données non publiées],[Données non publiées],vente de vins,[Données non publiées]
+3d0641ee-14ea-464f-a468-f889cd67957b,[Données non publiées],Mini World Lyon,[Données non publiées],[Données non publiées]
+3d2b940f-dfdb-4be9-a015-18e371a806ce,[Données non publiées],[Données non publiées],COURTIER EN PRET IMMOBILIER,AUTO ENTREPRENEUR
+3d30e7eb-9113-4eaf-afe3-9c7a0c3adf24,[Données non publiées],retraitée,néant,
+3d36264f-66a8-4870-be3c-aafd8862e456,[Données non publiées],Only Vet,Vétérinaire,
+3d3b2c3f-7e1d-4754-9f70-309705a26b97,[Données non publiées],Education Nationale,Professeur de lycée,
+3d59231c-df49-4937-ab55-7612d030b243,[Données non publiées],[Données non publiées] Côtes d'Armor,Professeur des écoles,
+3d61adb2-4b60-428f-94a0-37e4e04bf3f5,[Données non publiées],Banque Calédonienne d'investissement,Gestionnaire,
+3d6899bd-a0d6-42cc-bd3c-93b4b7c871f1,[Données non publiées],Ministère de la justice,Magistrate,
+3d6bacd9-dea9-49a6-af6b-0915dd35195c,[Données non publiées],auto entrepreneur,"artisan, second oeuvre",
+3d6fd2d2-03c6-4b42-be72-729ed9265c27,[Données non publiées],Algoé [Données non publiées],Consultante [Données non publiées],
+3d76b3e6-c050-4e6f-b70e-51d947cc5b17,[Données non publiées],neant,neant,
+3d787cb7-b9af-4323-a829-7457faf6fe11,[Données non publiées],LABORATOIRES DELPHARM,[Données non publiées],
+3d792390-17c5-48ae-a369-6c81c5665c71,[Données non publiées],LCL,[Données non publiées],
+3d7e8004-cf66-4145-93d3-f48744ce65ce,[Données non publiées],AIR FRANCE,Officier Pilote de Ligne,
+3d838d72-8ca9-4e47-b2c7-e6c44cad963f,[Données non publiées],COLLEGE JOSEPH ROUMANILLE,[Données non publiées],
+3d8becd9-1a2f-4fe0-95c6-11be7917d567,[Données non publiées],CARSAT,RETRAITE,
+3d8becd9-1a2f-4fe0-95c6-11be7917d567,[Données non publiées],MAIRIE DE PORTES LES VALENCE,DELEGUE,
+3d8becd9-1a2f-4fe0-95c6-11be7917d567,[Données non publiées],GARAGE PIETRI,DEPANNEUR,[Données non publiées]
+3d921fdb-7b3c-4cea-9ba0-14ee9f581ec7,[Données non publiées],NEANT,NEANT,[Données non publiées]
+3da24ea0-49f8-4856-af7a-2ce707941f03,[Données non publiées],Conseil départemental [Données non publiées],Fonctionnaire,
+3da94faf-f551-4d8c-b23e-ccec61be172a,[Données non publiées],néant,néant,retraité
+3daff5df-e518-479b-83eb-354726688dae,[Données non publiées],Groupama,Conseillère commerciale [Données non publiées],
+3db49259-8d52-4072-9956-2ccc405868ec,[Données non publiées],Education nationale,Enseignant certifié hors classe en fonction [Données non publiées],aucun
+3db8a89d-884b-49d4-a0a5-a61fed2fec29,[Données non publiées],ministere des finances publiques,contrôleur du trésor,[Données non publiées]
+3dc1a691-db9a-44dc-88ba-dd74d2213adb,[Données non publiées],ACADEMIE LILLE,PROFESSEUR DES ECOLES,
+3dd1d191-aee0-4799-b8fa-4034608961a7,[Données non publiées],néant,néant,[Données non publiées]
+3dd4ae43-f38f-4ae5-a3ef-da48df9a6e87,[Données non publiées],sans employeur,sans profession,
+3dd8adcd-e353-421b-8ac3-0ac2f0724029,[Données non publiées],ADAMEden,[Données non publiées],
+3de21ec9-01af-4083-bfc6-6794cc32aba1,[Données non publiées],CCVS,Agent d'animation périscolaire,
+3de7bdf7-fcd6-4e7e-869f-7244b1203f84,[Données non publiées],Mairie Sevrier,Directrice Générale des Services,
+3defdc3c-5e03-409b-92a9-c1f3bf1dc898,[Données non publiées],[Données non publiées],Cadre territoriale,
+3df47a2d-0901-45ac-b3cc-b76927d87880,[Données non publiées],[Données non publiées],Retraité,
+3dfc6661-7bba-40a6-aff7-90e24e966428,[Données non publiées],INDEPENDANT,MANDATAIRE IMMOBILIER,
+3e038fff-d81e-4c63-8d02-3e470ebed470,[Données non publiées],Entreprise [Données non publiées],Dirigeant; Transport et travaux public,
+3e03bcbe-793f-43cd-9194-312f578170ec,[Données non publiées],SENAT,Sénateur,
+3e0b6777-56ac-4561-b2e7-1940228630bc,[Données non publiées],néant,Retraitée [Données non publiées],[Données non publiées]
+3e15f3c4-9dfc-4777-b0f6-f2b8697d19b3,[Données non publiées],Education Nationale,Enseignante,
+3e209d45-8656-45ac-a8c8-451542abe786,[Données non publiées],SDIS [Données non publiées],pompier professionnel,[Données non publiées]
+3e237824-6cf1-47dd-8fcb-2685b550fdfc,[Données non publiées],CFA-FORMASUP,Cadre administratif,
+3e2b07fc-8044-40de-afc7-05cec4ff71c4,[Données non publiées],Hôpital Yves Le Foll,Psychologue,
+3e3163ac-932e-4fa8-b044-36e5473385d2,[Données non publiées],MINISTERE DE LA JUSTICE,Vice-Procureur de la République [Données non publiées],[Données non publiées]
+3e344b94-7d82-429b-a3d3-3fbbd378d80d,[Données non publiées],Retraité,Néant,
+3e374712-0e0c-474d-b73c-6e1c53168352,[Données non publiées],[Données non publiées],MENUISERIE,
+3e374712-0e0c-474d-b73c-6e1c53168352,[Données non publiées],[Données non publiées],MENUISERIE ALU,
+3e374712-0e0c-474d-b73c-6e1c53168352,[Données non publiées],[Données non publiées],HOLDING,
+3e374712-0e0c-474d-b73c-6e1c53168352,[Données non publiées],SCI [Données non publiées],IMMOBILIER,
+3e374712-0e0c-474d-b73c-6e1c53168352,[Données non publiées],SARL LA SABLIERE,Gestion d'équipements de loisirs et événementiel.,
+3e4a81b5-9e8b-4d15-b19e-dffefef1c20d,[Données non publiées],Néant,Retraité,
+3e51fef3-d389-4ea5-8e34-4f7db23afc1f,[Données non publiées],Groupe ADP,[Données non publiées],"En tant que conseiller départemental du Val de Marne, je prends l'engagement de ne participer à aucun débat ni vote concernant l'aéroport d'Orly."
+3e58efd5-0e6d-4448-9aa7-79bcaee3121a,[Données non publiées],Ville de Rennes,Technicien territorial - [Données non publiées],
+3e62e3bc-61b1-4f75-b24d-c482d3f55cfd,[Données non publiées],[Données non publiées],PROFESSEUR DE DANSE,
+3e65499e-6939-4132-b990-ae29c66b7d03,[Données non publiées],NANTES METROPOLE,agent,
+3e6f956c-b5ea-4391-98c4-9fcb37c71514,[Données non publiées],STMicroelectronics [Données non publiées] SAS,Cadre en Audit interne,
+3e73f2b2-5283-4e4b-9159-b394f6ff6bec,[Données non publiées],SELARL Pharmacie [Données non publiées],Pharmacien,[Données non publiées] membre du Conseil Municipal de la Ville de Troyes (en qualité de Maire Adjoint) et membre du Conseil Communautaire de Troyes Champagne Métropole.
+3e75a2b7-1eb7-4f10-b441-7c907306139d,[Données non publiées],Education nationale,Professeure des écoles,
+3e7c74a3-8c05-4b09-bf18-8cfc327193d8,[Données non publiées],Education Nationale,Professeur des Ecoles,
+3e7f5632-20fc-422e-9ff4-dfb755975bc6,[Données non publiées],Socité Dauphinoise de l'Habitat,[Données non publiées],
+3e8f54f8-9c8e-4d71-b67a-8328d4419e6e,[Données non publiées],Ville d'Evry-Courcouronnes,cabinet,
+3e91960b-e6cd-4574-ac3e-f7f16cd15aca,[Données non publiées],Médecin,Pédiatre Libéral,
+3e93166b-0bd8-4e8d-9991-2205ace7aba5,[Données non publiées],La Poste,Responsable commercial,
+3ea445ce-1127-415b-86cc-a30a9ba9ecd2,[Données non publiées],[Données non publiées],Agent relation abonnés,
+3eb50c60-c269-4548-be99-e0050137ef25,[Données non publiées],EI [Données non publiées],RESTAURATION RAPIDE,
+3eb77a70-0e34-4836-83ae-0d937766c684,[Données non publiées],NEANT,NÉANT,Avocat non inscrit
+3ebc27b5-aa99-42cf-b66e-80f1887acf49,[Données non publiées],Raise Partner,Cadre ingénieur,
+3ebc6006-8487-486f-8dcd-7224ea6a1438,[Données non publiées],NEANT,NÉANT,Avocat non inscrit
+3ebe9c2b-8834-4805-9b95-063f3a7896ac,[Données non publiées],EDUCATION NATIONALE,PRINCIPALE ADJOINTE DE COLLEGE,[Données non publiées]
+3ecdca0b-95e3-4d00-a095-ed752b25cdc1,[Données non publiées],néant,néant,retraitée
+3ee131ec-5bcd-424c-9c48-370c2e71dafa,[Données non publiées],CNFPT,Rédacteur principal [Données non publiées],[Données non publiées]
+3ee58047-4710-408f-9a5b-7f798f0a4d40,[Données non publiées],Ministere de l'intéreieur,Membre de la Police aux frontières,
+3efa12b5-a92b-4fec-899d-18ab9fe1f59f,[Données non publiées],Ministère du travail [Données non publiées],Inspectrice du travail,
+3f0572ba-8787-47ae-9102-1dcaf98dc271,[Données non publiées],CDOS [Données non publiées],secretaire,
+3f066bd1-2d02-41b9-b0cd-3cae5916025a,[Données non publiées],aucun,Aucune,[Données non publiées]
+3f067ada-080b-45e2-bd1a-d6e82b5f30df,[Données non publiées],néant,néant,[Données non publiées]
+3f081dab-a5da-4531-b8b5-d498009e332c,[Données non publiées],Centre Psychothérapique de l'Orne,Assistante Sociale [Données non publiées],
+3f0bb2b4-5d1e-48c9-bd6f-6f0292b20bfb,[Données non publiées],CHU [Données non publiées],Medecin Pédiatre,
+3f175f89-c63c-4f0e-923a-510edeef9d17,[Données non publiées],RETRAITEE,Fonctionnaire territoriale en retraite [Données non publiées],[Données non publiées]
+3f1ac39a-d364-4e8b-bee0-aadfb85ba77a,[Données non publiées],Reconquête !,Directrice de cabinet du Président,
+3f233649-7844-4c1e-ab67-7acd2c219ac6,[Données non publiées],SAS [Données non publiées],gérant,
+3f23d8a7-d82b-43e9-92b2-62ee88e658d2,[Données non publiées],AIR TAHITI NUI,Chef de cabine,
+3f2420ad-a962-4170-9d64-0c3ac64fcd0a,[Données non publiées],[Données non publiées],magasin de vetements,responsable salariee
+3f348413-05c8-4ed2-a14d-427a3ec2bc31,[Données non publiées],Pharmacie portes des alpes,Conseillère de vente,
+3f574919-936f-489c-90e3-444b15101824,[Données non publiées],NEANT,NEANT,RETRAITE
+3f5dc799-cfee-4084-aa54-2f7630e6efbd,[Données non publiées],Néant,Néant,[Données non publiées]
+3f5ebd1b-f403-40c2-94f6-7d867959e8f3,[Données non publiées],EDF,Ingénieur d'études,
+3f64c1b6-f12f-4d9c-bbe6-1cee2ea3eee9,[Données non publiées],CPAM [Données non publiées],[Données non publiées],
+3f6ea76a-f267-465d-a414-37d54f90b8db,[Données non publiées],Education nationale,Professeur des écoles,
+3f7d5ee8-c183-4023-87a5-fa44e48bee58,[Données non publiées],Centre Hospitalier de Brive,Médecin hospitalier,
+3f80fd49-60dc-4e07-917b-395b5ec1c0aa,[Données non publiées],Education Nationale,Enseignante,
+3f83719b-c420-4113-b142-6a7e5b0843cb,[Données non publiées],[Données non publiées],Consultant,[Données non publiées]
+3f85136d-8146-4926-8161-571993caf4d0,[Données non publiées],Société Générale,Chef de Projet,
+3f98dd6f-0bbc-4dfe-81fe-c21bbb97fd8b,[Données non publiées],[Données non publiées],conseil gestion administrative,[Données non publiées] autoentrepreneurs [Données non publiées]
+3f9abaf7-6e95-4b85-98a5-2b78ac721c78,[Données non publiées],orange,assistante [Données non publiées],
+3fb08345-ab2a-477e-9f03-e804f5ce932a,[Données non publiées],Education nationale,Enseignante,
+3fb4659d-86e2-4597-a89e-8f9064e17f47,[Données non publiées],Retraite,retraite,
+3fb4c169-6647-448b-a227-7d9c2e85d8e5,[Données non publiées],Nouvelle-Calédonie,Agent des services fiscaux,
+3fcca1c2-c11b-471f-9a87-befd88c02730,[Données non publiées],Lycée [Données non publiées],Infirmière scolaire,
+3fe2b84f-6b18-4b1b-b964-000b0c484cdf,[Données non publiées],néant,néant,
+3fee9b65-df4f-43c8-96d5-923c964a6600,[Données non publiées],Cooperl,Mécanicien,
+3ff3d91f-72ba-45df-a66a-25be640cd270,[Données non publiées],RETRAITE,NEANT,
+3ffc86dc-e2be-4708-b263-41a6f5fdbc54,[Données non publiées],Commune de FAAA,Agent administratif communal,
+4009d096-b406-4660-a95d-d623abb74b7e,[Données non publiées],Société FINET [Données non publiées],Comptable [Données non publiées],
+40145004-6fa4-448a-b595-94df13ff73f5,[Données non publiées],France Télévision,Journaliste,
+401bde79-53ab-4946-a04f-e6259ca92827,[Données non publiées],ghbs centre hospitalier,Infirmière,[Données non publiées]
+4028c818-13af-4f7e-93f1-abbdf82c6517,[Données non publiées],[Données non publiées],Architecte,
+4031019c-ba2f-4abb-901d-a4f74d60f7de,[Données non publiées],SELARL Hobson,Avocat Associé,[Données non publiées]
+403d25b3-d324-4bfa-a959-c5529010ccec,[Données non publiées],Retraite,NEANT,
+4045d1a8-1201-459b-b3fe-b783a2fc3075,[Données non publiées],[Données non publiées],gérant SARL CMEP [Données non publiées],[Données non publiées]
+404780d3-7675-4578-afc2-1b239df38435,[Données non publiées],Bordeaux Métropole,directrice [Données non publiées],
+40518f26-461a-47f9-8972-b044353390af,[Données non publiées],Néant,Retraité,
+405b1dc1-30ce-4dd9-8121-7286c68b8259,[Données non publiées],Région Auvergne Rhône Alpes,[Données non publiées],[Données non publiées]
+405b7e33-0645-411f-94ae-040aa3cf48ef,[Données non publiées],lui même,journaliste Président et directeur du journal Le petit mag Lens Liévin exploitant agricole [Données non publiées],[Données non publiées]
+4061fc2e-8c49-4d7c-a8f4-39a58179a59b,[Données non publiées],cabinet comptable CGFE,SALARIEE SECRETARIAT,[Données non publiées]
+4061fc2e-8c49-4d7c-a8f4-39a58179a59b,[Données non publiées],SCHNEIDER,AIDE MENAGERE,
+40692963-5dc5-4361-bc42-642e44164940,[Données non publiées],Initiative Terres d'Azur,Directrice.,
+406abef2-c9ab-485b-b51c-287c866f5f89,[Données non publiées],ITG CONSULTANTS,Ingénieure paysagiste [Données non publiées],
+406dbeb6-b7f4-41bc-bdfe-605e5602261b,[Données non publiées],SAS Bihannic,chargée de communication,
+40b19e83-09dd-412d-b1a4-5c49c13b1e5f,[Données non publiées],SARL [Données non publiées],Assistante administrative,A la retraite [Données non publiées]
+40b19e83-09dd-412d-b1a4-5c49c13b1e5f,[Données non publiées],Association [Données non publiées],Animatrice de la ludothèque [Données non publiées],A la retraite [Données non publiées]
+40b804ed-b05d-446b-9ff4-68e4793fa5b4,[Données non publiées],Conseil départemental,Agent Maison Départementale des Personnes Handicapées (MDPH),
+40bc985f-76b9-491f-8dfc-2d737a9d46ac,[Données non publiées],Reconquête,Fondateur et Président,
+40cb7966-51a2-4f68-8e75-80e71e18a970,[Données non publiées],CHU DE BORDEAUX,INFIRMIERE ANESTHESISTE [Données non publiées],
+40cda1b7-d8b8-4e43-b929-43732b3ae640,[Données non publiées],ECOLE SUPÉRIEURE D'ART DE LA RÉUNION,[Données non publiées],
+40d4313e-3aae-4560-9cc6-2def992eee5d,[Données non publiées],ETS LAVIALE,[Données non publiées],
+40d65446-7d93-4050-97b1-634e10744834,[Données non publiées],Département Seine-St-Denis,Elu local,
+40e07a8d-9eaa-40e2-b4fb-3193a94ad7ea,[Données non publiées],Parlementaire,Attachée parlementaire : mission terminée le 30 juillet 2021,
+40e392df-a79a-4d8e-91cd-4a79a9d0810e,[Données non publiées],NEANT,NEANT,
+40e91461-8136-4237-96a8-d9ba4eb2c053,[Données non publiées],Néant,Consultante - formatrice,
+40eff505-a6c0-414f-a854-c5e10913d337,[Données non publiées],[Données non publiées],Huissier de Justice,
+40f21e29-1af5-44bf-bccc-9be8d905ab05,[Données non publiées],Mairie [Données non publiées],Chargée de communication [Données non publiées],changement de poste en décembre 2021
+40f21e29-1af5-44bf-bccc-9be8d905ab05,[Données non publiées],Mairie [Données non publiées],Chef du service commnication et événementiel,Depuis le 01.01.2022
+40f9fb42-fb73-4098-b27a-895b030681c4,[Données non publiées],retraité,néant,[Données non publiées]
+40fa0be2-b665-496d-a82e-b8cc6f1851ba,[Données non publiées],[Données non publiées],Retraité,
+40fe9271-d7b3-4602-8057-878d525fbe68,[Données non publiées],Centre Commercial Européen,Gestionnaire Clients,
+40ffcbb4-5c92-4a30-a643-8ea8a2595fb6,[Données non publiées],Chemins de Fer de la Corse,Chef de train,[Données non publiées]
+410352e8-88f8-4750-9dd8-c21a5a0d32cc,[Données non publiées],Cherbourg en Cotentin,[Données non publiées],
+411dbf26-123d-4be3-88fc-b624cad5479c,[Données non publiées],EDUCATION NATIONALE,professeur,retraité
+41201522-75a9-490b-bd16-272a13429540,[Données non publiées],[Données non publiées],Dirigeant,
+41213508-0ede-4916-9dbb-2c5b04fdd2e8,[Données non publiées],Assemblée Nationale,Assistante parlementaire,
+41213508-0ede-4916-9dbb-2c5b04fdd2e8,,ASSEMBLEE NATIONALE,DEPUTE [Données non publiées],
+412aed5d-2184-4180-966a-edba9626abb2,[Données non publiées],Inspection académique,Enseignante,
+412fdffc-69c7-4578-997a-52056d407ee1,[Données non publiées],profession libérale,Psychothérapeute,
+413067e3-7ae0-48b8-9ff2-0a7514bf94c1,[Données non publiées],EPLEFPA [Données non publiées],animateur financier,
+41389911-33f4-4576-8f51-dcfc2ff9d5c2,[Données non publiées],REGION REUNION,FONCTIONNAIRE TERRITORIAL,
+413d1467-b083-40d0-b9f5-8c8c36a4002d,[Données non publiées],SAS MITJAVILA,Employée de bureau,
+414117b4-ed68-4107-9daf-9271c5812963,[Données non publiées],Office HLM [Données non publiées],Directrice de l'office des HLM [Données non publiées],
+4143bef2-9455-424f-91cc-841dd992be00,[Données non publiées],Pays de Montbéliard Agglomération,Fonctionnaire territorial,
+414599c5-34ea-410d-b586-a816eac6824d,[Données non publiées],néant,néant,
+414d69ec-bbf7-4f3a-ae77-7ebdef716e14,[Données non publiées],Centre hospitalier de la Bresse Louhannaise,infirmière,
+414ea165-9001-4e4d-8b32-756f2bbc11f5,[Données non publiées],AGRIAL,Cadre commercial agroalimentaire,
+415412e6-05fc-4e6a-b832-d71282bd6906,[Données non publiées],Groupe Saint-Sauveur,DAF,
+41661b11-a3e3-400d-b386-7d3ce8451ed5,[Données non publiées],Préfecture des Côtes d'Armor,Chargé de mission [Données non publiées],
+41670ecf-1d82-44c4-bab3-1b3c92a1bce3,[Données non publiées],Rectorat,Secrétaire administrative dans un lycée,
+417aca44-2f55-4508-858d-b8ecb72ef32f,[Données non publiées],[Données non publiées],vente de vins,[Données non publiées]
+418b7705-d5c0-4808-8a71-7166bf724845,[Données non publiées],[Données non publiées] CONSULTING SAS,Chef d'entreprise salariée,Agence de communication
+41919747-65d2-4203-b709-ed31cab3b712,[Données non publiées],Centre Hospitalier [Données non publiées],Médecin spécialiste en imagerie médicale,
+41a1ec0a-ec7b-471b-a301-617477daff2c,[Données non publiées],Auto-entrepreneur,Editrice,
+41a27b1a-24ba-4d0b-aa29-6cc83948dc3e,[Données non publiées],ministère de la justice,Juge,
+41a681fc-a9dd-479c-ad9d-49a5264845e2,[Données non publiées],Mairie d'Hénin-Beaumont,maire et conseiller départemental,
+41a6aee4-fcbb-4ae7-9be3-55655defa53b,[Données non publiées],Ministère Education Nationale,Professeure des écoles,
+41aa1910-3aa7-4287-9d87-9004f85f5d25,[Données non publiées],AFCCRE,Cadre au sein d'une association de collectivités territoriales spécialisée dans les affaires européennes et la coopération internationale,
+41aa521a-9d30-43f8-b06c-74a690b925a0,[Données non publiées],néant,néant,
+41bf7089-db08-4fd2-b9f9-8cdb398d62b9,[Données non publiées],EHPAD LAGUEPIE,Annimatrice,
+41c09df0-08de-4f38-906c-3b24fbb16228,[Données non publiées],CHRU de Tours,Cadre de santé,
+41c52d40-d93b-4499-ad32-773c6a4d6dd6,[Données non publiées],CIC,Conseillère Clientèle,
+41c66c04-75ec-4020-ac5b-ddf375a29ff4,[Données non publiées],RETRAITEE,RETRAITEE AGRICOLE,
+41ce7cbf-8e4c-4868-8562-be24fba71812,[Données non publiées],Lycée [Données non publiées],Enseignante,
+41db8164-4cbe-4b18-b36c-a53f0329a0b8,[Données non publiées],Profession libérale,Kinésithérapeute,
+41defcfd-e992-4b22-bb69-a7efc5853245,[Données non publiées],Retraitée,Retraitée,[Données non publiées]
+41eca22e-29f5-4b95-bfa4-82a8347c4223,[Données non publiées],Education Nationale,Professeur des écoles et Directrice d'école,
+41ee0c66-4de6-4c00-99a6-4b9cac071e5b,[Données non publiées],profession libérale,Medecin pneumologue,
+420174e6-6ef0-41a1-a287-20b25b96a3ff,[Données non publiées],CD [Données non publiées],[Données non publiées],
+42060d9a-4847-45fb-975c-af02eb011c42,[Données non publiées],sans,neant,
+420e09cd-e869-44a9-a179-b4cfd0ebe59a,[Données non publiées],[Données non publiées],"expert-comptable, associé et co-gérant de la société [Données non publiées]",[Données non publiées]
+4215e34e-0b54-4824-9837-33c75eb066b9,[Données non publiées],SOITEC,Ingénieur,
+42174c9d-821e-455d-b7be-292f5c4adfc7,[Données non publiées],La Banque Postale,chargée de clientèle spécialisée,
+421b0ba8-b030-4070-a1fe-c41c7c98b98c,[Données non publiées],Auto-entrepreneur,Activités de soutien à l'enseignement,
+4220afb8-25b0-4895-b01b-6887657d1988,[Données non publiées],[Données non publiées],[Données non publiées],Retraité [Données non publiées]
+423d35e3-a1a4-4b42-a209-678e9c0c85fa,[Données non publiées],Communauté de communes [Données non publiées],Directrice générale des services,
+4242136a-fb8e-4e80-bdac-2781c32a4eac,[Données non publiées],[Données non publiées],AVOCATE,
+424ef515-9b70-4273-884b-0e98ea348280,[Données non publiées],COVEA (assurance MMA),gestionnaire de sinistres,
+4252f6c9-dc00-45c9-a645-bfdca58d8ce9,[Données non publiées],SPA Destribats Dax,"Chef magasinier, [Données non publiées]",
+42614c47-e132-48e4-98ae-2195304d559c,[Données non publiées],[Données non publiées],entreprise &gro alimentaire Directeur technique,[Données non publiées]
+4278fd1e-d7c0-41da-936b-7d5f69b60446,[Données non publiées],SARL [Données non publiées],Employée d'optique,
+427f95ad-1a3c-412a-9bf5-3be5a44ca137,[Données non publiées],Sony Music,[Données non publiées],
+4284353f-7697-454e-b2e1-243f067cd554,[Données non publiées],Néant,Néant,
+4293e216-ef4b-45e3-b03c-834d69d162e2,[Données non publiées],[Données non publiées],conseillère de vente en librairie,
+429c6119-d71c-41c0-b8f2-69bb98844ab3,[Données non publiées],néant,retraitée,
+42a2bc29-1e57-405d-b96a-e461e6612105,[Données non publiées],centre hospitalier [Données non publiées],praticien hospitalier,
+42af7d6f-48d8-4634-9c83-0c4a4db2e95d,[Données non publiées],Communauté d'Agglomération Hérault Méditerranée,Responsable du Service [Données non publiées],
+42bbb83a-bc49-4bef-8598-4a45cfd5bcd6,[Données non publiées],Néant,Aide-soignant,
+42bea17b-da28-4cf4-800f-cd47b1d3fc10,[Données non publiées],Education nationale,Professeur des écoles,
+42bf6ea5-2b37-4c18-ad15-9732ad4f3302,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] En retraite [Données non publiées]
+42d27b67-b5c2-44ff-89a5-d567765877fa,[Données non publiées],[Données non publiées],[Données non publiées],RETRAITEE [Données non publiées]
+42e405a2-8629-4cd1-9a78-a8c657b10747,[Données non publiées],co-gérant du Gaec [Données non publiées],co-gérant d'une société agricole,
+42f53b32-0156-4b1a-a1ee-208089a3d02b,[Données non publiées],BCI,Guichettière,
+42fd8ddb-6d26-4a27-9de8-89df6890af78,[Données non publiées],EXPLOITANT AGRICOLE,[Données non publiées],
+43009288-7fb3-4754-94bd-92dac301fd6f,[Données non publiées],courtier,assurance,[Données non publiées]
+43043f55-2ea6-4897-be41-bc0686d20b4a,[Données non publiées],Education nationale,Professeur vacataire,
+4304915d-6d16-4016-bdfa-a3b78b66aae8,[Données non publiées],Association [Données non publiées],Educatrice spécialisée,
+430b9399-dcf3-400c-87d0-d51c0b2a51e0,[Données non publiées],Ville de Marseille,Service Ressources Humaines des écoles. [Données non publiées],
+43144a32-bf13-4095-ba77-7dfe77d06b55,[Données non publiées],Côte d'Azur Habitat,Cadre,[Données non publiées]
+431a8175-1dcf-4633-9737-ead5546e3807,[Données non publiées],aucun,retraitée,retraitée
+432382d7-eb8f-4c85-8e94-80ecfd315481,[Données non publiées],Pianos Hanlet,[Données non publiées],
+43397e45-0faf-480c-8784-ec74a5e16862,[Données non publiées],BNP Paribas,[Données non publiées] [Données non publiées],
+4342b851-60ab-476f-8efb-2116b81db7e0,[Données non publiées],Natixis,Cadre bancaire,
+434c3101-75bd-4011-9e9a-637732ceab49,[Données non publiées],néant,néant,
+434c426d-211f-4a2b-bfbc-7c266c8892d5,[Données non publiées],education nationale,professeur des écoles,en retraite [Données non publiées]
+435adc5a-317c-4af4-b605-401d833c045d,[Données non publiées],CPAM de l'Eure,[Données non publiées],
+436b57af-1f7c-410f-920f-588795f46baf,[Données non publiées],lui même,journaliste Président et directeur du journal Le petit mag Lens Liévin exploitant agricole [Données non publiées],[Données non publiées]
+436c9220-7037-4364-ae9b-3bd440b286de,[Données non publiées],BPALC,[Données non publiées],
+4378d42d-7891-40d8-b329-25e258f04225,[Données non publiées],SARL San Firmin,Responsable [Données non publiées],
+43802413-cfc8-438c-a2d6-709edac0fbfd,[Données non publiées],RETRAITE,RETAITE,
+43836291-a753-49e8-a754-99bf38ae362b,[Données non publiées],EDF,QSE /Chargé d'affaires,
+4399fc77-faeb-4b7a-97e9-0dbcbfe004a9,[Données non publiées],[Données non publiées],COMMERCANT AMBULANT,auto entrepreneur et intérim
+439bc3de-7e86-44ab-941a-689d74439cfe,[Données non publiées],Etude notarial [Données non publiées],Notaire,
+439e05c8-c548-4e92-8c78-b481b03814f6,[Données non publiées],Mairie d'Hénin-Beaumont,Secrétaire [Données non publiées],
+43a30e9c-fe29-422b-8f08-dcc417366477,[Données non publiées],ADAVIE,Employée à domicile,
+43a5c83c-4c87-4630-b73e-b0a00892deb6,[Données non publiées],Sénat,[Données non publiées],
+43abfd64-edaa-4192-b610-5bb45401701d,[Données non publiées],UGECAM Lille,[Données non publiées],
+43ad51c3-934e-4b62-bebf-6ff7c671e3fb,[Données non publiées],[Données non publiées],Cabinet dentaire,
+43ae6123-1383-485b-9582-6dc55f3c3e30,[Données non publiées],PROMAN,[Données non publiées],
+43b00afe-d5c1-4d58-85c4-526a9c932476,[Données non publiées],[Données non publiées],chargée de communication au crédit agricole [Données non publiées],
+43cb752b-df2f-481d-8b80-1080f75fc1eb,[Données non publiées],Evel'Up,[Données non publiées],
+43cf4432-6136-4721-ace9-55e20d3ea029,[Données non publiées],Profession libérale,Masseur Kinésithérapeute,
+43d9beaa-95ca-41ed-a323-178ddbb9c3ec,[Données non publiées],Kaleido'scop,[Données non publiées],
+43eacc30-3de3-454d-bdf2-5a00892cae4a,[Données non publiées],La Banque Postale,chargée de clientèle [Données non publiées],
+43ec14be-b48e-40d7-8bbb-e0578835ab1b,[Données non publiées],Groupe CISN,[Données non publiées],[Données non publiées]
+43f8a235-6d22-4996-86c7-a87099c842f6,[Données non publiées],[Données non publiées],location/gestion d'appartements meublés,
+4400bb32-14c0-4461-b427-e9ed5912a067,[Données non publiées],agriculteur,agriculture,
+44068f23-fea1-4f5f-837b-5d91c1cc37dd,[Données non publiées],kingfischer,Acheteuse bois [Données non publiées],
+4409b127-d14f-44a8-a1b1-15fcc4fec9ca,[Données non publiées],Onrangetout,Gérante [Données non publiées],
+440f90a5-63b7-4c66-bfae-06c17829adc3,[Données non publiées],néant,retraité,
+441e7d01-c6f8-4932-937e-43c08f455113,[Données non publiées],Communauté d'agglomération Grand Angoulême,Professeur [Données non publiées] Conservatoire Grand Angoulême,
+441e7d01-c6f8-4932-937e-43c08f455113,[Données non publiées],Orchestre Chambre Nouvelle Aquitaine,[Données non publiées],
+44258a90-38f1-4114-8b4b-efaf02b3629f,[Données non publiées],MAIRIE [Données non publiées],Agent administratif,[Données non publiées]
+44293d79-07b1-41be-a7b3-995ae0cb963e,[Données non publiées],EURA ENERGIE,Responsable de communication,
+44293d79-07b1-41be-a7b3-995ae0cb963e,[Données non publiées],[Données non publiées],[Données non publiées],
+44442163-ab1c-4677-8258-23336ea8f000,[Données non publiées],MINISTERE DE LA JUSTICE,SURVEILLANT PENITENTIAIRE,
+4465bfb0-1a60-431b-8914-3e2c887210ab,[Données non publiées],[Données non publiées],gestion parc immobilier,
+446617f9-695a-4b84-a4d3-506c7b4dc916,[Données non publiées],Néant,Néant,
+44671d21-3f40-4399-a55b-25d6dd579b43,[Données non publiées],UNIVERSITE [Données non publiées],MAITRESSE DE CONFERENCE,
+4469678f-4d92-47ac-a7d3-f5fa357252ba,[Données non publiées],retraitée,Retraitée,
+446d7c21-a9fb-4470-b3c3-d78b5837ee98,[Données non publiées],EDUCATION NATIONALE,ENSEIGNANTE EN ANGLAIS,
+447136cc-b293-4944-a59c-ddffd7b219fc,[Données non publiées],Fonctionnaire terrioritale,[Données non publiées] DRH,
+4472c4ce-dd03-4641-a77e-19ea1f5397b7,[Données non publiées],pharmacie [Données non publiées],Préparatrice en pharmacie,
+44776e0e-7472-40c3-8be8-e2588314aa65,[Données non publiées],CENTRE HOSPITALIER DE LA LOUPE,Attachée d'Administration Hospitalière,
+447bb581-9040-4c4a-9cd7-d8e8ca388ea6,[Données non publiées],Libéral + APHP,Urgences médicales à domicile en libéral Urgences à l'hôpital en salariée,
+448220dc-f535-4559-9028-7d98f22647dc,[Données non publiées],Avocate,Avocate,avocate en droit public [Données non publiées]
+44df96f3-b507-4ff5-8259-6c42ebbb7038,[Données non publiées],Néant,Néant,Retraité depuis 2007
+44e5fca3-5c32-483f-b605-3822790fb187,[Données non publiées],Métropole du Grand Lyon,Directeur de cabinet,
+44fa736e-958a-4a47-a6a4-ab8e4b28b9b8,[Données non publiées],General Electric,Technicien Qualité,
+44fbcb6c-ced0-44c5-bc2b-bd3a69721ba5,[Données non publiées],néant,néant,
+44fc9d44-aed2-418d-b440-37b4eeb5c4c8,[Données non publiées],Département 13,Fonctionnaire,[Données non publiées] auto-entrepreneur (en sus) [Données non publiées] activité de conseils en communication optimisation et management [Données non publiées]
+44ffccf3-2d4b-4ca9-b937-9c2b12bc04a2,[Données non publiées],Dinh Van,Responsable commerciale,
+450f5889-924f-487c-a341-84d5bffc8b48,[Données non publiées],Département de la Seine-Maritime,Instructeur social,[Données non publiées]
+45102d27-e15c-44cc-85eb-6735460d866b,[Données non publiées],néant,néant,
+4511ee67-ff9f-44ef-90c0-5306b5ca5aa7,[Données non publiées],Education Nationale,Professeur des Ecoles,
+451c3ef7-8f3d-4d3f-85fe-0b24bac28d7b,[Données non publiées],BRASSERIE DE BOURBON,[Données non publiées],
+451c9e27-4e8f-4654-9101-f45f986455ef,[Données non publiées],Maitre coq,[Données non publiées],
+451dada1-6d20-49a8-8c10-5427ab80c2df,[Données non publiées],neant,neant,
+452c2d8b-3a8d-409f-b3e7-93039b5ba4e9,[Données non publiées],Néant,Néant,
+45387237-a0b0-4e66-b3b5-db6ad1abb98d,[Données non publiées],BREST METROPOLE,[Données non publiées],[Données non publiées]
+45410dfb-36b4-4f51-b3a9-cd6cf0b5b26c,[Données non publiées],Sans emploi,Néant,[Données non publiées]
+45410dfb-36b4-4f51-b3a9-cd6cf0b5b26c,[Données non publiées],Ville de Canteleu,Maire,[Données non publiées]
+45410dfb-36b4-4f51-b3a9-cd6cf0b5b26c,[Données non publiées],Région Normandie,Conseillère régionale,Il ne s'agit pas d'une activité professionnelle mais d'un mandat électif rémunéré [Données non publiées]
+45410dfb-36b4-4f51-b3a9-cd6cf0b5b26c,[Données non publiées],Métropole Rouen Normandie,Conseillère métropolitaine,Il ne s'agit pas d'une activité professionnelle mais d'un mandat électif rémunéré [Données non publiées]
+45410dfb-36b4-4f51-b3a9-cd6cf0b5b26c,[Données non publiées],LOGEAL,Membre du conseil d'administration,Il ne s'agit pas d'une activité professionnelle mais d'un mandat d'administrateur (non rémunéré).
+45410dfb-36b4-4f51-b3a9-cd6cf0b5b26c,[Données non publiées],HABITAT 76,Membre du conseil d'administration,Il ne s'agit pas d'une activité professionnelle mais d'un mandat d'administrateur (non rémunéré).
+45410dfb-36b4-4f51-b3a9-cd6cf0b5b26c,[Données non publiées],CCAS de Canteleu,Présidente du Conseil d'administration,Il ne s'agit pas d'une activité professionnelle mais d'un mandat d'administrateur (non rémunéré).
+45410dfb-36b4-4f51-b3a9-cd6cf0b5b26c,[Données non publiées],Centre de Gestion de la Fonction Publique Territoriale,Membre du conseil d'administration,Il ne s'agit pas d'une activité professionnelle mais d'un mandat d'administrateur (non rémunéré).
+45463e21-fc54-4470-9c26-8bfae3b7edf0,[Données non publiées],Neant,Artisan jardinier,ARRET DE L ACTIVITE [Données non publiées]
+4546c7e9-c7f2-4b6f-97d8-f2d5700269b4,[Données non publiées],elle même,docteur en pharmacie,exerce comme pharmacien en milieu rural
+45512631-4fa8-4b3a-a684-3c0b6e4c17ba,[Données non publiées],Exercice libéral,Médecin généraliste spécialisé dans les urgences et les traumatismes.,Egalement associé dans la société AKI 3D société spécialisée dans les orthèses réalisées en 3D
+455b1255-8d30-434f-8e02-4d6a8ba086f9,[Données non publiées],Ville de Dijon,Direction des Musées [Données non publiées],
+455d43fe-ae4e-4889-8049-27d25efbb566,[Données non publiées],MAIRIE DE LANESTER,[Données non publiées],[Données non publiées]
+45641c39-1892-46e6-a3c5-1fc61c6cc9cc,[Données non publiées],Parlement européen,Député européen,
+45665808-08a4-43b9-b6ee-973f1a5e5fe9,[Données non publiées],profession libérale,activité médicale,
+4566d7da-fdd6-43d7-9fc5-04435933064e,[Données non publiées],MINISTERE INTERIEUR,POLICIER,
+4567e638-7893-403e-a36b-fdfd6238004c,[Données non publiées],Centre Hospitalier [Données non publiées],Manipulatrice [Données non publiées],
+456b1e8d-5258-4728-8fa4-6f5a8e8584c0,[Données non publiées],Département de Loire-Atlantique,Attaché Territorial,
+45781b63-d8e6-45ea-944d-41e2f3b180d2,[Données non publiées],néant,Néant,[Données non publiées]
+458f5c09-cd26-4aeb-9928-0eb4d3d064ff,[Données non publiées],autoentrepreneur,psychologue,
+45911303-1d4d-40f6-aad8-6b8daab74108,[Données non publiées],SAS Bihannic,chargée de communication,
+459a5487-e13f-46d7-baf8-926cabd16e67,[Données non publiées],SANS,SANS,
+45aec0d4-92e9-4ba0-9a6d-6f37dfc1bc96,[Données non publiées],Sas Fd Arnaud,[Données non publiées],
+45b3fba1-33c1-4c66-b8b4-9bfe953f52bf,[Données non publiées],AVOCAT,AVOCAT,
+45bbdfac-6db2-487f-8720-325a114ee324,[Données non publiées],Préfecture de l'Oise,"Attachée principale, [Données non publiées]",
+45bc924e-615f-4ff6-ad3c-8bd920d12a0c,[Données non publiées],AP-HM,PUPH radio-pédiatrie [Données non publiées],
+45c96133-5f22-425b-b6f7-4624370c305d,[Données non publiées],[Données non publiées],[Données non publiées],En retraite [Données non publiées]
+45d0ea8a-150b-4a18-bd59-763697a0ff81,[Données non publiées],sas [Données non publiées],Travaux administratifs et participation aux travaux d'élevage,
+45d899f1-b85e-402d-a236-a22055ad2f8d,[Données non publiées],Département de l’Isère,Infirmier,
+45d92267-fe81-42af-84a5-4bfc831e4ab3,[Données non publiées],Enseignement privé de la Drôme,Enseignante,
+45e4c8e5-8827-4c55-8c7c-32079f8b11eb,[Données non publiées],retraitée,[Données non publiées],
+45e7c1fe-58cc-45fd-944c-5fcfcc2b334f,[Données non publiées],[Données non publiées],[Données non publiées],Retraitée
+45ea6625-1b91-4388-a457-304881919a81,[Données non publiées],[Données non publiées],gerant de societée,
+45f870c5-d08c-4f57-898c-b0344673f6b5,[Données non publiées],Mairie de Gennevilliers,Professeur d'enseignement artistique [Données non publiées],
+46165c30-bb3f-4c87-ad7b-6afb7aad762f,[Données non publiées],ENEDIS,[Données non publiées],
+4616e62e-5795-4a47-89a9-d5b3d9fd64c3,[Données non publiées],EDUCATION NATIONALE,ENSEIGNEMENT,
+461885aa-3a05-45d8-8b71-140597d71a80,[Données non publiées],Journaliste auteure et conférencière,[Données non publiées],
+461ec2ee-58dd-48ef-9bb9-321e86a225fc,[Données non publiées],AUCUN,AUCUNE,
+4627a18f-ac3d-420d-a6cf-a4e0133c2343,[Données non publiées],Sans,Retraité,
+4629f70f-1da3-4e4a-9d0e-18c6d879818e,[Données non publiées],honewell aérospace toulouse,responsable [Données non publiées],
+462fdf2a-4691-4dd0-b311-3c807046bfa5,[Données non publiées],Crédit Agricole [Données non publiées],Directrice d'agence Bancaire,
+46306bbb-1db9-4c89-b62f-3d144e40abe2,[Données non publiées],AP-HP,Infirmière,
+4638168d-d156-49cc-b94e-9ac4b50e26e8,[Données non publiées],Mairie de Paris,Maire de Paris Vice-présidente de la MGP Présidente de la Société de Livraison des Ouvrages Olympiques Vice-présidente du COJO Présidente de l'AIMF Présidente du Conseil de Surveillance de l'AP-HP Membre du C40 cities climate leadership group Co-présidente de CGLU Membre de France Urbaine Membre de l'AMF,
+4643a895-f2b1-4318-a78a-fa526f122829,[Données non publiées],Retraitée,[Données non publiées],
+464699c4-95b1-4272-b98d-b541d0b40e80,[Données non publiées],auto entrepreneur,activités bien être,
+464c524f-8b84-4807-8ac0-a8ddbf0385ef,[Données non publiées],SCP,VETERINAIRE,
+46512d66-f758-4f95-9ee7-d1a7355da6ea,[Données non publiées],Naegelen SAS,Responsable Administratif et Financier,
+46521945-3376-4255-958e-a327e06bde8a,[Données non publiées],Education Nationale,Directeur de Segpa,
+465997bd-607f-4793-bc1e-1034c61dc950,[Données non publiées],CAMG,Directrice des ressources humaines,
+465b5273-ca9e-4fd6-8eb5-08fe1817a397,[Données non publiées],ASSOCIATION AGARDOM,Auxiliaire de vie ou aide à domicile,
+465de37d-b961-4aab-8070-f75e26acf0e2,[Données non publiées],retraité,[Données non publiées],
+4665c51a-b120-4741-ba67-ad0e63fb0890,[Données non publiées],néant,néant,Retraitée de l'administration territoriale
+4666e1e3-291a-430e-8a25-a1ba36122b87,[Données non publiées],Caisse d allocations familiales de l'Aude,chargé de conseil et de développement . Coordinatrice Petite Enfance,
+4682d74f-c9bf-467b-aea7-539a7a06b8cb,[Données non publiées],Ville d'Etampes,Directrice de la politique de la Ville,[Données non publiées]
+46898dd0-2753-4a49-9202-f3c9c3ee1380,[Données non publiées],VUITTON,[Données non publiées],[Données non publiées]
+46bbba89-6319-41a3-af5a-5d0364c1396a,[Données non publiées],Association GDR,Collaboratrice,
+46bbba89-6319-41a3-af5a-5d0364c1396a,[Données non publiées],André Chassaigne,Attachée parlementaire,
+46bdeb15-750b-4e68-b499-0c1af010275c,[Données non publiées],Éducation nationale,Enseignante lycée,
+46c3ed69-62bb-4bc2-bd1a-fe879d1642e2,[Données non publiées],retraité,[Données non publiées],[Données non publiées]
+46c59b7e-6493-4ec0-976f-303280e75fbc,[Données non publiées],Federazione Italiana Sport Equestri,Consultant,
+46de488d-7e16-4979-b68f-8b2ecaba3d7f,[Données non publiées],SED,responsable technique en muséologie,
+46e63284-3037-44f9-bdb3-50d709a9e119,[Données non publiées],Conseil régional d'IDF,élue,
+46ec9747-613a-4b45-9c4b-5a06521a9a5e,[Données non publiées],Ministère de l'éducation nationale,Professeur certifié d'histoire-géographie,
+46f17be8-9672-464b-abe6-cf6ff00cc831,[Données non publiées],Retraité,[Données non publiées],
+46f79697-ca0a-4bd8-89c9-9397e58356e7,[Données non publiées],Redimm,Conseil en immobilier,
+46fd7bf0-f5c5-4fc4-8223-4f35d45e1c57,[Données non publiées],Université de Caen Normandie,Maîtresse de conférences,
+47003a83-11b1-4775-ba98-c6848fe6c445,[Données non publiées],Conseil départemental de la Manche,Cadre Médicale Sociale,[Données non publiées]
+47030627-e15b-4bc3-b2d0-df4ed92dc230,[Données non publiées],ASTRAZENECA,Responsable Médical Régional,
+470dfbb8-d751-42a5-9432-27ef21690b0a,[Données non publiées],Retraitée,Néant,
+470eb344-e433-477c-8dd0-a7a2f8aa1bad,[Données non publiées],Ministère de l'Education Nationale,Professeure des écoles,
+470f1f94-795b-4175-b579-bf63995d005d,[Données non publiées],NEANT,NEANT,[Données non publiées]
+471182c6-f4e3-48e8-baf4-b19ce503e6b7,[Données non publiées],La banque postale,Conseiller clientèle,[Données non publiées]
+471377c7-4a0e-425c-bf04-9ab896219b88,[Données non publiées],[Données non publiées],Pharmacien titulaire d'une officine de Pharmacie,
+47182182-2580-42be-b583-fdac6874b2be,[Données non publiées],Cab,secretaire [Données non publiées],
+473487f1-0d46-46d0-ba10-7e500fd2ab5e,[Données non publiées],EDUCATION NATIONALE,Professeur d'histoire et géographie,
+473e2e4b-12b9-4ed0-bb57-ddd4477b908a,[Données non publiées],Artic 42,Pharmacien [Données non publiées],[Données non publiées]
+47410799-9b86-4c8e-9a43-10da2171fbe9,[Données non publiées],Groupe Abbvie,[Données non publiées],
+47492ce1-8f36-4063-be25-f45660652c07,[Données non publiées],Profession libérale,Médecin,
+4760d532-5c01-4ba3-a63f-4cd2bbb66560,[Données non publiées],France Television,Rédacteur en chef adjoint [Données non publiées],
+47701de0-c9af-46dd-b4b5-bed5c1133e54,[Données non publiées],Hopital Beauséjour,Médecin [Données non publiées],
+47800c03-c618-4906-9adc-89918ec3ad2f,[Données non publiées],La Poste,Conseillère aux particuliers,
+47800c03-c618-4906-9adc-89918ec3ad2f,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] retraitée
+478192ee-a42b-4243-97db-981b14542998,[Données non publiées],FLOWBIRD,Comptable,
+47827b87-f9c3-41a4-87c3-50fdc4b8278f,[Données non publiées],EDF,[Données non publiées] Retraite [Données non publiées],
+4783e18f-25dc-4936-b649-9c222f1d6454,[Données non publiées],[Données non publiées],Participation,
+47889506-a1cd-46f0-aa81-82cd0eaaa33c,[Données non publiées],GAEC [Données non publiées],Salariée d'élevage et administratif,
+47889a71-9ddc-49ed-b07f-46694daeff0c,[Données non publiées],[Données non publiées],"caissiere ventre de produits pour jardinage, animaux agriculture",
+478ffba0-00d8-40b9-99f1-498f0f63520e,[Données non publiées],Fédération nationales des SCoT,Directrice de structure [Données non publiées],[Données non publiées]
+4792d79c-b229-452b-9c31-fe4ba32d84dd,[Données non publiées],mairie de chesny,[Données non publiées],
+4794faad-da62-40f8-a76d-8e05539adeb8,[Données non publiées],CNP Assurances,[Données non publiées],
+479f9ed7-2a39-40ab-b183-1388ab86b20d,[Données non publiées],néant,retraitée,néant
+47a53cb9-60de-4a01-8c7d-52f6263f0e98,[Données non publiées],néant,néant,[Données non publiées]
+47ac2355-bd71-40c9-bf95-3f3db5ffddce,[Données non publiées],Sénat,Assistant parlementaire,
+47b8b8ee-f4f5-4103-91f7-7e771e87d20b,[Données non publiées],Assemblée_Nationale [Données non publiées],Attachée_Parlementaire,
+47c8008c-68aa-435a-8f4a-0b165022b752,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] retraite [Données non publiées]
+47d197d4-a4a1-48df-8b60-035e8462e46b,[Données non publiées],[Données non publiées],cabinet d'orthophonie libéral,
+47d483af-b00f-4283-81a3-0d0ee8af47e3,[Données non publiées],Ville de Pantin,[Données non publiées],
+47e0fae9-97c5-45a2-aaee-457e34d026b5,[Données non publiées],Travailleur indépendant,Moniteur de ski et guide de haute montagne,
+47e881a7-1a2b-41f2-b18c-87cb47819061,[Données non publiées],Indépendant,Médecine Gynecologique,
+47ecca20-c304-4f16-83df-bc73f303f265,[Données non publiées],néant,Intermittente du spectacle,
+47f26b36-9b25-4bbe-be5a-e8f4b8f605e1,[Données non publiées],Hôpital [Données non publiées],Directeur Général Adjoint,
+47fdeec3-9222-434e-83dc-c0b86a1f502d,[Données non publiées],conseil général de l'yonne,infirmiere,
+48023fef-cc1a-4da3-971f-ffa5bd663f6c,[Données non publiées],Education nationale,professeur d'Histoire-Géographie,
+48129e24-96c1-4ec3-8269-0b527ba68ac8,[Données non publiées],etablissement public du Louvre,Administratrice générale adjointe,
+48174cb6-b018-4eb9-adcd-355941c3ea58,[Données non publiées],HOTEL LE GUANAHANI,[Données non publiées] CONCIERGE,
+4825d205-21a8-4b4f-8e23-aafb39d61b3a,[Données non publiées],Intermittent du spectacle,Artiste de spectacle vivant (magicien)Comédien,
+482a3abc-254e-47bf-9e5a-2bad28f8e460,[Données non publiées],BIOROCK,COMMERCIAL,
+482efddb-70e9-46af-94ba-7e72e3e38a82,[Données non publiées],Université Jean Monnet,Ingénieur d'études,
+4837974c-cad6-4c78-9653-9ea1d09bc4e0,[Données non publiées],Neant,Retraite,
+4837f8e4-71c0-401b-afe2-33330f135cf7,[Données non publiées],CANCE,conducteur-travaux,[Données non publiées]
+483a9c67-e53b-4cf1-bc97-90f03f916645,[Données non publiées],INSEE,[Données non publiées],
+484bf122-ac4b-4723-87a3-bb19f73d026f,[Données non publiées],profession libérale,vétérinaire,[Données non publiées]
+484f3bf7-a235-4e16-a6a0-9ec2feb032b0,[Données non publiées],[Données non publiées],Administrateur Réseau Systèmes d'information Finances,
+48530332-0539-4a05-bfa6-6995f6e92926,[Données non publiées],EPLEFPA [Données non publiées],[Données non publiées],
+4862bd27-ec22-4050-905d-6dd7b32eacd0,[Données non publiées],La Banque Postale,chargée de clientèle [Données non publiées],
+4869b1d7-b1d6-4539-b0d5-d5f7c2833c92,[Données non publiées],CHRU de Brest,Vaguemestre [Données non publiées],[Données non publiées]
+486ad1dd-aa5c-4ff9-8742-81e4646dcdb3,[Données non publiées],[Données non publiées],AUTOENTREPRENEUR,Neant
+486c9864-8e23-4789-b2d3-01b8b2f0cf5d,[Données non publiées],Vetea Conseil,[Données non publiées],
+486c9864-8e23-4789-b2d3-01b8b2f0cf5d,[Données non publiées],Open Lande,[Données non publiées],
+486e4fc9-3c60-4a88-a1f9-6c0c6f2f7479,[Données non publiées],MINISTERE DE L'EDUCTATION,PROFESSEURE DES ECOLES,
+48717dd2-ef72-4454-9c7c-89e8a6c14e26,[Données non publiées],ACR,Responsable [Données non publiées],
+48812683-835d-4eaf-bf4b-5969097b0c80,[Données non publiées],Descours&Cabaud,[Données non publiées],
+488604f9-8da5-43a8-af19-751ff76b89d1,[Données non publiées],Conseil Départemental 89,[Données non publiées] Cadre de santé [Données non publiées],Toujours en activité à ce jour.
+488cd850-ac40-4753-803e-aa0ba22c9c16,[Données non publiées],néant,Retraitée de l'Education nationale,
+489022d6-1ee5-45d7-abeb-0f05038d5e91,[Données non publiées],Université Grenoble Alpes,[Données non publiées],
+489bd999-3834-42d2-a6ad-3fd303662e7b,[Données non publiées],Retraitée,Néant,
+489cb3dc-7a2b-43ab-bb45-940e54b07745,[Données non publiées],Ministère de l'économie et des finances,Directeur de projet [Données non publiées],
+48a4765a-490c-4474-81b0-cf74814bd5b0,[Données non publiées],SCP [Données non publiées],Salariée cabinet d'avocat,
+48ad7a32-7634-4f68-9dec-c77dcfd333ea,[Données non publiées],[Données non publiées],Maison de Tante Bio,
+48b5149a-8e68-4dad-bde3-a5f916f4c316,[Données non publiées],CASDEN,[Données non publiées],
+48b61bc2-c98a-4530-bc49-9416e4e61f3a,[Données non publiées],NEANT,NEANT,
+48cb21e0-9349-4589-bbae-d7b72b58f5e4,[Données non publiées],France Télévision,Journaliste,
+48cfbb9b-48e8-48e7-b2db-af4dd2d4a535,[Données non publiées],[Données non publiées],Notaire,
+48d0fef7-7515-4120-91bf-5b1c58c15e8f,[Données non publiées],Gérant SARL [Données non publiées],Consultant en sécurité des systèmes d'information,
+48d1bc41-6d77-4b36-b320-ffc2e67e9d05,[Données non publiées],[Données non publiées],Médecin Généraliste,
+48d30045-25f9-4d78-9dc6-9f284d1012e2,[Données non publiées],Rectorat de Nantes,AESH,
+48eb8fae-43e3-437a-8b99-0dafceed301a,[Données non publiées],Education Nationale,Professeur des écoles,
+48eea6fb-9e18-45a0-bb2c-246751febfe4,[Données non publiées],MAUGES COMMUNAUTE,Chargé de mission [Données non publiées],
+48eea6fb-9e18-45a0-bb2c-246751febfe4,[Données non publiées],AUTO ENTREPRENEUR,Auto-Entrepreneur [Données non publiées],Activité en sommeil depuis septembre 2019
+48fb3bab-fc61-4da7-99f7-ff9eefd9cde3,[Données non publiées],Société Michelin,Responsable de développement grands comptes,
+48fc7d9f-0f35-4a87-ab90-b94b4fe8b7ea,[Données non publiées],Keolis Lyon,[Données non publiées],
+4914b688-fe6d-4b87-909a-39713e037403,[Données non publiées],Cabinet d'expertise,Expert automobile judiciaire,
+49345c79-fa66-4ce8-bc87-36c474192f2d,[Données non publiées],IDEFHI,[Données non publiées],
+495a138c-0e2c-4264-9a7b-c43ea096768c,[Données non publiées],0,0,0
+4974186c-e449-48d8-a227-1f1e480a346c,[Données non publiées],Confederation Paysanne,[Données non publiées],
+4980d3be-9b0d-4a15-84f7-d3d7f63a27ea,[Données non publiées],Ville de Paris,Directrice de cabinet adjointe,
+4992bb28-bd3e-4769-a3ce-d7b8ae7d65f5,[Données non publiées],VILLE [Données non publiées],DIRECTEUR GENERAL DES SERVICES,
+499614f5-1d6b-4865-8a29-2397a9e2cc8c,[Données non publiées],EDF,[Données non publiées] Retraite [Données non publiées],
+49ad0113-b55d-402f-ac88-b96826ddb121,[Données non publiées],néant,infirmière libérale,
+49aee622-c0f6-4471-a846-f68f7e5a5772,[Données non publiées],Conseil départemental,Cadre de santé,
+49b24fdb-d69e-4bdc-82f6-421618a1b70a,[Données non publiées],Big Ben Interactive,[Données non publiées],
+49b3fc5e-e896-4cc8-88db-72749bf3ddcf,[Données non publiées],mairie d'Eguilles,[Données non publiées],
+49b3fc5e-e896-4cc8-88db-72749bf3ddcf,[Données non publiées],mairie de Ventabren,[Données non publiées],[Données non publiées]
+49b5eea2-84e4-49f4-998d-051141a077f4,[Données non publiées],néant,néant,[Données non publiées] retraité [Données non publiées]
+49be23ee-69bd-4dfe-8b2e-5178c71dc89e,[Données non publiées],Education Nationale,Professeur des écoles - Conseillère pédagogique départementale,
+49bf35eb-4184-4796-aa73-6c42c8ff463a,[Données non publiées],Néant,Retraité,
+49c27510-4253-464d-a58d-083e3a380cc7,[Données non publiées],néant,néant,[Données non publiées]
+49c844a6-643c-44f8-8539-6bd0432388bc,[Données non publiées],néant,néant,
+49d5f057-a172-4314-89b5-6d25c02abb78,[Données non publiées],Lycée Professionnel [Données non publiées],Formateur / enseignement agricole privé sous contrat,
+49d78be9-60eb-4ddc-98ec-96a2c13a45fd,[Données non publiées],Sans emploi,[Données non publiées],
+49e3952c-5380-4e5c-8cab-b26427ebdc5a,[Données non publiées],[Données non publiées],[Données non publiées] retraite,
+49e904ff-343d-42f9-9808-e2efba0ecba4,[Données non publiées],RETRAITE,[Données non publiées],NEANT
+49eaa34a-6626-4f12-a02b-affc04c6cc09,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+49f99b18-705e-4629-b219-39f18d18d142,[Données non publiées],retraité,néant,[Données non publiées]
+4a021327-ca5a-4e8e-8a81-f5cc06584f1f,[Données non publiées],Panthera technologies Chambéry,Chargé d'affaires,
+4a021327-ca5a-4e8e-8a81-f5cc06584f1f,,Région Auvergne-Rhône-Alpes,Conseiller régional,
+4a04e136-5c02-4714-89f7-add60b44c403,[Données non publiées],Paris Musées,Chef du bureau [Données non publiées],[Données non publiées]
+4a073633-7a7b-4703-9f7e-722768e27f25,[Données non publiées],hopital [Données non publiées],secraitaire médicale,
+4a14d978-4082-4e4f-887f-732c8b39ade5,[Données non publiées],[Données non publiées],[Données non publiées] agence d'assurance.,
+4a2255cf-445a-4151-9a0c-21fe4e55308b,[Données non publiées],néant,Retraité,
+4a36e2f4-fa35-4dfc-994a-96cb6815888b,[Données non publiées],Etat (ministère de l'intérieur),Préfète [Données non publiées],[Données non publiées]
+4a4617ed-bd29-45a0-a756-b272ade82e51,[Données non publiées],Education Nationale,Gestionnaire Comptable du Lycée [Données non publiées],[Données non publiées]
+4a484b89-2e72-439f-a467-965362cb7173,[Données non publiées],Cabinet Marc Merlin,Chargé d'affaires [Données non publiées],
+4a50a546-6bfb-4144-bffe-51c44ec5ed08,[Données non publiées],SNCF,CADRE DIRIGEANT [Données non publiées],
+4a514d1c-6839-4447-8d01-b78b5e145458,[Données non publiées],[Données non publiées],Loueur meublé [Données non publiées],
+4a543e5b-6510-4477-a7a9-87969e093a18,[Données non publiées],MATMUT,Employée d'assurance,
+4a5db9b7-50e1-485b-acc3-9be085b4570a,[Données non publiées],RETRAITEE,[Données non publiées],
+4a63533b-f2ca-45db-8bcf-53a6310a5cbd,[Données non publiées],Intérimaire,Missions d'intérim,
+4a78166f-8019-474d-9048-6497d9eed505,[Données non publiées],Conseil Régional Nouvelle-Aquitaine,[Données non publiées],
+4a89afcb-6670-4cc7-ae47-08e2244e804c,[Données non publiées],indépendant,traiteur,
+4a8a898a-602c-4ea9-9901-d835e2fe964b,[Données non publiées],exploitant agricole,[Données non publiées],
+4aa44c7c-203c-4f28-af65-df413965e56a,[Données non publiées],néant,néant,
+4aafedcc-17a6-4413-a95a-ce269f788215,[Données non publiées],Indépendant,Graphiste,
+4ab648f2-e72f-439b-b48b-47535e7c08e2,[Données non publiées],ORSADE,[Données non publiées],
+4ace3802-a07b-4229-bfed-79943f551301,[Données non publiées],Pompes funèbres [Données non publiées],Conseillère funéraire,
+4acf43d0-e547-4621-a4c4-5358ad3d1c84,[Données non publiées],FEDERATION pcf,employé,
+4ad1abb1-4cc7-454e-9d03-1bd4cacdceca,[Données non publiées],SNCF Réseau,Responsable unité juridique environnement,
+4ad66582-9630-4c87-924f-cb128b177a83,[Données non publiées],indépendante,Artiste peintre [Données non publiées],
+4af002f9-3521-4b15-b887-f70cf4b9f681,[Données non publiées],Commune de Grenay,Chargé de communication,
+4af1d6ee-8853-4872-b681-1678a2ac2c44,[Données non publiées],[Données non publiées],Retraitée,
+4af6133c-ff88-4e91-8046-72b4262ba6e5,[Données non publiées],sarl [Données non publiées],gerant,
+4affbeee-0525-43b4-a70d-7de0c1dd2f16,[Données non publiées],Thales LAS,[Données non publiées],[Données non publiées]
+4b0a2fd0-0699-42ef-b89b-12f02f52e98e,[Données non publiées],Education Nationale,Personnel de direction,
+4b1554ad-b5e1-49d6-bfe8-b78cfc265328,[Données non publiées],DIECCTE [Données non publiées],CHARGEE DE MISSION,[Données non publiées]
+4b30e206-3376-44c7-9411-fee8f72e3916,[Données non publiées],Retraitée,Néant,[Données non publiées]
+4b3482a5-54bf-4084-81df-09c8ee4e4722,[Données non publiées],A titre personnel,Agricultrice,
+4b3f8172-8740-4909-bcb2-5f691ee2cdbc,[Données non publiées],[Données non publiées],Vendeuse,
+4b45fc9c-5bd1-4119-b3b5-e3ad90d4c0f6,[Données non publiées],Enseignement privé [Données non publiées],Enseignante,
+4b4715f5-ff99-4a60-aa34-63485f41d751,[Données non publiées],Cab,secretaire [Données non publiées],
+4b4a7861-8158-4d32-8fdf-13f20237dc59,[Données non publiées],Intermittent,Auteur / Réalisateur,
+4b4f5e50-85b6-4fdd-b4b3-cbaf912cdfcb,[Données non publiées],Grand Besançon Métropole,Professeur [Données non publiées],
+4b539054-566a-4c9d-8c57-9c55ce6b7718,[Données non publiées],CIAS [Données non publiées],conseillère [Données non publiées],
+4b629b3d-730a-428b-a602-8540c6c5f483,[Données non publiées],FAURECIA,Responsable [Données non publiées],
+4b6801b7-396a-44e5-b964-888675c803dd,[Données non publiées],Education nationale,Professeur certifié de physique et chimie,
+4b6c6f0a-7311-4d33-b6e4-852ccfb7afc0,[Données non publiées],Néant,Directeur juridique retraité,
+4b6dfbe3-8995-4bed-ae85-e5be50e6e768,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+4b6dfbe3-8995-4bed-ae85-e5be50e6e768,[Données non publiées],NEANT,NEANT,[Données non publiées] SASU de designer concepteur [Données non publiées]
+4b6dfbe3-8995-4bed-ae85-e5be50e6e768,[Données non publiées],TNS SARL ECP,TNS Concepteur en emballage et conception d'emballage,
+4b7187e0-35e0-4188-b81a-190e91e6d94f,[Données non publiées],Orange,Employée,[Données non publiées]
+4b75827c-3608-48c6-a815-79ac8aa69d03,[Données non publiées],[Données non publiées],Professeur des écoles,
+4b7e85fc-7916-4b16-914e-319e5069b024,[Données non publiées],néant,retraité,
+4b7f57b4-773a-4188-9b62-2a8c303be1a0,[Données non publiées],Intermarché [Données non publiées],Employée de boucherie,
+4b81afc4-4e2f-40c5-8f3d-b4766f8eeaca,[Données non publiées],"Culture, Conseil & Communication",Gérant de société,
+4b881156-d249-483d-958d-6ca5c9edcd29,[Données non publiées],Retraité,Néant,
+4b886c35-09df-42a9-bf16-4d779a3cb3df,[Données non publiées],Carrefour [Données non publiées],grande surface,[Données non publiées]
+4b8e93ff-dc30-4a51-b591-0b5d5f9954c2,[Données non publiées],GSK,Délégué médicale,
+4b9159ba-78ae-4f6c-a2a9-5a2ae216a72a,[Données non publiées],neant,neant,
+4b9349b6-62ab-4cd0-9005-766d785722ad,[Données non publiées],Education nationale,Professeure des écoles,
+4ba03f27-4119-4e4b-9a6f-56ea0fe857d5,[Données non publiées],GERANT,gérant d'une société dans la restauration (brasserie traditionnelle),
+4ba99da8-df77-4a04-8bad-80518d95b317,[Données non publiées],Association des Amis du Centre de Cancérologie [Données non publiées],Agent administratif,
+4bae4433-d0a6-426c-9849-1e4de536f3ec,[Données non publiées],Education Nationale,Professeur des écoles,
+4bb3e159-af0c-465f-ba9f-409cbb2322f4,[Données non publiées],CHU [Données non publiées],Praticien Hospitalier,
+4bb57b19-c0c3-4378-9f1e-3a4273844ed9,[Données non publiées],Fédération de pêche de Seine Maritime,Régisseur de la pisciculture fédérale de Maulévrier Sainte Gertrude (76),[Données non publiées]
+4bbfb4b1-b397-494a-a6d8-19f067cf640e,[Données non publiées],Retraitée,aucune activité,
+4bc25138-201e-44e6-abf9-f0492ef85132,[Données non publiées],Ministère de l’interieur,Gardien de la paix,
+4bc262a0-b01c-4489-9a4e-abd8e57a978b,[Données non publiées],retraité,néant,[Données non publiées]
+4bc6315a-8b4c-44a7-9f20-b130cee4d2b7,[Données non publiées],Co-Gérante SARL,"SARL Le Petit Quai [Données non publiées] Commercialisation au détail de vins, de bières, de boisons non alcoolisés, de produits d'épicerie fine frais ou secs et de plats cuisinés en bocaux.",
+4bd56728-4d33-4590-ac38-baf8c6213525,[Données non publiées],EPCI,Attachée territoriale,
+4bdc3624-4cf0-40ed-ae90-e15b0f98db95,[Données non publiées],EPHAD D'ARGONNE,Aide soignante Agricultrice,Double activité
+4bde6116-7e91-4da3-a3f9-d45ad4edf44f,[Données non publiées],sénat et conseil régional,[Données non publiées],
+4be0be4b-0376-4be8-8765-d1c6016557bb,[Données non publiées],Office Municipal du Tourisme Villard de Lans,[Données non publiées],
+4be52885-73f6-4816-8505-f8e54be9fe87,[Données non publiées],Sans employeur,Location immobilière en saisonnier ou à l'année [Données non publiées],
+4be8142e-923d-4486-b6a9-dc689b404bfa,[Données non publiées],REPUBLIK MDC,senior key account manager,[Données non publiées]
+4bec90db-360e-4dae-b0e8-e18ea2d475e4,[Données non publiées],3C2A,Dirigeant [Données non publiées],
+4becbb4e-fb87-458a-9d0d-534ebc2239c7,[Données non publiées],néant,néant,[Données non publiées]
+4bf9b821-f219-4a0a-8fd6-61f9fddc94be,[Données non publiées],RIO TINTO par PIMAN,Chef de projet,[Données non publiées]
+4bffb1d2-dc96-4642-ae2e-f5aa315d28fd,[Données non publiées],Travailleur indépendant,Activités de bien être Garde d'enfants,[Données non publiées]
+4c1061c2-17ea-4d59-8032-11eada0af83e,[Données non publiées],Conseil général,Secrétaire,
+4c17aaf0-e494-491e-9434-2ac8446dae43,[Données non publiées],[Données non publiées],Exploitant agricole,
+4c18ce5b-97df-4bf5-80e5-51a9a0cec6b3,[Données non publiées],Imprimerie SMIC,[Données non publiées],
+4c20b3e7-5395-428d-840a-c0cf67cdc673,[Données non publiées],Auto Entrepreneur,Chef d'entreprise - secteur communication,
+4c265e4a-bf4b-4ebe-86b3-decaa0c8ee7b,[Données non publiées],LP INVESTISSEMENT,Employée de bureau,
+4c2a822e-508b-4691-99cf-fe696fd2fb43,[Données non publiées],SA GERFLOR,Directeur commercial,
+4c3641b8-9ee6-47a1-9405-1fc62cdf2102,[Données non publiées],0,aucune,
+4c37f5b4-d242-46fa-8d8a-1f6c34455861,[Données non publiées],Airbus,[Données non publiées],
+4c469ca9-46bc-4c1e-8733-a3ef3969c4dd,[Données non publiées],la poste,controleur,[Données non publiées]
+4c46c674-8141-4b8a-b91b-7e09dc070655,[Données non publiées],ACS,Contrôle technique automobile,
+4c52f884-47ec-4f82-bca7-025d2c132ff7,[Données non publiées],CEREP,Arthérapeute,[Données non publiées]
+4c582520-e883-419e-a56c-6cd18d929a78,[Données non publiées],Initiative Terres d'Azur,Directrice.,
+4c62ad70-e19d-4b5b-8d57-8fd44d2a6a8a,[Données non publiées],Education Nationale,Professeur des écoles,
+4c63e42e-2fb0-4b8a-94f1-2f5a6a2eb253,[Données non publiées],Néant,néant,[Données non publiées]
+4c658afe-bdf4-4876-be9b-e85e1bd30d5d,[Données non publiées],CNFPT,Enseignante vacataire,
+4c93a85b-06c0-47ac-8ed0-618294a351c6,[Données non publiées],Accenture,Consultante,
+4ca98692-ee94-4452-84e3-039815a27c79,[Données non publiées],RECTORAT GUYANE,ENSEIGNANTE SECOND CYCLE,[Données non publiées]
+4cc2a629-6b4c-49fe-9305-63b234c58e56,[Données non publiées],[Données non publiées],Agriculteur,
+4cc4b46e-a29e-4852-b6fc-370b634fe225,[Données non publiées],TOTAL,Cadre,
+4cccd3be-41d7-4e1c-a7e8-af2f64d798d1,[Données non publiées],SOCIETE DE RESTAURATION MUSEE DU LOUVRE,ASSISTANT MANAGER,
+4cd143a6-2ebe-441e-bdcf-80f0ce20bbf0,[Données non publiées],Professionlibérale,Orthophoniste,
+4cdd6e24-0515-4250-b13a-b9b65242cf7f,[Données non publiées],Retraitée,Néant,
+4cea66d9-c4c9-487c-b889-43178c2b623a,[Données non publiées],Conseil Départemental du Val De Marne,Cadre territoriale,
+4ced95a3-6976-4187-b54f-b92b7a385ed0,[Données non publiées],Sarl activité libérale,Architecte D.P.L.G,
+4cef2f52-5eec-4eda-91d5-14633d39a06b,[Données non publiées],Carrefour [Données non publiées],grande surface,[Données non publiées]
+4cf0accd-b7bc-40a4-aea5-e0d4184349b2,[Données non publiées],[Données non publiées],AGRICULTRICE,
+4d06d9f5-0a00-4762-b2ee-d0cc99977f6c,[Données non publiées],Groupe Saint-Sauveur,DAF,
+4d16eea1-9610-495c-b6c5-c855f41e58ae,[Données non publiées],France Télévision/Autres média,Journaliste,[Données non publiées]
+4d1729e6-741e-4af3-90eb-240515115721,[Données non publiées],CQFD,comptable,
+4d1bf832-6757-478a-9d62-431855bfbd14,[Données non publiées],CDC DE SABLE SUR SARTHE,[Données non publiées],[Données non publiées]
+4d1c4ac3-1724-4476-9649-a400a42787b6,[Données non publiées],Mairie de Paris,Maire de Paris Vice-présidente de la MGP Présidente de la Société de Livraison des Ouvrages Olympiques Vice-présidente du COJO Présidente de l'AIMF Présidente du Conseil de Surveillance de l'AP-HP Membre du C40 cities climate leadership group Co-présidente de CGLU Membre de France Urbaine Membre de l'AMF,
+4d215d28-3d10-44cb-8cea-9d4408c784d5,[Données non publiées],Ministère de l'Agriculture,Enseignant chercheur,
+4d367c12-9eed-44aa-9b67-cba3e1f2024b,[Données non publiées],MINISTERE DE L INTERIEUR,Fonctionnaire de police,
+4d565f05-2e50-44f7-af14-897cc0b9d5ef,[Données non publiées],brest metropole,[Données non publiées],
+4d6195ab-b912-407f-a08a-72cb0bcb81da,[Données non publiées],Education nationale,Enseignant second degré,
+4d6350b3-a295-446f-ad0e-b99da87c8128,[Données non publiées],sncf,agent en retraite,
+4d66b0df-edd7-4c1e-a62e-e64e364d1a33,[Données non publiées],BULLE DE LINGE,[Données non publiées] - [Données non publiées],[Données non publiées]
+4d6d22d2-f8a0-48f2-bede-f9502231b242,[Données non publiées],Onrangetout,Gérante [Données non publiées],
+4d87cf0c-b6f9-447f-a5fc-3d00860f7d27,[Données non publiées],neant,retraité,[Données non publiées]
+4d9255e2-7346-424b-bdd2-6718c24f5ba3,[Données non publiées],Agence Française de Développement,Responsable [Données non publiées],
+4d9ff2bc-a368-4058-b888-93f67aa7b566,[Données non publiées],néant,néant,retraitée
+4db016a0-6bb8-47e5-aa6c-432ff29ca850,[Données non publiées],[Données non publiées],GERANTE D'UNE EXPLOITATION AGRICOLE,
+4db016a0-6bb8-47e5-aa6c-432ff29ca850,[Données non publiées],FRUTICOR,RESPONSABLE DEVELOPPEMENT FRUITS SECS,
+4db6728d-fedc-45cc-8196-517a2c589cc3,[Données non publiées],TERRE DE LIENS,[Données non publiées],
+4dba0d85-5372-4574-998b-e9450cf13ae5,[Données non publiées],[Données non publiées],avocat,
+4dc11841-2522-49c9-ad3d-3b0b406c9478,[Données non publiées],[Données non publiées],CONSEIL ET COURTAGE FINANCIER,
+4dc25250-6179-4f44-b10c-5b0cc8826b91,[Données non publiées],[Données non publiées],pharmacien,
+4dcf1435-3483-48e2-a6f7-096da6f30d4c,[Données non publiées],GM PARTICIPATIONS,GERANTE,
+4de81c2b-9f85-4bf1-b845-4829c8359500,[Données non publiées],Néant,néant,[Données non publiées]
+4df1fd39-7d07-491d-aff4-f6bcfe78b79d,[Données non publiées],[Données non publiées] [Données non publiées],[Données non publiées],
+4df1fd39-7d07-491d-aff4-f6bcfe78b79d,[Données non publiées],NEANT,ADJOINTE AU MAIRE DE BORDEAUX [Données non publiées],
+4dfe031b-09d6-46df-9c11-69395ba886e9,[Données non publiées],Travailleur indépendant,Moniteur de ski et guide de haute montagne,
+4e0188c0-3bcb-4e5b-81b0-ac6b58980aa4,[Données non publiées],SOFRECOM,Consultant [Données non publiées],
+4e06ff81-73cf-4827-9433-afe6784abaca,[Données non publiées],Orléans Métropole,[Données non publiées],
+4e0eef40-9d0f-4415-b901-0f30ff4b65e2,[Données non publiées],Particuliers,Assistante Maternelle,[Données non publiées]
+4e1103a2-c4ed-44ca-8eb0-d4099c8141f5,[Données non publiées],Comme de Hoenheim,Responsable petite enfance,
+4e1103a2-c4ed-44ca-8eb0-d4099c8141f5,[Données non publiées],Hopitaux universitaire de Strasbourg,Jury concours,[Données non publiées]
+4e1103a2-c4ed-44ca-8eb0-d4099c8141f5,[Données non publiées],CNFPT,Formation en petite enfance,[Données non publiées]
+4e12e421-70dd-455d-9ef4-a7b6380638cc,[Données non publiées],CEREMA,[Données non publiées],
+4e1d5434-59f5-4f7d-ada5-f8a0f8353310,[Données non publiées],Centre Hospitalier de Laval,Infirmière,[Données non publiées]
+4e1f80e0-7e93-46ee-a64d-8042149515b8,[Données non publiées],cid [Données non publiées],employée en confection,
+4e20174a-09f6-43fa-9650-8c600c4ac05c,[Données non publiées],PHARMACIE DES COMBRAILLES,[Données non publiées],[Données non publiées]
+4e2f8a43-4ce1-458f-a324-a2cba76175aa,[Données non publiées],Néant,Néant,Retraité
+4e45ffd0-4ad6-4323-b549-0f00141b32bd,[Données non publiées],Conseil départemental des Ardennes,rédacteur territorial [Données non publiées] du [Données non publiées] Conseil Départemental des Ardennes,
+4e481858-0143-4686-a2e2-721275b64e97,[Données non publiées],aucun,aucune,[Données non publiées]
+4e4fef94-8d21-478e-96a5-158a9d5feee1,[Données non publiées],néant,néant,Retraitée de la fonction publique territoriale
+4e6c7ac9-618e-462b-8250-6388729c4a1f,[Données non publiées],[Données non publiées],Responsable Mission Jeunesse,
+4e7027ec-b629-409f-91f9-c30d994e409a,[Données non publiées],Gerante de sociétés,prêt a porter,
+4e789cda-de58-41a0-afb2-a1bff2f9ab97,[Données non publiées],Cristal Habitat,[Données non publiées],
+4e7bf251-f753-41c9-8499-e1c57a6f611a,[Données non publiées],CYCLIFE France SA,CHARGE D'AFFAIRE MAINTENANCE,
+4e8eeed1-b471-4e9c-9951-52572a541533,[Données non publiées],SCP David Gaschignard,secrétaire,
+4e9b74d0-a52c-475c-a662-4d0ff3de70b1,[Données non publiées],Chambre d'agriculture de Normandie,Assistante administrative [Données non publiées],
+4eba5ff9-e8d7-4626-8b50-c71b37477de0,[Données non publiées],PST médecine au travail [Données non publiées],Secrétaire médicale,[Données non publiées]
+4ebe3d8f-b3d8-4b13-99bd-239c383c67fb,[Données non publiées],néant,néant,[Données non publiées]
+4ec3cdb8-9c23-4a7b-97a3-00eab63e803d,[Données non publiées],néant,néant,Retraite fonction publique
+4ec6651d-c4d0-4141-9826-141f20859bf5,[Données non publiées],Conseil Départemental de la Dordogne,Chef de Cabinet,
+4ed0c5c2-ca02-461f-bc0a-ee2f6f2e4b8e,[Données non publiées],profession liberale,ostéopathe,
+4ed1aa49-ec86-43d6-9770-f005cd8f9a6b,[Données non publiées],Alliance Networks,Gérant.,
+4ef5913f-718d-4b23-a81f-f91c2c46502d,[Données non publiées],Parlement européen,[Données non publiées],
+4ef7cab1-4bec-4e2e-8deb-74f36d862828,[Données non publiées],[Données non publiées],Cadre administratif dans une école d'architecture,
+4f0ba7ae-46ec-4cfd-86c4-83d2f9f95739,[Données non publiées],France Télévision,Journaliste,
+4f134d0f-6c66-4247-92f2-0ab954acb8bc,[Données non publiées],Transdev [Données non publiées],Directeur des Ressources Humaines,
+4f2807f5-faca-4394-9b8c-59f0434a4e01,[Données non publiées],Assemblée nationale,Député,[Données non publiées]
+4f387837-1485-4f24-9935-f2dec5587a59,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+4f38c718-24da-432d-9216-44a803229c54,[Données non publiées],Ministère de l'intérieur / CCSP,[Données non publiées],
+4f392023-a85c-4bb4-ba8e-6b0379d060f5,[Données non publiées],néant,néant,
+4f3a8c46-3d89-49d8-9fc8-9683e64da903,[Données non publiées],Conseil départemental de la Haute-Loire,Médecin [Données non publiées],
+4f4d44b7-c8e3-46c9-af71-21898e3cc17e,[Données non publiées],AEFE,Chargée de formation,
+4f5dc773-69a2-470b-9fd8-a7e1a1f67fae,[Données non publiées],SA SYRINXPAN [Données non publiées] et Association E.T.A.I.,Chargé de formation (SYRINXPAN) et Agent commercial Technico Commercial (ETAI),
+4f666ca4-d59b-464a-a3a7-9d3f18db75f8,[Données non publiées],BAUER MUSIQUE,[Données non publiées],
+4f66f1bc-37b8-4a20-9c4e-cdab513e1976,[Données non publiées],Artélia,[Données non publiées],
+4f742d76-befd-41a9-9773-6b6d4fd0cc7e,[Données non publiées],GENERALI,[Données non publiées],
+4f74e008-ef63-4800-aeea-505827001817,[Données non publiées],Profession libérale,Avocate,
+4f7f47e9-0448-416d-8f5e-c8319c5b70d2,[Données non publiées],Profession libérale,Ostéopathe,
+4f87d4ed-4f2c-43d4-92dc-334f428254a1,[Données non publiées],neant,neant,
+4f9444d2-948c-47db-b302-faefdcb301b8,[Données non publiées],La Francaise REM,[Données non publiées],
+4f960b55-25ff-4cbb-ba7d-16d00b33922a,[Données non publiées],Ministère de l’interieur,Gardien de la paix,
+4f9831df-7b1e-4d2b-a084-cbc98fe0707c,[Données non publiées],Fidesco,[Données non publiées],"Fidesco est une ONG, organisée sous forme d'association qui envoie des volontaires à l'étranger."
+4fa8b125-5a8f-4347-844f-bdb7d56035f5,[Données non publiées],Néant,Néant,retraitée
+4fad97f1-1e4b-4a70-a8fa-ce8f8c097836,[Données non publiées],ALLIANZ,CADRE - ASSURANCES,
+4fb363dc-4514-492f-a7b3-64128aeba267,[Données non publiées],Groupe Abbvie,[Données non publiées],
+4fb87ec6-1a3c-4962-be80-9a7ea9e2f2f2,[Données non publiées],APHM,[Données non publiées],
+4fdad276-648b-411b-ac46-a28c7e8e0a62,[Données non publiées],Boulanger CF SAS,Chef magasin,
+4fe027ff-1725-40de-8153-0e076c538601,[Données non publiées],Education nationale,Professeure de Mathématiques / Physique-Chimie en lycée professionnel,
+4ff94388-9865-48dd-a317-1137df83ac5e,[Données non publiées],IDEFHI,Médecin des usagers,
+5000b69b-5bfb-4411-83bc-27a0dd394d21,[Données non publiées],Clinique Mutualiste de l'Estuaire Saint-Nazaire,Médecin,[Données non publiées]
+5019bd0e-1082-4769-8b66-b2f28bcdedd9,[Données non publiées],sdis,officier,
+501f3150-0023-451a-80e4-3f9a629cfded,[Données non publiées],Retraitée,Retraitée,
+502709e8-ec6b-4287-9468-621ea47a0408,[Données non publiées],Education Nationale,Directrice d'école Maternelle,
+5027e0f4-ef96-46ea-aa08-3c35e6ad8bde,[Données non publiées],GFA [Données non publiées],GERANT,
+5028b22b-54c5-4c00-922a-c7f6ce015982,[Données non publiées],Entreprise [Données non publiées],Auto entrepreneur petits travaux,
+50291039-f4dd-4350-9a3c-e0ea41490f68,[Données non publiées],GRAND PORT MARITIME DU HAVRE,[Données non publiées],
+502994f4-ab2a-4c01-af53-318e6fdbd17a,[Données non publiées],ADM 87,Directrice,
+504355cd-64ca-405d-8c69-0593892643fa,[Données non publiées],credit agricole [Données non publiées],employée de banque,
+50441d15-4c1b-4c1c-9157-7a6006d9be82,[Données non publiées],GAEC [Données non publiées],Gérant [Données non publiées],[Données non publiées]
+5046842d-543e-455b-b270-9f47221597ed,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+5046842d-543e-455b-b270-9f47221597ed,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+5046842d-543e-455b-b270-9f47221597ed,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+5046842d-543e-455b-b270-9f47221597ed,[Données non publiées],[Données non publiées],[Données non publiées],
+5046842d-543e-455b-b270-9f47221597ed,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+5047e405-f02b-462b-9b3b-bb5bd3648141,[Données non publiées],Retraitée,Retraitée,Retraitée
+5049b5fb-d7ed-461f-b239-eabec4a4491e,[Données non publiées],Indépendante,Kinésithérapeute,
+5055d413-b964-48df-be8d-e4eaa3b7ed59,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+5055d413-b964-48df-be8d-e4eaa3b7ed59,[Données non publiées],Mairie de Vetraz-Monthoux,Chef du service commnication et événementiel,[Données non publiées]
+505d1a46-715a-4e7b-b227-91df2b286ff2,[Données non publiées],auto-entreprise,rééducatrice au geste d'écriture,
+5071cb16-a265-457f-84b8-a905ffcd118f,[Données non publiées],[Données non publiées],MEDECIN,
+5072ad14-f68d-4826-b1cf-8e4b4bf56616,[Données non publiées],travailleur indépendant,prestations dans le domaine culturel : cours de théatre metteuse en scène et aminatrice culturelle,
+5072ad14-f68d-4826-b1cf-8e4b4bf56616,[Données non publiées],Maison de la jeune fille [Données non publiées],Salariée à temps partiel animatrice en résidence d'accueil,
+507f65b1-b6f1-426d-b584-828c1d8e4333,[Données non publiées],NEANT,NEANT,RETRAITEE
+50815940-5b7f-4338-b6a4-48491b44e4e7,[Données non publiées],Profession libérale,Podologue,
+508465b4-43b2-4110-8af9-0caa527cf862,[Données non publiées],néant,neant,
+5086f62e-d03c-4bff-ad7f-577ef7d25b3e,[Données non publiées],SAS NEGOCIM,Directeur d'agence d'aménagement foncier,
+5090cbb8-de99-4050-a637-6d3ee2689b6f,[Données non publiées],Ministère de l'Education nationale,Professeure des écoles,
+50a73e16-37cc-499d-afdc-4a5715762fe6,[Données non publiées],Néant,Néant,
+50a9007a-23f6-4594-864a-503fbb39053d,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+50a96386-a601-4836-9afe-a9bf3f1f25b3,[Données non publiées],CAB et AFB,[Données non publiées],[Données non publiées]
+50b7b69a-1cd1-43ad-8102-0e9fbaf68213,[Données non publiées],néant,néant,[Données non publiées]
+50b9bdc3-ed32-4c68-92b3-7d3820c65ea9,[Données non publiées],Auto-entrepreneur,Technicienne du sommeil indépendante.,
+50b9e9cb-2fb2-486a-bac6-230b78b74fb8,[Données non publiées],[Données non publiées],esthétique,
+50c171e8-24e4-4aa4-8557-75b4a76a5c74,[Données non publiées],Université de [Données non publiées],Cadre administrative,
+50c6f490-823b-40f4-b542-b5bad591511d,[Données non publiées],GIE ELEVAGES DE BRETAGNE,Sauvegarde et promotions des races animales bretonnes à petits effectifs,
+50d1ca29-6c21-4aae-b223-f0dc6e0b4b0d,[Données non publiées],néant,retraité,
+50dcb7aa-f0fb-49f6-afe7-f9fbd8ed871f,[Données non publiées],Rectorat de Lyon,Professeure des écoles,
+50df4814-e237-4b76-b57c-c90b34486569,[Données non publiées],[Données non publiées],Ingénieur RD chef de projet,
+50e13a2d-0285-4497-a323-65761e0461ba,[Données non publiées],Action Logement,Directrice générale [Données non publiées],
+50e13a2d-0285-4497-a323-65761e0461ba,[Données non publiées],Conseil Régional Grand-Est,Vice-Présidente,
+50e26106-49d2-4432-a520-f5b45fce7285,[Données non publiées],Caisse d'Epargne,Responsable clientèle particulier,
+50e26d2c-94b9-4b61-beb7-a8620892af11,[Données non publiées],HYQUAL SERVICES,ASSISTANTE TECHNIQUE ET ADMINISTRATIVE À MI-TEMPS,
+510033ab-e2b5-4962-9b34-25e7e68379fc,[Données non publiées],sans emploi,[Données non publiées],[Données non publiées]
+5101c685-079c-4d15-982f-18eb75267ea9,[Données non publiées],Education nationale,Directrice [Données non publiées] de l'Université [Données non publiées],[Données non publiées]
+51052f3a-748a-4e25-a413-9e3c4f5a842b,[Données non publiées],Retraitée,Sans,
+510fdfda-88e9-495a-8372-dd28e4b95367,[Données non publiées],néant,néant,
+51100228-c475-4a08-90f0-d692d64286d8,[Données non publiées],retraite,neant,
+511634de-3922-469f-8303-d2c0dc5e063b,[Données non publiées],NEXITY [Données non publiées],Responsable technique,[Données non publiées]
+5120eba2-6a91-433f-acf1-ff502d42572b,[Données non publiées],AGGLOMERATION HERAULT MEDITERRANEE,[Données non publiées],
+512c27cf-3b81-4b73-ba69-9473b7319cf9,[Données non publiées],Auto entreprise,Community Manager Social Média,
+5132a18b-e355-4b05-931d-bb2b5e00405c,[Données non publiées],Néant,Néant,
+514e0f27-af51-4797-9aed-6a48366a54f6,[Données non publiées],néant,Néant,
+51500a80-6124-469b-972e-73096177e53a,[Données non publiées],OMS Genève (Suisse),Employée,
+5150e95b-7a21-44af-9f80-9b9aa68edf0f,[Données non publiées],Ministère de l'Education Nationale et de la Jeunesse,Inspecteur Général [Données non publiées],
+515d6139-f41e-46bd-b4d0-13b086e5d615,[Données non publiées],LABORATOIRE PHARMACEUTIQUE AMGEN,[Données non publiées],
+516b1ce9-d3c5-4b1d-8f25-f3b09c2ec5d5,[Données non publiées],WILL&CIE,Evénementiel professionnel Accompagnement en stratégie de communication Formation en relations publiques,cessation d'activité au 30 juin 2021/ [Données non publiées]
+516b1ce9-d3c5-4b1d-8f25-f3b09c2ec5d5,[Données non publiées],Dialogues et Solutions,salariée depuis le 1er avril 2021,
+517eec03-2cf6-440a-b803-091ceffa0fa5,[Données non publiées],CEMEA OCCITANIE,"Directeur Adjoint au sein d'une association, mouvement d'Education populaire, organisme de formation",
+51940743-b366-4bdd-9fc4-c05396a89c60,[Données non publiées],néant,néant,
+5195e586-1eba-4dd3-b85e-de4b0a59260f,[Données non publiées],libérale,infirmière libérale,
+51a4d945-02b4-4663-b9fe-87156fc48497,[Données non publiées],Métropole de Lyon,Chargée de Mission [Données non publiées],
+51a60ea1-bcee-423e-b262-897d6f88e43f,[Données non publiées],Conseil Régional,Responsable de projets [Données non publiées],[Données non publiées]
+51a61f45-26c5-49f6-a14f-b6d504f54b3a,[Données non publiées],DGFIP,Cadre [Données non publiées],
+51a74cdd-24a2-463a-b1db-da2feeefe2d2,[Données non publiées],[Données non publiées],Collaboratrice parlementaire,
+51ae59d9-7d0f-486f-ab23-d57c66a2108a,[Données non publiées],Hopital,Retraité,
+51ca70d8-79ff-42b6-ba97-c98882b067b1,[Données non publiées],[Données non publiées],Présidente bureau d'études économie de la construction,[Données non publiées]
+51e00a96-2422-4ade-b385-55d4d5cd87e7,[Données non publiées],EHPAD [Données non publiées],AIDE SOIGNANTE,
+51f35cdc-8e00-4f12-999a-bcc201614cf5,[Données non publiées],[Données non publiées],Technico-commercial,
+51f48ff4-07c9-495f-8400-65e63ad4190d,[Données non publiées],Mairie de Bobigny,Directrice [Données non publiées],
+51fbc7ff-dc34-4489-88d3-bb68459b5f32,[Données non publiées],néant,néant,
+51fd4ee2-590a-44b4-bf56-bbb1958a17ce,[Données non publiées],Néant,Retraitée,
+5202f675-0f33-4413-87c9-f106a081cb3e,[Données non publiées],Artisan,Coiffure à domicile,
+520898f3-c434-48b6-b058-daa3cb4c7fd6,[Données non publiées],Coopérative Maritime,Employé de commerce,
+5214467d-0d22-44ab-acda-17e6ff52b5bf,[Données non publiées],Gérant non salarié de la société [Données non publiées],Gérant non salarié de la société [Données non publiées],[Données non publiées]
+5214467d-0d22-44ab-acda-17e6ff52b5bf,[Données non publiées],Autoentrepreneur,Développement informatique,[Données non publiées]
+52298a29-42bc-4c4c-b8ba-d6bc5a4bd47b,[Données non publiées],NEANT,NEANT,
+52325882-74b7-46e9-8402-67a2ef25c888,[Données non publiées],CPAM 93,Cadre de la fonction publique,
+5232f10f-d5e2-49f9-a6f3-963192a019e4,[Données non publiées],Education Nationale,Professeur des Ecoles,
+523477a8-e7dd-4150-9366-c8bf753d4731,[Données non publiées],L'Equipe,[Données non publiées],
+5234a0bd-5132-4467-b449-666233008ddf,[Données non publiées],Néant,Néant,[Données non publiées]
+523587ff-cbea-4753-8bdc-f7f6a573c089,[Données non publiées],INSTITUT DE FRANCE,Chancelier de L'Institut,
+523643a2-862d-4be7-9a90-4aa323dd9afe,[Données non publiées],L'Equipe,[Données non publiées],
+5238391b-f5f3-4f68-aa0d-ac3be9dcc2b9,[Données non publiées],Arthur Lyod Developpement,[Données non publiées],
+5238d585-2b77-448f-adf5-a355ebfa00dc,[Données non publiées],néant,néant,retraité
+52419940-0019-4824-8c3e-c7d8f6e78926,[Données non publiées],[Données non publiées],NOTAIRE ASSISTANT,[Données non publiées]
+5259fc3a-56ff-4069-9244-cf38e719460e,[Données non publiées],Mairie [Données non publiées],Secrétaire générale,
+52654c2d-3ad9-4794-b2fb-810d85d1f01b,[Données non publiées],HOPITAL [Données non publiées],TECHNICIENNE DE LABORATOIRE,
+5267a1ce-3608-43e6-baa9-ad1523a3f338,[Données non publiées],Ministère Education nationale,Enseignant,
+526ed737-2051-4117-be65-9f5f891ff1ee,[Données non publiées],Ballot,Fabricationdeproduitcosmétiques,
+527dc752-1e13-4630-a57b-225f6e9f5211,[Données non publiées],[Données non publiées],Vendeuse,
+527e508e-93bf-470c-b923-f3f9877605e7,[Données non publiées],SCEA [Données non publiées],gerant exploitation agricole,gerant
+527e508e-93bf-470c-b923-f3f9877605e7,[Données non publiées],SNC Vaucourt travaux agricoles,gerant d'une societé de prestations de travaux agricoles,
+527e508e-93bf-470c-b923-f3f9877605e7,[Données non publiées],SAS Theuvy Biogaz,President societé Production de biogaz,
+527f7940-ffa9-4d30-a8ca-7bc3e24ad181,[Données non publiées],auto-entrepreneur,professeure de yoga,
+52865134-e91e-40a6-a478-506a85ee7f02,[Données non publiées],Néant,retraite,[Données non publiées]
+5291c72c-a5fc-4e56-a381-d17a634730a5,[Données non publiées],Société Dolmen,Responsable [Données non publiées],
+52932551-ee50-45d6-bd8a-f6d3da3bed83,[Données non publiées],Independante,Orthophoniste,
+5297ea97-c73c-4cdd-b63e-100fec8a4e19,[Données non publiées],néant,néant,
+529eaed1-9d11-481f-b62e-8d13d5ff4629,[Données non publiées],Coformatique,informaticien,
+52aa4ec1-6220-4b9c-b70f-a43758099c8f,[Données non publiées],Wivoo,Consultant senior,[Données non publiées]
+52ae89e6-29ce-49db-8bd5-e7813cfe2c69,[Données non publiées],[Données non publiées],[Données non publiées] retraité,[Données non publiées]
+52b2fa03-51c6-428f-8179-d58deba48f3b,[Données non publiées],[Données non publiées],Plomberie. [Données non publiées],
+52bc440d-f950-4a8f-86c4-07dde59273d5,[Données non publiées],Ville de Nice et Métropole NCA,[Données non publiées],[Données non publiées]
+52bdd6f5-ea58-44af-90e9-5de736318926,[Données non publiées],SCP [Données non publiées] notaires associés,Notaire,
+52d03ed2-746a-4f76-8df7-014d74ee8bd1,[Données non publiées],Néant,Néant,
+52d5208d-4e4c-405d-afe4-b2185ee92752,[Données non publiées],Auxiliaire paramédical,Infirmière libérale diplômée d’État à domicile,
+52edf52d-6ec4-4f43-add3-3317947651fe,[Données non publiées],Minerals suez,[Données non publiées],
+5312bf4d-c761-4f30-9d1b-bb9b4245ce29,[Données non publiées],Education nationale,Enseignante,
+53146fd1-09fe-4e21-b318-d92f0dc10209,[Données non publiées],Groupe France Télévision,journaliste,
+53156d06-3dba-46ec-b960-360523d3b1da,[Données non publiées],CIS Bio International,[Données non publiées] - Cadre,
+5315a6f1-f227-4137-98f1-4b38711173a8,[Données non publiées],Clinique [Données non publiées],Medecin,
+532273f7-896f-4e86-ac55-daec910185d6,[Données non publiées],OPTEO,ASI,
+532590e9-6fac-478d-9597-d0448cb12625,[Données non publiées],Conseil Départemental,Secrétariat,
+533a4e89-dc84-4222-bf17-b24bcb35bbdc,[Données non publiées],Collège et lycée [Données non publiées],Professeur d'espagnol,
+5340fbee-5e0a-4f9e-9926-d66651126e80,[Données non publiées],NEANT,NEANT,[Données non publiées]
+534102d7-ef92-4119-a3a1-4ef34e19e787,[Données non publiées],retraitée,néant,[Données non publiées]
+53659d36-75c0-4c55-9e00-9af0df329f00,[Données non publiées],RETRAITE,NEANT,
+5399159a-00ac-48db-9a62-4101a2610353,[Données non publiées],Education nationale,Professeur des écoles,
+539c9431-860e-4d66-8a95-7fa4e6e89f19,[Données non publiées],[Données non publiées],INFIRMIERE LIBERALE,
+53a1c5c3-5e13-4123-ba78-2742cd3e9223,[Données non publiées],[Données non publiées],Directrice du Service des Transports,[Données non publiées] Des mesures préconisées [Données non publiées] avaient été prises pour éviter une situation de conflit d'intérêt entre l'activité professionnelle [Données non publiées] et mon mandat de Président de l'agglomération. Ces mesures ont été reproduites pour Vienne Condrieu Agglomération
+53bdcac8-561b-48e3-b64e-e7646ad36a95,[Données non publiées],[Données non publiées],[Données non publiées],retraitée [Données non publiées]
+53cb4cfc-69e6-45ca-85fd-b4377f5bf7e4,[Données non publiées],Lee Hecht Harrison France,"Consultante senior, salariée",
+53cf9283-a72b-4140-9a97-ac38ed39e4e4,[Données non publiées],Artiste,Artiste plasticienne,
+53cf9283-a72b-4140-9a97-ac38ed39e4e4,[Données non publiées],SAS HALMAHERA,Présidente,
+53d89ec0-1659-4323-bbbd-636607d58340,[Données non publiées],SPL Océan Marais de Monts Tourisme,Responsable du Pôle [Données non publiées],
+53dd5929-fbd8-4491-9ccb-3318a94fe9ba,[Données non publiées],SAS [Données non publiées],PRESIDENTE,
+53f0c3c9-a44d-4900-bbf3-ebc238188d94,[Données non publiées],Libéral,Masseur Kinésithérapeuyr,
+53f5d812-c069-4e47-bbd4-c4ed6c3056d1,[Données non publiées],[Données non publiées],gérant société conseil en gestion des risques,co-gérant
+53f94a2e-3753-480b-a037-1dfa4561729d,[Données non publiées],Retraité,Retraité,[Données non publiées]
+53fe26cb-d2e0-4f19-9a64-e06f88736b5e,[Données non publiées],EDF [Données non publiées],RESPONSABLE D EQUIPE,
+541779f2-ab67-4d73-8838-8a22c5ac9d1c,[Données non publiées],CAF GUYANE,Technicien conseil [Données non publiées],
+54180699-c5c8-4bba-b81c-d8264c13390f,[Données non publiées],Assemblée nationale,Assistant parlementaire,
+541d62d5-0b2b-40e6-9c51-8f7464d32d2d,[Données non publiées],Education Nationale,Enseignant,à la retraite
+541e42aa-103a-486b-8852-03b36033a449,[Données non publiées],camping [Données non publiées],Gerant,
+5423e2a6-20e7-4d7e-b2b6-6bbbb583dd80,[Données non publiées],[Données non publiées],Maison de Tante Bio,
+542bc6cd-4ce4-4609-918f-d3b4d61334f3,[Données non publiées],NEANT,NEANT,[Données non publiées]
+543182c6-8a25-45cf-bd8d-ba7c0a577919,[Données non publiées],néant,rétraitée,
+54347d6f-1fd7-48e5-bd2b-751f9a370ebf,[Données non publiées],Néant,Néant,Retraité [Données non publiées]
+543d4c60-25ff-404b-bcb0-9374e149968e,[Données non publiées],[Données non publiées],DIRECTEUR DE CONCESSION AUTO,
+54403613-9ae8-4a0f-8561-bdd01e4d6a58,[Données non publiées],cpam,Directrice [Données non publiées],
+54431259-7c85-410e-ae36-fc742bf3fc8e,[Données non publiées],Education nationale,Retraitée [Données non publiées],
+5447cd70-dfe6-46c3-b6f7-4a077ccf7f64,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] retraite [Données non publiées]
+544c29b5-c881-4fba-8a09-ffb434bce3ef,[Données non publiées],MAIRIE ST CYR SUR LOIRE,FONCTIONNAIRE CADRE,
+5454d78b-c71e-47c5-9678-801e082ac10d,[Données non publiées],Néant,micro entrepreneur,
+54627055-f140-4c84-9771-02fde6b6a40c,[Données non publiées],MTE / DREAL PACA,Chargé de mission politiques sociales du logement,
+546e645e-2061-42d1-9481-306cea1b24d6,[Données non publiées],CPAM [Données non publiées] [Données non publiées],CADRE [Données non publiées],
+5470f8f6-b3a6-4a9a-b00b-cf5d910ab910,[Données non publiées],Ministère du travail -DIRECCTE Bretagne,Inspectrice du travail,
+54713e56-a071-43c4-a250-f602f4403f93,[Données non publiées],[Données non publiées],saariée d'une activité de tourisme,[Données non publiées]
+54769042-705f-4e46-bbe4-2b74905e578b,[Données non publiées],EARL [Données non publiées],SECRETAIRE,[Données non publiées]
+54776631-4051-4c06-9530-4641fe1439ca,[Données non publiées],CD90,Directrice de la communication,
+54804721-e623-48eb-9a56-ff0a75e7b121,[Données non publiées],SARL Montagnani,[Données non publiées],néant
+54804721-e623-48eb-9a56-ff0a75e7b121,[Données non publiées],sarl montagnani,[Données non publiées],
+5485e949-49e5-42e0-980e-241d7ab0f16d,[Données non publiées],DREAL,Secrétaire administratif,
+5486a04d-ac1f-42e6-a6c5-b891e7f890ce,[Données non publiées],[Données non publiées],[Données non publiées],Retraitée [Données non publiées]
+5486eb44-2b22-47a0-a8f3-62ee3289dcab,[Données non publiées],sans emploi,0,
+549b4453-ed2e-4eb8-9566-0c77fbbbfecc,[Données non publiées],Crédit Agricole,Chargée de clientèle professionnelle,
+54a71f3b-064d-4ead-bd6b-a16626c5ba07,[Données non publiées],[Données non publiées],Administrateur Réseau Systèmes d'information Finances,
+54b12c70-75e1-469f-b073-54df6ab93f3a,[Données non publiées],EDUCATION NATIONALE,PROFESSEUR RETRAITEE,
+54b22698-dce3-459d-a181-96a30554155b,[Données non publiées],Mutualité Française Limousine,Opticienne diplômée [Données non publiées],
+54bf6783-ee93-4e94-a842-17e5f86836a7,[Données non publiées],néant,néant,
+54c4316a-bec0-45c9-ab35-336759bea9e2,[Données non publiées],Education nationale,enseignante.,
+54c92487-95bc-4eed-a8c0-ffb44e97c339,[Données non publiées],SENAT,Sénateur,
+54d61ae1-170c-4feb-a566-37ddd1ae3a09,[Données non publiées],Société Générale,Chef de Projet,
+54d992eb-5daf-4a4d-991b-d0683871d829,[Données non publiées],Education Nationale,Professeur d'EPS,
+54da15a2-1c0c-49ca-b5d0-0cf5d532e78e,[Données non publiées],sasRemi,technicien,
+54e33afb-e4e3-4125-a393-f786703a94f4,[Données non publiées],KINE en liberal,masseur kinésithérapeute,
+54e7ad55-e82c-482d-84ec-9cea685d7656,[Données non publiées],MINISTERE DE L INTERIEUR,Fonctionnaire de police,
+54fddba0-1c63-4e4f-930c-b275bd3b5a42,[Données non publiées],SARL MAV,Salarié,
+5505b986-4455-4191-b42a-303962a8ae0b,[Données non publiées],[Données non publiées],[Données non publiées] Retraité de l'éducation nationale.,[Données non publiées]
+5511c021-5c9f-45a8-b911-f33efd0b6c9a,[Données non publiées],néant,retraitée,néant
+55178f8c-fe20-4154-a747-3ede5a61e070,[Données non publiées],EDUCATION NATIONALE,AGENT ADMINISTRAIF,
+552ce388-5e9d-4e28-880f-bf452ea392bd,[Données non publiées],LABORATOIRES DELPHARM,[Données non publiées],
+553793ac-6143-49f4-ad43-6c7b234f7478,[Données non publiées],Mairie de Vals les Bains,[Données non publiées],
+553c3db7-51d3-4d6d-b053-d0a46a69b8dc,[Données non publiées],LVMH,[Données non publiées],
+554472ac-e9a6-462e-804d-2ea340982ce3,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+5552c5d7-db0f-4190-b08f-f922628ea1c0,[Données non publiées],FODENO [Données non publiées],directrice,
+5558a571-5c87-42a7-a041-fd62334517c4,[Données non publiées],néant,néant,
+556657ac-a4a8-49c8-b73e-5222bea6486e,[Données non publiées],[Données non publiées],Chauffagiste [Données non publiées],
+55668ffb-1734-495b-aadd-3598a061e0f7,[Données non publiées],SEMC,Graphiste,
+557c38fd-bd6d-49a7-96ab-5241961e1c35,[Données non publiées],Conseil Régional Nouvelle-Aquitaine,[Données non publiées],
+5582f53c-1a53-4a1a-ad2d-caae7291f5e5,[Données non publiées],Education Nationale,Professeur des Ecoles,
+5590a25d-4d3c-4e46-bab5-008f43767adc,[Données non publiées],Lycée [Données non publiées],Professeur de Lycée [Données non publiées],
+55a3e325-7849-415e-bb80-b4e7b17a6376,[Données non publiées],Hopital,Medecin,villeneuve-sur-lot
+55acc476-34a7-4d77-8092-f35f2b6d8cba,[Données non publiées],Retraitée,Sans,
+55b35e7f-2335-43bc-84cb-7c9d18e8da01,[Données non publiées],GE,Secrétaire commerciale,
+55b46e76-0d5d-452d-b616-18b794db4c0f,[Données non publiées],CHU Amiens,Responsable [Données non publiées],
+55cd225b-f6ef-4aff-b305-49248e37e49b,[Données non publiées],BRUNO DASSE,ouvrier manoeuvre dans le BTP,
+55d2f1d0-42a8-46a6-a15c-06d195405772,[Données non publiées],Éducation nationale,Professeur certifié d’Histoire- Géographie,
+55d78608-ccf4-416f-8e53-9530cbff6be1,[Données non publiées],néant,néant,
+55d8143f-8fee-4511-a1f0-5358efcc957c,[Données non publiées],néant,néant,
+55dc2c6b-da46-47fd-97b2-6ecba02ac08c,[Données non publiées],CPR SNCF,gestionnaire,
+55dcd70d-6d19-42fa-a8e0-ad6eac2f6d8d,[Données non publiées],Crédit Agricole,Animatrice vie mutualiste,
+55e4be35-220c-42ad-a817-6cbe357be3fb,[Données non publiées],Exercice en nom propre,Avocat,[Données non publiées]
+55f2ee87-6791-45a3-a9dd-571d137bf9af,[Données non publiées],[Données non publiées],Cadre administratif dans une école d'architecture,
+55f4b9c0-454c-430b-9d85-1231f8d70dd7,[Données non publiées],Néant,Néant,
+55f998a2-22bc-41d0-a14e-08d903323a25,[Données non publiées],[Données non publiées],EXPLOITANTE AGRICOLE,
+5608290a-c0d8-4899-af8a-bc0176c650d9,[Données non publiées],Ville de Dijon,Direction des Musées [Données non publiées],
+560d2278-45b6-4112-89d8-d431b0c08844,[Données non publiées],Ville et Agglo de Montélimar,[Données non publiées],
+5622a16c-2bab-4a44-b875-22f7379d4292,[Données non publiées],néant,Pharmacienne,[Données non publiées]
+56263b57-ee29-46d0-a782-dbfd45715317,[Données non publiées],collége [Données non publiées],enseignant mathematique,
+562e9b94-7426-4a6c-8f7b-fcd9b106295a,[Données non publiées],néant,néant,[Données non publiées]
+563be464-efe7-49ff-8954-bafefc9c0e8a,[Données non publiées],Sans employeur,Gestion de meublé de tourisme,
+563f0824-c5ab-4db3-8656-5928b3b1bc76,[Données non publiées],RETRAITE,RETRAITE,
+563fa6ed-fc78-4e96-9dc2-4a7ed625a51d,[Données non publiées],néant,néant,
+5641f9a2-0d8a-41fd-a332-de7bd656c902,[Données non publiées],Education Nationale Collège [Données non publiées],Professeur d'Arts Plastiques,
+564205cd-4db2-419c-8a7c-7c67225b60ec,[Données non publiées],[Données non publiées],Directrice Paramédical d'une HAD (hospitalisation à domicile),
+5643b0d8-dbd7-42e2-95cf-f39f4ce512f3,[Données non publiées],SARL AGORILA,Gérant majoritaire,
+5645819e-3066-43c5-bddb-3bd30c92dcee,[Données non publiées],[Données non publiées] ENTREPRISE INDIVIDUELLE,EXPLOITANTE AGRICOLE DEPUIS LE 01/01/2024 ET VDI CHEZ VORWERK FRANCE,
+564e9b8f-fd96-40d3-8c30-aafc34eb9083,[Données non publiées],ATPARTNER,comptabilité,
+5650c6d9-f39d-4391-aeb5-4bae3647716e,[Données non publiées],Ministère de l'Education nationale - [Données non publiées],Assistante d'éducation,[Données non publiées]
+56547691-d68b-446d-b8ab-bbb5a11109e7,[Données non publiées],FAVE Francis,secrétaire comptable,
+56595aae-a483-45d9-97bc-de5434f1ebb8,[Données non publiées],Vénétis - Groupement d'Employeurs,Directrice générale,
+5662e3c9-1aa7-40c9-9830-ffb404aaac8e,[Données non publiées],CCAS VILLE DE MAYENNE,[Données non publiées],
+566b41c7-acab-4546-94cb-34c2e31779bc,[Données non publiées],ASP [Données non publiées],[Données non publiées],
+566e2a1d-d8dd-4a88-a99a-a5d410892a29,[Données non publiées],Education Nationale,Professeur de lettres modernes en Collège.,
+5675e9a4-a77e-4249-ae13-f4e23dd5a0f3,[Données non publiées],CAPEB Vosges,[Données non publiées],
+56770de5-f98f-47f3-ae98-223415103b85,[Données non publiées],[Données non publiées],Secrétaire comptable et médicale,
+56770de5-f98f-47f3-ae98-223415103b85,[Données non publiées],Autoentrepreneur,Production audioviduelle,
+56790b3b-e030-49b0-96fc-05f08ef15922,[Données non publiées],néant,néant,
+567a6a26-9010-4f59-be67-6a56523197e7,[Données non publiées],IDEFHI,[Données non publiées],
+567b365a-9a79-48ab-9ddc-9043a6c0d069,[Données non publiées],Groupe EVALIS,DGA [Données non publiées],
+568b54e8-a034-4dcd-a183-e7b7ac30d922,[Données non publiées],SARL POIRIER [Données non publiées],négoce de porcs,
+568cc2a2-1e38-49bf-bdca-ecd443324df7,[Données non publiées],[Données non publiées],Responsable Mission Jeunesse,
+568f1a11-cf93-4871-8cd5-e9c8e0ebeff9,[Données non publiées],SNCF,TELECONSEILLERE AGENT SERVICE COMMERCIAL,
+569674e4-046e-41c2-a82d-bc8aeb4fbc4f,[Données non publiées],NEANT,NEANT,RETRAITE
+569f8bd3-3eb8-4600-a481-a2148679bbbb,[Données non publiées],Librairie des Thés,Vendeuse en librairie,
+56a3588b-bbfd-45c6-8da0-5f6734116d26,[Données non publiées],SAS PATRIMONIUM,PRESIDENTE,
+56aadb99-054f-4949-9458-de2e0ca40c41,[Données non publiées],Groupama,Conseillère commerciale [Données non publiées],
+56b3098f-bd7c-4fae-922b-298ac4efc8bc,[Données non publiées],Educationnationale,enseignante,
+56b36fdd-191e-4588-90f7-b415594d414a,[Données non publiées],CHU [Données non publiées],[Données non publiées] retraitée [Données non publiées],[Données non publiées]
+56b41736-9930-459c-94a8-655412ac06e0,[Données non publiées],retraité,retraité,[Données non publiées]
+56b88855-5830-4535-889e-e9ccdc5a42fe,[Données non publiées],Dentons,Avocat [Données non publiées],
+56bc8ad3-c614-49b4-8b94-6d4abfc59ffc,[Données non publiées],néant,néant,
+56d0da64-f5ab-489b-847e-f3ac171877e6,[Données non publiées],CH [Données non publiées] + activité liberale,Chirurgien,PH temps partiel
+56f19a67-8e96-4a43-861c-e73609cd206a,[Données non publiées],commerçante indépendante,Fabrication de pain et gâteaux bio et négoces de produits régionaux,
+56fc5f1d-38ec-488c-b3d8-95919711f9ee,[Données non publiées],SARL [Données non publiées],Gérant de la société SARL [Données non publiées],travailleur non salarié
+57007ac6-9a0a-4d7b-9430-cea454006263,[Données non publiées],neant,sans,[Données non publiées]
+57015554-c7e5-49a3-b633-325572b2edf0,[Données non publiées],néant,Retraitée de l'éducation Nationale,
+5702d0ac-8b75-44ba-bb35-503601d4f26f,[Données non publiées],Chef d'entreprise,Dataanalyste,
+570628f1-7eda-469b-96a8-4429492bed2d,[Données non publiées],EUROLEV,cadre commercial,
+5709b6e1-75d0-468a-a66e-0c5635503cd8,[Données non publiées],ENEDIS,[Données non publiées],
+570b29a1-afc4-4662-bccc-a9c4395bd8f8,[Données non publiées],Les Celliers Jean d'Alibert,Conducteur de chaine d'embouteillage,
+570c5fbd-855b-4d5d-82fd-154e74145374,[Données non publiées],autoentrepreneur,naturopathe,
+570c63ca-f431-47a2-b1ae-7b3dd9f9b7ff,[Données non publiées],Christine Loir députée de l'Eure,attaché parlementaire,
+5713863f-0152-4d23-9273-f9b1ec782a07,[Données non publiées],Communauté de communes des 4 rivières,Animatrice de Relais Petite Enfance,
+57152062-aaf8-4634-9281-57ae5c5fc0af,[Données non publiées],Groupe CISN,[Données non publiées],[Données non publiées]
+572b091b-50b4-413b-90ce-3088de6249f2,[Données non publiées],GEIE GECOTTI-PE,Chargée de mission [Données non publiées] [Données non publiées],
+572dfc3f-3f33-4f6a-b025-5e305cb66bc2,[Données non publiées],Ville de Grenoble,Directeur,
+574325db-1152-4ef2-9024-25d27c0cbdd0,[Données non publiées],tns,huissierdejustice,
+574b3d59-5296-4a66-bb62-214bc2578681,[Données non publiées],PHARMACIEN,GERANT DE PHARMACIE SELARL DU MARAIS,
+574f730b-59cd-4f8e-90d9-72fe04879e9c,[Données non publiées],[Données non publiées],journaliste sportive,
+5751c917-2d2a-40da-9d2f-2472f9c7775c,[Données non publiées],NEANT,NEANT,Pas d'activités Professionnelles
+5752eb08-d820-446b-a464-99e6f3af396d,[Données non publiées],Ville de [Données non publiées],Redacteur,
+5759907d-c959-4305-b996-af77e0420935,[Données non publiées],Profession libérale,Avocate,
+575fea37-488e-4d6c-b70b-5626a2b403df,[Données non publiées],lycee de couasnon Dreux 28,[Données non publiées],à la retraite [Données non publiées]
+57676973-a7d7-4ebf-b629-50046bfb93de,[Données non publiées],Mairie de Paris,Chef de cabinet,
+5768f62c-b3da-4d2d-a391-6c80a4f1510b,[Données non publiées],Education nationale,Enseignant second degré,
+576cfb35-e068-4405-a212-08201a6eb1da,[Données non publiées],Retraitée,aucune activité,
+5775459e-661a-4099-a6ca-a6890df1e72f,[Données non publiées],ENTREPRENEUR INDIVIDUEL,FORMATION CONTINUE D'ADULTES,[Données non publiées]
+57764699-4e72-423c-b363-e07e36a3db03,[Données non publiées],Néant,Néant,[Données non publiées] à la retraite [Données non publiées]
+5776d89f-26a3-4bf4-9fe8-d25128a8f70d,[Données non publiées],éducation nationale,professeur d'histoire-géographie [Données non publiées],
+577956c9-465d-43e9-877b-dd660e45621f,[Données non publiées],Education nationale,Directrice départementale [Données non publiées],
+577da8ca-21a1-4eca-bfd6-082b38b5b7c0,[Données non publiées],Néant,Néant,
+5780abd5-3647-48a6-9a86-3417df1d4238,[Données non publiées],Médecin Libéral,Médecin Ophtalmologiste,
+57874e0e-2efb-4d16-a319-4b713ae33577,[Données non publiées],Centre Hospitalier [Données non publiées],Directrice des Affaires médicales,
+579be55e-ef75-4307-8635-4e29836739a6,[Données non publiées],Retraitée EN,Néant,
+57a592c8-a092-486a-8103-952fa0364e7c,[Données non publiées],commerçante indépendante,Fabrication de pain et gâteaux bio et négoces de produits régionaux,
+57a592c8-a092-486a-8103-952fa0364e7c,[Données non publiées],Sarl Le Poher hebdo,graphiste polyvalente,
+57a8d5e3-5346-4b65-b55f-8d119a9c01d1,[Données non publiées],aucun,aucune,[Données non publiées]
+57a99dd0-0f89-4aca-a535-b6170e96996e,[Données non publiées],Neant,Neant,
+57b61208-5b9e-4194-8559-e9eff6fcef8e,[Données non publiées],retraité,RETRAITE,
+57c22ae3-6c96-420d-b626-d9736d51084d,[Données non publiées],aucun,néant,[Données non publiées]
+57c63933-b8d9-43de-8a2d-b474e44882e5,[Données non publiées],Groupe Austral Assistance,Manager de plateau d'assistance en télécommunication,
+57cb7d4b-8d23-4d06-a48c-04e9cdd60aca,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+57cb7d4b-8d23-4d06-a48c-04e9cdd60aca,[Données non publiées],NEANT,NEANT,[Données non publiées]
+57de6fdb-abfd-48e3-a3c9-e66b39c6cb85,[Données non publiées],Profession libérale,Médecin généraliste,
+57deedbf-df9e-45b9-ad06-ebe0f0cc5ac2,[Données non publiées],AGENCE DU NUMERIQUE EN SANTE,[Données non publiées],
+57ea687b-8d62-41a9-b119-c895ad37802a,[Données non publiées],Hewlett Packard Centre de compétence France,Directeur développement,Cette activité a cessé le 1er octobre 2021 [Données non publiées]
+57f12c20-915a-48cc-8471-a68d506d6da3,[Données non publiées],[Données non publiées],Elu Maire-Adjointe + Conseillere Regionale IDF,
+57f61db9-551a-4cc0-b4cb-ed4f2248d5d7,[Données non publiées],Descours&Cabaud,[Données non publiées],
+57fa1d74-6fc7-4963-ab12-a7093c723ef0,[Données non publiées],[Données non publiées],[Données non publiées],cessation d'activité [Données non publiées]
+57fa1d74-6fc7-4963-ab12-a7093c723ef0,[Données non publiées],[Données non publiées],salariée [Données non publiées] NENO [Données non publiées],
+58002de9-1b52-455e-a9da-82cac038851c,[Données non publiées],/,/,Retraitée (Médecin Territorial)
+580948a8-f8f4-44a9-8550-364c879b3e3b,[Données non publiées],Néant,Néant,
+5812378a-72d6-460a-af97-3c4b1f932134,[Données non publiées],AS60 AGC Association [Données non publiées],Comptable Catégorie 2,
+58136000-611a-4a30-9223-ab96c348e6ed,[Données non publiées],Profession Libérale,Notaire,
+5818111a-43c5-4e05-89eb-8184c0040e30,[Données non publiées],FRANCETV ACCESS,[Données non publiées],
+58255b78-278f-44a0-bf45-a0cea2ceda71,[Données non publiées],Néant,Néant,
+5825d1c2-e1e3-401c-8e3e-65b57a8f098c,[Données non publiées],SAS [Données non publiées],Restauration,Président de la SAS
+584132e3-3245-4f4b-aef2-6ef793674d09,[Données non publiées],Retraité,néant,
+5850dd9b-b792-4e61-ac02-bf04e4111dc8,[Données non publiées],Credit Agricole,Employée de banque,
+58552c24-81a1-40e2-b3df-a9f070f91b08,[Données non publiées],Education Nationale,Professeur des écoles,[Données non publiées]
+58726c6e-9e49-4ce7-b523-3b3e57e9dff7,[Données non publiées],[Données non publiées],Auto-entrepreneur dans le domaine de l'évènementiel et de la culture.,
+58765427-96a8-41a1-a42e-7defd9894e13,[Données non publiées],néant,néant,
+587d0ab5-51b3-451c-b6bd-1c3da99050a1,[Données non publiées],néant,Néant,retraité
+5884837a-27e4-487e-9ddd-67ebf18b39c5,[Données non publiées],SEMC,Graphiste,
+5884d662-edf2-44d6-ad17-60e15d1a6bc0,[Données non publiées],Fédération française handisport,[Données non publiées],
+5884d662-edf2-44d6-ad17-60e15d1a6bc0,[Données non publiées],Dirigeant,SASU [Données non publiées],[Données non publiées]
+5888f889-6064-4f27-aa60-c79f8bdf1b88,[Données non publiées],OTIS,RESPONSABLE CENTRE DE SERVICES,
+58987c2f-705c-43d3-b1ba-edfccc42abfa,[Données non publiées],Education nationale,Enseignante partagée à 50/50 entre le premier degré et l'université (INSPE),
+58a56b62-b8d5-4f18-8fc8-1020b2d571ef,[Données non publiées],Entreprise individuelle,Fabrication et vente d'épices,
+58a6cf04-f70f-4a37-8e6e-e54e2a1e3a74,[Données non publiées],SCP [Données non publiées],Avocat aux Conseils,
+58ab0058-f646-4f77-ad1c-5d63e1aaa806,[Données non publiées],Express Coiff [Données non publiées],Responsable de magasin,
+58adc477-2f6a-4ed7-8a06-6752c0f5da55,[Données non publiées],Education Nationale,Professeur des écoles - [Données non publiées],
+58bd0998-b692-4a2c-bd20-30521997dba3,[Données non publiées],la poste,controleur,[Données non publiées]
+58ca2e64-9cdb-432c-8cd0-86aa628f5d94,[Données non publiées],SA De Giorgi,[Données non publiées],
+58d25f72-2bf1-47ef-b8ee-066ae2e4a1e9,[Données non publiées],Biocoop / Les 7 épis,Responsable de rayon,
+58de6981-a5d1-43de-8986-86654f637ce8,[Données non publiées],Communauté d'Agglomération Hénin-Carvin,[Données non publiées],
+58e15c43-eca7-4241-bdd3-12586ab79293,[Données non publiées],Education nationale,Enseignant,
+58e21de0-7670-4941-82b3-82b431381efd,[Données non publiées],SUPERGROUP (LOGISTA),[Données non publiées],
+58fe21ac-f35d-4b6b-97fd-9135539ccb65,[Données non publiées],Centre hospitalier [Données non publiées],Aide soignante [Données non publiées],
+590468d6-2e25-4df9-a9bd-2a3239564a1c,[Données non publiées],L’assemblée de la Polynésie française,"[Données non publiées] collaborateur, [Données non publiées]",[Données non publiées]
+590e0f03-735b-47e4-b112-3229c685f3df,[Données non publiées],CHUM MARTINIQUE,Praticien Hospitalier,[Données non publiées]
+590e0f03-735b-47e4-b112-3229c685f3df,[Données non publiées],Profession libérale,Chirurgienne gynécologique,[Données non publiées]
+59114234-68e6-475d-b993-c4cb5199cb9c,[Données non publiées],Néant,Retraitée,
+5912ea2a-7a8c-4903-ae14-94de7261013a,[Données non publiées],néant,néant,
+59197dc6-746a-4348-884d-50ad2905417b,[Données non publiées],[Données non publiées],Auto-entrepreneur dans le domaine de l'évènementiel et de la culture. Loueur de meublés non professionnel,
+59251573-9ffa-4e69-b2bd-a0e97fbfc420,[Données non publiées],Néant,Neant,[Données non publiées] élue au conseil départemental du Val-de-Marne.
+59269733-48e7-4a4d-af64-160cbe4e4b5c,[Données non publiées],Neant,Neant,Mon conjoint a cessé toute activité professionnelle depuis 2001 et n'occupe que ses fonctions electives de maire et president de communaute des communes hava'i
+592e5053-bd5d-4a35-babc-328d9784b2ca,[Données non publiées],[Données non publiées],[Données non publiées],
+592e5053-bd5d-4a35-babc-328d9784b2ca,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] à la retraite
+5937461a-149d-46aa-9300-5d44cecdcce3,[Données non publiées],Ministère de l'intérieur,Fonctionnaire de police,
+5937bbd7-c8fc-4639-a9f6-bf845005d701,[Données non publiées],État,Professeur des Écoles,
+5946de5c-3725-426d-8c7a-68338b66eced,[Données non publiées],conseildépartementaldelaNievre,[Données non publiées],
+594ad4e4-dd78-468d-b0d1-fb0df1af5f04,[Données non publiées],Education nationale,Enseignant,
+594f3197-bbed-48d9-95da-6e6e9f51a061,[Données non publiées],SCA [Données non publiées],Co gérant de la SCA [Données non publiées],
+59582264-6568-4cd8-9a31-080eba8b0fca,[Données non publiées],Mairie de Draveil,Retraitée,
+596cf8e7-3547-459d-8cf0-27a8b756484f,[Données non publiées],Lycée Général et Technologique et Lycée Professionnel [Données non publiées],Professeur d’Education Physique et Sportive. [Données non publiées],[Données non publiées] [Données non publiées]
+5972c985-b8b1-4436-9ae6-3ec8ee74934d,[Données non publiées],néant,retraité,
+5974dfcf-6fe3-49fe-b569-ec2a1ea5ae10,[Données non publiées],CCI Guyane,responsable d'antenne de Saint Laurent,
+59764081-ac61-49c7-833c-7dcf6d3f7753,[Données non publiées],lui-même,chirurgien dentiste,
+59791242-8d5e-4b10-99cd-28d739b26ef7,[Données non publiées],CEREMA,[Données non publiées],
+5979b97e-7907-4958-856e-b6caf3ddbb83,[Données non publiées],Bnp paribas,Directeur de projet informatique,
+59834d54-c529-4aab-a0b3-3c13c6d34ef9,[Données non publiées],[Données non publiées],MEDECIN,
+59868916-1dd1-4323-85e3-e8d3d7bfb0fb,[Données non publiées],[Données non publiées],Orthophoniste en structure d'accueil pour enfants handicapés,
+59895410-2663-44e9-9eae-f3a5abf8d564,[Données non publiées],Education nationale,Professeur des écoles,Actuellement directrice de l'école [Données non publiées] [Données non publiées]
+598c1ac6-02ad-47b4-a80a-2053dcb266e7,[Données non publiées],Ville de Poitiers,Agent de maîtrise [Données non publiées],
+59b07cf4-470e-4387-b4c7-12b5a18d4d37,[Données non publiées],néant,néant,
+59b589f2-fa4b-4c16-94fb-be614d766413,[Données non publiées],ATPARTNER,comptabilité,
+59bf5fee-f017-43fd-a0c5-cb90f333d8f4,[Données non publiées],Communauté de Communes du Champsaur Valgaudemar,Salariée Responsable de la France Services du Champsaur Valgaudemar,
+59c097eb-0831-41c6-a324-88ef9ebbeff3,[Données non publiées],AEP ND du Mont Carmel,Institutrice,[Données non publiées]
+59ce2627-7ce4-4031-9bad-60fe20250123,[Données non publiées],IFAC et Atout Environnement,[Données non publiées],[Données non publiées]
+59d820ca-63d7-4886-9bc1-18016406981b,[Données non publiées],EARL [Données non publiées],co gérant de société,
+59d820ca-63d7-4886-9bc1-18016406981b,[Données non publiées],[Données non publiées],Entreprise de Travaux agricoles,
+59dae19d-d816-47ee-93f6-cf64dbc9a985,[Données non publiées],Covea assurances,informaticien,
+59db697d-dd7e-4a0d-a97d-bcc26fe3f4f7,[Données non publiées],Dirigeante de la SARL Atelier Sardane,[Données non publiées] agence de communication,
+59dd511d-5a64-409f-bb53-52e76837ac6b,[Données non publiées],Activité libérale,Médecin psychiatre,
+59dd8ce9-5315-4c1a-855d-f81b73cb1c9b,[Données non publiées],retraitée,retraitée,[Données non publiées]
+59dfa642-d4b6-48d0-9ea6-61685d8b082a,[Données non publiées],Fonctionnaire Etat,Sous Préfet,
+59f2340e-69fb-433e-b0fd-49f9a255dceb,[Données non publiées],Minstere de l'enseignement supérieur et de la recherche,Professeur des Universités [Données non publiées],
+59f66301-db9d-46a5-8eb3-284d0cb389f1,[Données non publiées],Foncière de la tour,gérant,
+59f71998-2e70-432b-b86b-b501b60db122,[Données non publiées],Direction des Services Départementaux de l'Education Nationale du Cantal,AESH [Données non publiées],
+59fa0dd3-725d-4516-a602-4320394eb1fb,[Données non publiées],ACORUS,Chargé d'étude de prix. Agent de maitrise.,[Données non publiées]
+5a04e616-cfd0-4762-b45e-aa524f27d3b6,[Données non publiées],Education Nationale,Professeur des écoles,
+5a1ed790-8331-43ec-842a-1ddb7879da49,[Données non publiées],AHSS,[Données non publiées],
+5a2a68b5-faa1-4a70-8f47-c5860da8d2dd,[Données non publiées],SAS INTENDANT VILLA SERVICES,MANAGEMENT VILLA,[Données non publiées]
+5a2b92a5-af70-45f9-8aed-6e793ea59915,[Données non publiées],néant,néant,retraitée de l'éducation nationale.
+5a2bc94f-11e9-451d-98c6-b168926e23c8,[Données non publiées],NEANT,NEANT,[Données non publiées]
+5a335187-e8b1-49b9-aa6b-0973f523481a,[Données non publiées],Néant,Neant,
+5a3bc3a0-e047-4b9a-a99c-441f9ac750f5,[Données non publiées],Néant,Retraitée,
+5a4ba3de-0256-4a04-8a33-f6fd85c00f03,[Données non publiées],TRIXELL,Ingénieur,
+5a4ba3de-0256-4a04-8a33-f6fd85c00f03,[Données non publiées],[Données non publiées],Conseil en entreprise,Activité de conseil crée en 06/2020 [Données non publiées]
+5a958a69-c5f1-492c-a2de-fd8b96d19ea0,[Données non publiées],Travailleur indépendant,[Données non publiées] réseau immobilier [Données non publiées],
+5a96176e-3e8c-4f6c-b65d-a7a3da526c8c,[Données non publiées],Assemblée nationale,Député,[Données non publiées]
+5a9b2912-cc37-4a44-9d75-b94162fe0f34,[Données non publiées],Retraitée,Retraitée,
+5aa0b11f-a35c-49b3-aba5-6625253c2677,[Données non publiées],Education nationale,Enseignante,
+5aa91642-dfd0-4ca0-9f28-f83739bf8b28,[Données non publiées],régie networks,[Données non publiées],
+5aaedb61-a973-43a2-bc09-4b0afec93044,[Données non publiées],NEANT,Retraité SNCF,
+5ac160a5-fd3f-4112-9901-7dfcf6479415,[Données non publiées],SAS [Données non publiées],SECRETAIRE COMPTABLE,
+5ac160a5-fd3f-4112-9901-7dfcf6479415,[Données non publiées],EARL [Données non publiées],GERANTE,
+5ac21f18-7370-441d-9533-61816978c689,[Données non publiées],[Données non publiées],Groupe pharmaceutique et dermo-cosmétique Chargé d’études de marché,
+5ac68da2-4a06-4635-bbd3-8fa18ec3ac2c,[Données non publiées],néant,néant,
+5ac7c5c8-009e-41e3-9570-0c7b0d0ffc52,[Données non publiées],NEANT,NEANT,
+5aca390d-5eb7-4b05-842d-cbaf5c4a5259,[Données non publiées],Néant,Pas de conjoint,[Données non publiées]
+5ade91a8-b4e6-4edd-b91d-022a1f738977,[Données non publiées],Education nationale,Professeure des écoles,
+5ae03be0-7732-4d1c-8145-e296a2551734,[Données non publiées],MANUFACTURE BREGUET,Opérateur en horlogerie,
+5ae8c652-63b2-4fef-a014-932ba5239660,[Données non publiées],Néant,Néant,
+5b02b07c-4ec5-438f-821f-bb589f0f3330,[Données non publiées],éducation nationale,enseignante en collège [Données non publiées],Aucun
+5b03c6ea-7817-4802-aed2-b97932fc23e3,[Données non publiées],DIOTSIACI,Directeur Général [Données non publiées],Groupe de courtage et conseil en assurance
+5b03ddbd-0514-406e-861a-efc19927ed2b,[Données non publiées],Associé-co-gérant de société civile professionnelle d'avocats,Avocat,
+5b054b89-7417-466d-aa6f-2cd03d796c74,[Données non publiées],MAAF,Gestionnaire de sinistres / matériels automobiles.,
+5b076404-d0ea-4cc5-98ff-f795785c3e54,[Données non publiées],CINEOR,SOUDEUR,
+5b079955-40aa-427d-aad6-ef8a3226f761,[Données non publiées],ASSURANCES [Données non publiées],COLLABORATRICE AGENCE ASSURANCE,
+5b0a3f4c-f552-47ca-8eb5-7249f47e60da,[Données non publiées],Assemblée nationale,Député,[Données non publiées]
+5b111d36-a4c4-44b2-86c4-1abaa3b0810b,[Données non publiées],Ville de Marseille,Service Ressources Humaines des écoles. [Données non publiées],
+5b14d037-3f9d-4ad0-bb73-05bb914e9660,[Données non publiées],courtier,assurance,[Données non publiées]
+5b191c78-128a-466a-8e85-9ef579456558,[Données non publiées],retraité,aucune,
+5b1b40a0-b1cc-475b-b7a3-c36f621b1e14,[Données non publiées],GAEC [Données non publiées],Exploitante agricole,
+5b2c2369-de9c-4793-a1c1-13c19ec35934,[Données non publiées],Etat,professeur des écoles,
+5b38fc17-9fc7-4ddf-b667-c08026c4faf9,[Données non publiées],néant,exploitante agricole,[Données non publiées]
+5b43754c-d6ca-4852-9d4f-d7684084a8c6,[Données non publiées],mairie,[Données non publiées] [Données non publiées],
+5b43754c-d6ca-4852-9d4f-d7684084a8c6,[Données non publiées],retraite,ancien médecin généraliste [Données non publiées],
+5b4622e8-5bf7-46f5-a2f7-45212ec7565a,[Données non publiées],SAS [Données non publiées],gérant,
+5b478161-42d5-413d-b5d2-51343433db18,[Données non publiées],Communauté de communes Cazals-Salviac,[Données non publiées],
+5b55c1d9-fd86-4a78-ac9d-89abf46723b2,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+5b57836f-540d-452a-8baa-7f87ee850b25,[Données non publiées],Mairie [Données non publiées],Secrétaire générale,
+5b6108fc-fa53-4357-9dae-c10dd5d5bcdb,[Données non publiées],Neant,Retraitée Néant,
+5b643a66-7607-4ceb-abcc-143bf6aa0fdd,[Données non publiées],Ministère Education Nationale,Professeure des écoles,
+5b6cf1ea-00c3-400b-9bad-95d39e4eb7aa,[Données non publiées],Education nationale,Enseignante,
+5b739b83-6b09-4eb3-ae05-b700f30391cf,[Données non publiées],SAS [Données non publiées],Président de cette société qui a pour activité le Conseil en Gestion de Patrimoine,
+5b742aef-126c-4055-a879-b92c833bd02a,[Données non publiées],Divers,Journaliste et autrice indépendante.,[Données non publiées]
+5b74c305-189a-4b3c-8558-fb046e43b104,[Données non publiées],Centre Hospitalier [Données non publiées],Cadre administratif [Données non publiées],
+5b81f7f2-790c-4206-adcb-e24ce0816ea6,[Données non publiées],Centre hospitalier [Données non publiées],Directrice [Données non publiées],
+5b8a5b48-1e71-4191-86ac-88d83575957e,[Données non publiées],Association régionale biomasse normandie,[Données non publiées],"L'association répond à des marchés ou passe des conventions de partenariats, selon les cas. L'association est l'un des prestataire/partenaire de la Ville. La Ville de Caen siège au conseil d'administration de l'association."
+5b8c30dd-3b49-4f1e-bdc5-e0faeb73d134,[Données non publiées],[Données non publiées] Agglomération,Responsable pôle habitat,
+5b9ca584-87b5-4625-b889-ee710e240d7b,[Données non publiées],Ecole des Ponts,chargé d'enseignements,
+5b9ca584-87b5-4625-b889-ee710e240d7b,[Données non publiées],Parlement européen,Député européen,[Données non publiées]
+5ba16bb1-0906-4cd1-b72a-7a9d9bdab569,[Données non publiées],NEANT,NEANT,
+5ba75142-bacc-46b0-b519-bf476e879f1a,[Données non publiées],néant,retraité de la Société Taxis Cousin,"Au 27 août 2021, gérant de la SCI [Données non publiées] (terrains et bâtiments)"
+5ba8ff83-10cd-4529-9737-1e8a80735de4,[Données non publiées],[Données non publiées],[Données non publiées] EXPLOITATION AGRICOLE EN CAPRIN LAIT,[Données non publiées]
+5badc463-af58-43cb-a04b-7ee39e9c47c6,[Données non publiées],R+4,Assistante,
+5bb7d1e8-5517-407a-9c39-53c22e39c4fd,[Données non publiées],cosy home france [Données non publiées],[Données non publiées],gérant [Données non publiées]
+5bbb3c90-d2c6-402f-9a35-b6aef59d0eb3,[Données non publiées],[Données non publiées],Présidente de SAS MOJO CONSEILS,
+5bbb9ade-4ab3-4f21-aeb4-2d7d5f18d821,[Données non publiées],La Francaise REM,[Données non publiées],
+5bc96dc6-891a-4b20-92b3-401c627990e0,[Données non publiées],ORANGE,Responsable [Données non publiées],
+5bcb4214-8f69-43dd-a1a8-b84b73b47a32,[Données non publiées],Orange,Ingénieur architecte réseau,
+5bce7abb-4cb7-47fa-a503-6b0bff5a7700,[Données non publiées],EDUCATION NATIONALE,ENSEIGNANTE,
+5bd10317-62d4-48cb-bc47-31d73a308893,[Données non publiées],NEANT,NEANT,[Données non publiées] élue [Données non publiées]
+5bd7920c-fd39-4e82-931a-603a1c9de0bb,[Données non publiées],néant,infirmière libérale,
+5bdceed0-e413-4918-9c2f-1c80317876e2,[Données non publiées],IPSEN INNOVATION,Chef de projet,
+5bdfef34-2e7f-4419-b4f1-e50bd4b3273b,[Données non publiées],CMA France,Directeur des relations institutionnelles,
+5be6b2b5-1fe5-4413-98ac-7f59f8779142,[Données non publiées],Macon beaujolais agglomération,Directrice de service,
+5beb4a43-ea51-4639-a370-76e8a0de1934,[Données non publiées],France Télévisions,Journaliste spécialisée,
+5bf62766-b885-4d8c-af32-f87bd844cacf,[Données non publiées],Ecoles Militaires de Bourges,Responsable du pôle [Données non publiées],
+5bf64553-38f5-4608-ad0d-bf63ae827cbe,[Données non publiées],CABINET LEFÈVRE ET RAYNAUD,AVOCAT,[Données non publiées]
+5bfbc3ef-c9b4-42d5-b770-e25c7c62ec23,[Données non publiées],Parfum Christian Dior,Responsable de Laboratoire,
+5bfe0cc5-eda8-469a-9980-e5a27cdb4b6c,[Données non publiées],Mairie de Clermont-Ferrand,[Données non publiées],
+5c061798-61b1-4cf6-a60a-b8bb157c0e0a,[Données non publiées],hôpital de Ribérac,cadre de santé.,
+5c102529-5d54-445b-abe6-015ee91af234,[Données non publiées],pole emploi,conseillere emploi,
+5c2bbd52-e773-4b8e-b041-638b07c5691b,[Données non publiées],Suez [Données non publiées] [Données non publiées],Assistante de gestion,
+5c4973d4-7fca-4fbe-8e5d-d18040d3875d,[Données non publiées],Parlement Européen,Député Français au Parlement européen,
+5c4a867b-5ed0-43cd-879e-829c1a3c5ec4,[Données non publiées],[Données non publiées],[Données non publiées],Plus d'activité professionnelle [Données non publiées]
+5c4ebe5f-15e6-492b-b620-b4c7c872d37e,[Données non publiées],Cnam,Animation et pilotage [Données non publiées],
+5c4fa135-19df-4272-b2a0-28364ddb6516,[Données non publiées],Centre Electrique Entreprise,Animateur Prévention Sécurité,
+5c582382-e954-4a56-ac12-fc4446ca0adc,[Données non publiées],Apple Retail,Manager commercial,
+5c61a637-6c1a-4c5b-9b57-491ea1edad88,[Données non publiées],Education Nationale,inspecteur,
+5c6fd6c9-e8a9-4997-839a-f25af82d4fac,[Données non publiées],Pompes funèbres [Données non publiées],Conseillère funéraire,
+5c7bbed7-6ce9-4e58-a44b-32dfe582eeda,[Données non publiées],Libérale,Infirmière,
+5c7cdb25-37c1-4b18-8c5d-94a13df62ffc,[Données non publiées],AGCAG,Association de gestion et de comptabilité Cabinet expertise comptable,[Données non publiées]
+5c7e4f30-6aeb-4d9e-baec-90ee05112864,[Données non publiées],CONSEIL DEPARTEMENTAL,COLLABORATRICE / ASSISTANTE DE GROUPE POLITIQUE.,
+5c7ffe2f-386a-4bd3-8f46-dfa4265f9d7d,[Données non publiées],PTC,Ingénieur,
+5c8089f4-62be-4cb1-962b-3bfdef856c49,[Données non publiées],Conseil Départemental Gironde,[Données non publiées],[Données non publiées]
+5c81dcf7-e749-47e4-985b-d07809947217,[Données non publiées],Conseil départemental des Yvelines,Sage-femme,
+5c84dd1b-13c4-4e7b-aa8f-84e2ad9608f0,[Données non publiées],SA MILLET,Fabricant de portes et fenêtres,
+5c8621dd-05d3-4944-bb98-e72eb7efa442,[Données non publiées],MISSION LOCALE REGIONALE DE GUYANE,[Données non publiées],
+5c8fc5f9-f9df-416a-82d3-c6d68a678980,[Données non publiées],Bati 85,Assistante commerciale,
+5c918934-67e2-4108-9783-cca47ce97f93,[Données non publiées],CNRS,Chargé de Recherche [Données non publiées],
+5c94dad2-859f-4033-b504-10ca0821503b,[Données non publiées],Pays,Adjointe administrative,[Données non publiées]
+5cb76d7c-5c3f-488f-be17-fe294ad54388,[Données non publiées],Education Nationale,Professeur certifié d'Histoire Géographie [Données non publiées],
+5cb917e9-621f-4d72-a66a-a213d1ff3a49,[Données non publiées],[Données non publiées],[Données non publiées] retraitée,
+5cc874bb-2fec-48ea-b572-dda5972e50a9,[Données non publiées],Polyclinique de [Données non publiées],Infirmière Responsable du Service [Données non publiées],
+5ce84475-fe62-4915-b95b-fd898e9ea454,[Données non publiées],Spim menuiserie,Menuisier,
+5ce8c569-465f-4cb9-9472-7f7345d108dd,[Données non publiées],Néant,Néant,[Données non publiées]
+5cf6dce8-14da-4aca-ae8c-160a7430cb5e,[Données non publiées],AUTOENTREPRENEUR,DIVERS TRAVAUX DE RENOVATION PETITE MACONNERIE,
+5d00b800-1a71-46f1-824b-eb59fe49ba57,[Données non publiées],[Données non publiées],Animatrice de gymnastique volontaire,[Données non publiées]
+5d0583f8-069b-483f-b08b-826573f3a2ad,[Données non publiées],AUTOENTREPRENEUR,Etude Marketing,
+5d0944ae-139f-40bb-8aad-ba9219442ff4,[Données non publiées],Centre hospitalier [Données non publiées],infirmière,
+5d0a545e-7acd-40f8-8a72-fbf13f1efe01,[Données non publiées],Maison de retraite SAS L'Hespérie [Données non publiées],Assistante de direction,
+5d0b1790-ccbb-4692-889f-30b2f7bc553b,[Données non publiées],SCP NIQUE SEGALEN PICHON,Bureautique et comptabilité,
+5d0d7fc8-8a26-4711-891f-3b67285e3f6d,[Données non publiées],neant,[Données non publiées],[Données non publiées]
+5d12ecc2-3763-486e-ab05-4dda694c0128,[Données non publiées],[Données non publiées],directrice maison de retraite,
+5d1cf9eb-aa2f-4dba-b7e6-68bc7cbb5236,[Données non publiées],NOMALYS,CHEF D'ENTREPRISE,
+5d2b2864-d0ec-42d2-a4a9-68392955b909,[Données non publiées],URIOPSS PACA CORSE,Conseillère technique [Données non publiées],
+5d36d206-58b7-4853-a6e1-4ad31016d43d,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+5d3ccb2c-0ace-4d25-a543-c69dc6a677a6,[Données non publiées],Mairie de Luisant,Responsable de la communication,
+5d42107b-e3b5-4adf-8f4f-ea0dff82e914,[Données non publiées],Education Nationale,Professeure des écoles,
+5d47fd57-42cc-4600-9e7d-2252ff9dd915,[Données non publiées],CAPEP,[Données non publiées],
+5d49974d-5037-4c9b-89a6-0262547c70bc,[Données non publiées],direction generale des finances publiques,auditrice,
+5d4ea581-39ec-47fe-bd22-838ad8df1fa5,[Données non publiées],[Données non publiées],directrice de cabinet,
+5d4f4e56-64ce-46fa-bc38-a6db08324b78,[Données non publiées],CRIDON [Données non publiées],Juriste [Données non publiées],
+5d50121b-ba45-49c6-ac7e-c060ef1ea8fd,[Données non publiées],[Données non publiées],AUTO-ENTREPRENEUSE PSYCHO-PRACTICIENNE,
+5d56aa7d-196e-4a45-9857-3d23dc9a60d6,[Données non publiées],Néant,Néant,
+5d6948e0-7592-4722-a95d-6aa4a7881d55,[Données non publiées],La Fab,[Données non publiées],
+5d6b4c24-bc34-4846-9716-b2198272c6a1,[Données non publiées],EPSM [Données non publiées],Infirmière,
+5d6b5bea-5db9-476d-a517-181486944ee1,[Données non publiées],régie du palais des congrès,directrice [Données non publiées],[Données non publiées]
+5d921565-70b9-4144-b180-6fa212d71978,[Données non publiées],PROFESSION LIBERALE,infirmiere liberale,
+5d9523e9-ac11-428f-bf68-ddd35002896d,[Données non publiées],[Données non publiées],Urbaniste-Chargée d'études principale,
+5dad2cbb-c8be-4f7f-9c55-10952b88cc92,[Données non publiées],néant,Néant,
+5dd34dce-7a24-4f2a-9ff0-a61d881d84f7,[Données non publiées],néant,néant,
+5dea67e9-41cf-4b5e-8ad9-8f4c61684d05,[Données non publiées],Conseil Départemental de la Charente,[Données non publiées],
+5df1353b-cefa-4591-89a8-016cce1828b2,[Données non publiées],SARL MPC,Gérante de SARL [Données non publiées],mandat électif Conseillère Régionale Nouvelle-Aquitaine
+5dfef5cf-a2eb-455a-a115-46b491ef3c57,[Données non publiées],[Données non publiées],Retraite,
+5e11cd01-7cb6-4f9c-acc5-d50fcf1fd2bd,[Données non publiées],Education nationale,enseignante.,
+5e28c9d3-11ac-47f7-a71a-d12e45ed19ad,[Données non publiées],SUPERGROUP (LOGISTA),[Données non publiées],
+5e2f14c9-ff08-43b2-b94a-eed4ff3f4a98,[Données non publiées],Mairie de Rieumes,[Données non publiées],
+5e3260ca-6756-42b4-b0da-7b70a4fe29e5,[Données non publiées],Néant,Néant,
+5e3b7ffd-3c25-446d-9662-7c273dda7049,[Données non publiées],NORAUTO,VENDEUSE,
+5e3f9568-bb91-4ebc-a478-64470448064f,[Données non publiées],divers,assistante_maternelle,
+5e524467-a33c-462e-bf50-407c1021bb04,[Données non publiées],CD90,Directrice de la communication,
+5e531883-cbdf-43ff-9bb7-ad862b3b104e,[Données non publiées],GENERALI FRANCE,[Données non publiées],
+5e583949-9594-455e-8ad2-e42ff7021790,[Données non publiées],EDUCATION NATIONALE,Professeur des ÉcolesDirectrice,
+5e5b6222-edb3-4f2e-a40f-8fac5aaf81ed,[Données non publiées],[Données non publiées],pharmacien titulaire [Données non publiées] [Données non publiées],
+5e666d4f-8c07-4dff-a9c8-634524c742b6,[Données non publiées],Greta de l'Aisne,Formateur en formation continue,
+5e668ee6-9cf3-4d32-b5dd-1595b28c3029,[Données non publiées],[Données non publiées] Agglomération,Responsable pôle habitat,
+5e67aa40-218e-4d2c-bdc6-fc8a55cb9845,[Données non publiées],RATP DEV,"Transport en commun, responsable d'unité.",
+5e873f52-32e0-4523-bade-7c42754c4631,[Données non publiées],[Données non publiées],TRAVAUX PUBLICS ARTISAN,
+5e8b4702-16c9-4686-b449-e64788025120,[Données non publiées],SARL SPORTIMMO,[Données non publiées],
+5e8c2bf8-7757-4e12-94b5-9d8c9a7d2ebc,[Données non publiées],France Télévision,Journaliste,
+5e8ce105-4039-4751-b425-e881e0bdd1be,[Données non publiées],AGCAG,Association de gestion et de comptabilité Cabinet expertise comptable,[Données non publiées]
+5e944cab-b8c0-438f-8d14-9317381f96ee,[Données non publiées],Cooperl,Mécanicien,
+5e9757ec-1186-4483-ab2e-6e5a022d81e3,[Données non publiées],Aucun,Pas d'activité professionnelle,Gérante de la SCI [Données non publiées]
+5e97f7f9-f8ef-40b1-b56d-9c814522a438,[Données non publiées],[Données non publiées],Assistante de service social,retraitée [Données non publiées]
+5e980d1b-2360-4417-83a0-2d4a5f8a84b3,[Données non publiées],Art Escale,Galiériste,
+5ea2faef-1ae5-4cb5-a348-de9f5d96c6bc,[Données non publiées],SOCIETE D ACCONAGE ET DE TRANSPORT,MANUTENTION PORTUAIRE,
+5ea9afaf-a1d7-4d9d-b7db-0e73f6620188,[Données non publiées],[Données non publiées],Gérant,
+5eae22be-8cde-4859-89e7-afbec21d6ad5,[Données non publiées],Retraitée Education Nationale,[Données non publiées],
+5ebb89db-9f3b-4562-a287-60acf6f0fae8,[Données non publiées],Agriculteur,[Données non publiées],
+5ee0b604-0d19-4964-a3d3-95256c51b605,[Données non publiées],APEI AUBE,[Données non publiées],
+5ee12390-07e8-4ed1-a789-f491b7b925fc,[Données non publiées],Inspection academique,Professeur des ecoles,
+5eea71fd-e605-4801-9683-eb801602d511,[Données non publiées],Hopital [Données non publiées],Infirmière,
+5eec953f-d9de-481d-ba95-391eae4d3c61,[Données non publiées],SAS GinKo,[Données non publiées],
+5ef2942c-772b-4d57-bbd0-68afef106e48,[Données non publiées],Etude d'Avocats [Données non publiées],Secrétaire,
+5ef2de94-9df2-4019-9790-08462a13d1da,[Données non publiées],Centre Hospitalier [Données non publiées],Infirmière DE,[Données non publiées]
+5f04a806-8157-4a1e-bc38-e31a34502312,[Données non publiées],camping [Données non publiées],Gerant,
+5f096a22-9917-443d-bea8-e374db71dc3c,[Données non publiées],AXA [Données non publiées],Conseillère clientèle,
+5f11686c-edf8-47ce-b170-33717e333ca0,[Données non publiées],Education nationale,Professeur des écoles,
+5f1539b8-0fc2-4dca-be60-cf7e621492d8,[Données non publiées],EDUCATION NATIONALE,PROFESSEUR,
+5f17d431-c459-4b23-82ec-54b1437f15af,[Données non publiées],KEOLIS,Conducteur,
+5f1de4b5-3a33-4696-b801-2330bd435348,[Données non publiées],Ministère Education Nationale,Professeure des écoles,
+5f27f1f3-fb53-475c-befe-7cd957617912,[Données non publiées],assurance maladie,Assistante administrative,
+5f45e46a-b8ce-4f6a-b583-253e9d8a9e47,[Données non publiées],Néant,Néant,[Données non publiées] [Données non publiées] retraité
+5f49ba04-d003-40ee-8f34-34f0ed619021,[Données non publiées],NEANT,RETRAITE,
+5f560e23-abea-4632-8df1-5f849b8b0a02,[Données non publiées],UGECAM IDF,Cadre de Santé,
+5f5ef815-01e9-47df-98a8-9a7c93199bb8,[Données non publiées],ASSOCIATION MEDICALE LA TEPPE,MONITEUR D'ATELIER,
+5f5fb3f6-5ac3-4f13-8f84-3a5bf45b8eb6,[Données non publiées],Communauté d'Agglomération du Grand Périgueux,[Données non publiées],
+5f671977-a631-486a-a52f-0d6f0b0482fd,[Données non publiées],artisan,plombier,
+5f683397-da93-482b-b93b-40176bfc6d8a,[Données non publiées],keller williams,transaction immobiliere,[Données non publiées]
+5f683397-da93-482b-b93b-40176bfc6d8a,[Données non publiées],iteva - gerant,sarl [Données non publiées],[Données non publiées]
+5f6b7152-b9b2-475c-ae3a-3051f02bb174,[Données non publiées],UNIVERSITE [Données non publiées],MAITRESSE DE CONFERENCE,
+5f6fb502-e413-4424-833d-e9c6b774c3e8,[Données non publiées],Ministère de la Justice,Conseillère d'insertion et de probation,
+5f74710f-c90d-438f-89a1-98f6319f0913,[Données non publiées],AGRI BOUCHET,COMPTABLE,
+5f74710f-c90d-438f-89a1-98f6319f0913,[Données non publiées],RELAIS ACCUEIL PROXIMITE,SECRETAIRE COMPTABLE,
+5f8acffd-c264-4668-a1b0-ddbd8d87cde4,[Données non publiées],NEANT,NEANT,
+5f929029-7ae9-4fcf-881c-f3562de37a9f,[Données non publiées],Ville de Saint-Denis,Ingénieur sans activité. élu local depuis le 4 juillet 2020 (ville de Saint-Denis et EPT Plaine COmmune),[Données non publiées]
+5f93e97b-79a2-4da4-b2f4-02769f3986fd,[Données non publiées],MAERSK FRANCE,EMPLOYE DE CONSIGNATION,
+5f9c15af-748c-44af-85ef-35437b597834,[Données non publiées],Préfecture de l'Oise,Attachée principale [Données non publiées],
+5fb7b2e3-27e2-4eb8-89e9-1c327ea8c133,[Données non publiées],Celtic Wisky Comagnie,[Données non publiées],
+5fbf61a9-a1dc-43ef-9635-4d690a1788aa,[Données non publiées],Education Nationale,Professeur des Ecoles,
+5fc0d806-a4e8-44f9-a545-dfa6f52d13a8,[Données non publiées],AP-HP,Infirmière,
+5fe48867-579b-4c92-84f5-f051176b211f,[Données non publiées],CD14,Responsable de pôle,
+5ffb92e8-7cc1-48b4-9aea-630355cdcbcd,[Données non publiées],Etat: DIR [Données non publiées],Contrôleur principal de travaux,retraité [Données non publiées]
+6009137b-169a-425b-96fc-2cc8f69b8218,[Données non publiées],[Données non publiées] [Données non publiées],[Données non publiées] [Données non publiées],
+6009137b-169a-425b-96fc-2cc8f69b8218,[Données non publiées],Libérale,Activité d'avocate libérale en droit de la fonction publique [Données non publiées],
+6038c50a-c3d4-4cc5-b749-e404e45bc964,[Données non publiées],Société Dolmen,Responsable [Données non publiées],
+60435924-6685-45b5-8edf-714300f931e3,[Données non publiées],Sénat,Assistant parlementaire,
+6046f528-880b-407e-8596-0f095bad15a3,[Données non publiées],néant,néant,
+60491155-987d-4bf2-9254-4d70ce8a8273,[Données non publiées],[Données non publiées],[Données non publiées] CENTRE SCIENTIFIQUE MONEGASQUE,
+604d0c22-3023-49e8-989a-a1a1998c31b5,[Données non publiées],Education Nationale,AESH,
+605337ca-a666-455b-a4b5-9bdad5a5f0cc,[Données non publiées],Neant,Neant,
+6054aac2-30ad-4051-b5dd-179ad69f34ae,[Données non publiées],université [Données non publiées],Enseignant chercheur,
+605c3696-f748-4360-9bf5-bd96e86c290a,[Données non publiées],Assemblée Nationale,Député [Données non publiées] et Notaire,[Données non publiées]
+60605c8e-4210-475c-9852-5aac2406c855,[Données non publiées],L'Ellara,Restauration,Gérante appointée de la SARL l'ELLARA
+606563fe-acfd-4f0c-94d0-ec521b87a1d1,[Données non publiées],Ministère des Armées,officier de carrière,
+60688c4c-e773-406a-a3d5-a970b2fb9ca7,[Données non publiées],Education Nationale,Professeur de Physique Chimie [Données non publiées],[Données non publiées]
+606e385e-1482-4026-9d5d-cf1c0f801a88,[Données non publiées],Retraitée,néant,
+60775923-45a3-47ca-85c6-a14504c0b72c,[Données non publiées],education nationale,professeur des ecoles,[Données non publiées]
+6079ffb6-037b-498d-9b0c-857bd6cd01c9,[Données non publiées],EDUCATION NATIONALE,PROFESSEUR,RETRAITEE [Données non publiées]
+60836b7b-a722-4ac8-9948-6eebcfd05bec,[Données non publiées],LIBERAL,MEDECIN GENERALISTE,
+608ffc15-34ae-45ad-87b7-9af32a052170,[Données non publiées],Ministère de la Culture,Ingénieure d'étude,
+60915461-1b03-4731-b3e0-dce54ee4af36,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] retraite [Données non publiées]
+609e82ed-45d1-4cd0-8c35-87de9ca9f068,[Données non publiées],UBIQUS,Rédaction et interprétariat,
+60a0ebaf-e54f-4e1a-99b4-7405fac47a91,[Données non publiées],profession liberale,Dentiste,[Données non publiées]
+60a31a72-df8f-4c22-9ab1-249391bb35d5,[Données non publiées],néant,Néant,Sans emploi
+60b3b5a2-408b-4063-b0f2-96bd4b32f2fd,[Données non publiées],SCHNEIDER ELECTRIC,VP Energy Transition Research,
+60badfdd-2dcb-49da-b555-2352aec30343,[Données non publiées],Ville de montreuil,Assistante de direction,
+60c180fa-0b2a-4575-94a3-18e6f0bc01d5,[Données non publiées],Education Nationale,Professeur des ecoles,
+60c7ba8f-6abc-43ab-a3b8-e67ded9b7088,[Données non publiées],CPR SNCF,gestionnaire,
+60d8c311-f3c6-4dee-9541-aa3d7e43a4c1,[Données non publiées],SARL LE JEU AUX QUILLES,[Données non publiées],
+60d8c311-f3c6-4dee-9541-aa3d7e43a4c1,[Données non publiées],SAS LES QUILLES RENOUVELABLES,[Données non publiées],
+60db0276-e4f3-4c3a-b2b5-d55f0eac8639,[Données non publiées],Ministre de l'économie,Administratrice civile,
+60dd8cc4-6fbd-4665-bd1b-0edb251d5989,[Données non publiées],néant,néant,
+60debd21-7887-4a0d-b3ec-05f9a12533f7,[Données non publiées],Néant,Neant,[Données non publiées] élue au conseil départemental du Val-de-Marne.
+60e557f6-98eb-4329-8d6a-05cd01bd36d5,[Données non publiées],CPAM,Cadre Coordonnateur,
+60ec9af5-c9a7-4db6-9bc5-240eda70c325,[Données non publiées],conservatoire de musique et de danse du tarn,agent comptable,
+60f90c46-e958-49b2-9a43-2998d9e4ca9c,[Données non publiées],AXIOME NOTAIRES,Notaire associé [Données non publiées],
+610a1ea4-a8dc-406e-9c6a-c18b44f2cbaa,[Données non publiées],Jacer Primeur,Vendeur [Données non publiées],
+610ee5b2-4030-46aa-8a55-552755feaa85,[Données non publiées],MAIRIE,COLLABORATEUR DE CABINET,
+61139ca4-09bf-41a8-93ba-0aa46deb4b4d,[Données non publiées],CLOTURES MOIZARD,RESPONSABLE ADMINISTRATIF ET FINANCIER D'UNE ENTREPRISE DE CLOTURES DE MOINS DE 10 SALARIES,[Données non publiées]
+61160d37-40b0-45c9-8be8-ffc161328f1e,[Données non publiées],Retraitée,Retraitée,
+611a0267-c43e-4a91-8cb7-7a907b652dd7,[Données non publiées],[Données non publiées],Avocate/juriste [Données non publiées],[Données non publiées]
+611e8d85-7115-4b7c-9b7d-7364c0d867c5,[Données non publiées],Mairie de Noisy le Sec,[Données non publiées],
+6123f270-5800-4717-8565-a418eed609f8,[Données non publiées],MICRO ENTREPRISE,COIFFURE A DOMICILE,[Données non publiées]
+612af3ef-76a1-4b74-88f6-352da2b49dc9,[Données non publiées],Néant,Néant,
+612b5453-e299-4e5b-9f31-2a3fe5827a24,[Données non publiées],L2N,SECRETAIRE,
+612bf178-0eac-4adb-9dc4-343dccadcf90,[Données non publiées],Retraitée,aucune activité,
+612e8be2-b507-4797-b1c4-e762a15d8bb8,[Données non publiées],Bourse de l'immobilier,Chef d'agence [Données non publiées],
+6130a236-11bd-494f-b31c-0a1b8bf7f11f,[Données non publiées],[Données non publiées],[Données non publiées],
+6130a236-11bd-494f-b31c-0a1b8bf7f11f,[Données non publiées],[Données non publiées],[Données non publiées] retraitée,
+61338e4d-e4dc-4c62-b386-bf6bf5868592,[Données non publiées],STAG - Villers Bretonneux,Assistante administrative,
+6137b601-872c-42f0-9ee7-cae070435d14,[Données non publiées],NORCAN,[Données non publiées],[Données non publiées]
+6140dc6b-5d3f-43a5-aefb-a1cbd2e9eeb6,[Données non publiées],centre hospitalier [Données non publiées],[Données non publiées],[Données non publiées]
+6151711e-df77-45c4-9180-32203186f27e,[Données non publiées],Colas [Données non publiées],conducteur d'engin,
+6158d684-c2c9-4200-9879-a14d4ccf30b9,[Données non publiées],Groupe SEB,Ingénieur [Données non publiées],[Données non publiées]
+616221bd-5b25-4706-b9bb-1a17f5f892f4,[Données non publiées],Ccce,[Données non publiées],
+6168aa20-c76b-490c-8a94-7eeea1f12872,[Données non publiées],Mairie du Coteau (42120),Maire,[Données non publiées]
+6168e105-93f0-49f9-8f87-561cef8431db,[Données non publiées],[Données non publiées],[Données non publiées],
+6176eb56-ccdb-4c31-b240-5cba3b712da4,[Données non publiées],Scholz and Friends,Chargé de clientèle [Données non publiées],
+61790b16-cfc4-44b3-8491-7480819c1336,[Données non publiées],SARL VEGA,EMPLOYE [Données non publiées],
+61790b16-cfc4-44b3-8491-7480819c1336,[Données non publiées],EIRL BARREAU,ELECTRICITE PLOMBERIE,
+617c28ed-6a7b-4158-979c-486031618795,[Données non publiées],Macocco Ouest,Assistante commerciale,
+617cbd34-4f9b-4835-9afb-9ca5fdf8d825,[Données non publiées],CWT SAS,Global Project Manager - Entreprise spécialisée dans le gestion des voyages d'affaires,
+61813833-ff46-4f0f-b22e-ff4a7ed2aa9d,[Données non publiées],AUCUN,[Données non publiées],
+61853e75-80cc-457b-865c-80456d4a0985,[Données non publiées],neant,néant retraité,
+61864d43-2d65-4282-ad95-3865d12c21d2,[Données non publiées],EXCO,[Données non publiées],
+61b416aa-db51-4912-828b-43337677b0dc,[Données non publiées],Polynésie française (collectivité),Juriste [Données non publiées],[Données non publiées]
+61ba1d66-11de-4ab0-9a8a-3228e7768cd4,[Données non publiées],Suez [Données non publiées] [Données non publiées],Assistante de gestion,
+61dba76c-229a-4823-912a-3314f64a5209,[Données non publiées],Ville de Montivilliers,[Données non publiées],
+61dd0e2b-dd80-4c08-9310-edfe8b21ff61,[Données non publiées],néant,néant,
+61decc35-d163-47ad-84aa-e3a6abe18177,[Données non publiées],Orange,Directrice adjointe territoriale,
+61eede89-2c1c-4595-ba2a-addc95c8c6a0,[Données non publiées],Archipel,Auxiliaire de vie sociale,
+61f0b13e-f05a-40b1-81a8-5adaae6cc90c,[Données non publiées],Paris Musées,Chef du bureau [Données non publiées],[Données non publiées]
+61f2b92f-b08f-41bf-83d7-9ac2f0ae5964,[Données non publiées],éducation nationale,professeur des écoles,
+61f5b9ec-e69b-49ca-bb0e-c627d90afdae,[Données non publiées],CONSEIL DEPARTEMENTAL DE L'ARIEGE,ASISTANTE FAMILIALE,
+61f9ceca-47bf-4959-ae62-80e2a9a7a546,[Données non publiées],SCP [Données non publiées] et ERIC VUILLEMIN,Notaire,Gérante [Données non publiées]
+61fbc791-7637-44fe-8650-ee892ba457dc,[Données non publiées],Nantes Saint-Nazaire développement,Chargée de mission,
+61ffdd8c-78cb-4c6f-8733-9fa210440c62,[Données non publiées],Selarl [Données non publiées],Avocate collaboratrice libérale [Données non publiées],
+6208660e-7322-4918-9f67-303bc427703b,[Données non publiées],Vermon,Ingénieur,
+620aeff3-487f-4117-8826-16a35566550c,[Données non publiées],[Données non publiées],Fabrication et vente de chaussures,
+620b777c-ad5f-467d-addf-9a4d991bdfe0,[Données non publiées],DAUNAT [Données non publiées],Assistante R H,
+620be31e-27d8-40a8-a92a-91789991a9ea,[Données non publiées],Education nationale,Retraitée [Données non publiées],
+621b6b64-003a-4b78-98be-b526067d6691,[Données non publiées],Parti socialiste de Belgique francophone,Président [Données non publiées] [Données non publiées] bourgmestre de Charleroi [Données non publiées],[Données non publiées]
+622253cb-7252-4dd9-b0d9-32f543211831,[Données non publiées],Néant,Néant,
+622aefc4-e231-4b1e-9630-8cb2a3b40828,[Données non publiées],Conseil départemental [Données non publiées],Assistante familiale,
+6237eb01-7da5-407f-8391-b067fb5010cc,[Données non publiées],MONDELEZ,COMMERCIALE,
+623c468c-5a75-476c-84ff-3bddeccb1069,[Données non publiées],Assemblée nationale,Assistant parlementaire,
+6245622d-91a3-4a9d-aca9-c044b8bfae08,[Données non publiées],NEANT,NEANT,RETRAITE [Données non publiées]
+62508674-7a4f-41f7-8a84-d8a0b009040b,[Données non publiées],Holding Euro-Sys,Président,
+6270725c-4343-4485-a71f-886d9413d0d1,[Données non publiées],Communre ETUPES 25,[Données non publiées],
+6270f56b-b1fc-41b8-899a-b6d3ffe0598f,[Données non publiées],profession libérale,avocat,[Données non publiées]
+62712967-ee66-40b8-bb37-7f562bc2833a,[Données non publiées],ASSOCIE CLINIQUE VETERINAIRE,VETERINAIRE LIBERAL,
+6272511e-4b6a-42bb-b3d0-3aa144deadaa,[Données non publiées],Mairie de FAA'A,Agent municipal [Données non publiées],[Données non publiées]
+629f0fa5-9c01-47ba-ae7f-27c9b7279fb4,[Données non publiées],AGGLOMERATION HERAULT MEDITERRANEE,[Données non publiées],
+62a33528-c925-4611-99dd-c22fff55cfc6,[Données non publiées],SUET Syndicat intercommunal de danse et de musique,[Données non publiées],[Données non publiées]
+62a4cbdb-f017-4977-acf3-4b8befcff511,[Données non publiées],néant,aucune,
+62a50b2b-3c0e-4143-8256-069799573ff2,[Données non publiées],maison Hanras,fleuriste,
+62b7fad7-8e5c-4b20-b71d-74a11762103e,[Données non publiées],Retraitée,Sans,
+62bcfcc7-aca6-46f3-b33a-514598c697fe,[Données non publiées],[Données non publiées],Société d'Investissement,[Données non publiées]
+62bf1124-b629-4a27-b48f-bc46a5817035,[Données non publiées],[Données non publiées],Pharmacien titulaire d'une officine de Pharmacie,
+62c3e649-7300-4e68-b419-dbafda4ce7c2,[Données non publiées],[Données non publiées],[Données non publiées],
+62ce3458-6dca-48b9-bde1-39dd4cf85910,[Données non publiées],Tours Métropole Val de Loire,Adjoint administratif,
+62de338c-ac44-4ce8-9c3d-921ccebaeba1,[Données non publiées],Education nationale,Professeur,
+62e6593e-75d7-4957-ad40-8b2853ac4288,[Données non publiées],MMA IARD,Responsable Conseils juridiques. [Données non publiées],
+62f5fd6b-0c1d-41cd-bca6-f456b9a692e8,[Données non publiées],OWENCE ILLINOIS,VERRIER,
+62fb6868-ba2a-43de-a5a6-6b30383ed1a5,[Données non publiées],Conseil Départemental,Secrétariat,
+62ff2064-cfd6-464f-8468-6aa2f0c8d453,[Données non publiées],REGION SUD - CABINET,Conseiller spécial,[Données non publiées]
+62ff2064-cfd6-464f-8468-6aa2f0c8d453,[Données non publiées],Ville de Nice,Adjoint au Maire de Nice [Données non publiées],[Données non publiées]
+62ff2064-cfd6-464f-8468-6aa2f0c8d453,[Données non publiées],Métropole Nice Côte D'azur,Vice-Président de la Métropole Nice [Données non publiées],[Données non publiées]
+63008a23-4449-4fdb-8609-cc20028bb6e6,[Données non publiées],APRR. Autoroutes Paris-Rhin-Rhône,Technicienne assurances. [Données non publiées],
+6304191a-f2f4-46ea-908c-5344ff55903a,[Données non publiées],Néant,Néant,
+63068979-a577-48a0-ab16-77c63c7be60b,[Données non publiées],Retraité,[Données non publiées],
+630a6b1c-1295-4d6e-ba76-87c544bd3273,[Données non publiées],Néant,Néant,
+6310b026-2128-48b5-9488-abca423a69a9,[Données non publiées],entreprise individuelle,commerçant,
+6315a953-09c1-48a1-ab91-834f97ede037,[Données non publiées],Néant,Néant,
+631b36fd-a2f8-450f-a242-0841ffb30202,[Données non publiées],Mairie de Fontainebleau,Adjointe [Données non publiées],
+63296a27-3785-42a2-8da6-c5e66a7f2a14,[Données non publiées],médecin RETRAITEE,[Données non publiées],
+632ab778-3883-47c7-ad0f-6bfb181aa6a2,[Données non publiées],Gérant de la Sarl Panonacle Immobilier,[Données non publiées],Retraité [Données non publiées] Poursuite de l'activité en qualité de gérant majoritaire.
+633ed9a6-4d00-45e6-833e-67f756249a9e,[Données non publiées],ASSOCIATION AGARDOM,Auxiliaire de vie ou aide à domicile,
+63408757-8ab1-496c-93f9-d45479bce370,[Données non publiées],CONSEIL DEPARTEMENTAL HAUTE_LOIRE,CHEF DE SERVICE [Données non publiées],
+63461a78-37a0-44bd-bda6-e8410dfc1672,[Données non publiées],SAS [Données non publiées],gérant,
+6348ad0d-b22d-4015-a572-a307f9b3c318,[Données non publiées],neant,neant,retraitée
+6348ad0d-b22d-4015-a572-a307f9b3c318,[Données non publiées],neant,retraitée,
+634fabc3-f4c2-4de3-91fd-8b67605aaeb8,[Données non publiées],Wivoo,Consultant senior,[Données non publiées]
+6350b742-ba2b-4011-9c50-d33e2f5d527a,[Données non publiées],Ville [Données non publiées],Redacteur,
+635a9cab-84c4-4d9d-80a7-560afe8686c6,[Données non publiées],[Données non publiées],Directrice,
+635cff61-8f36-4b2f-b274-0e3de645f9f4,[Données non publiées],sans objet,prestations de traduction,
+635e6371-7582-47cf-8cda-66f5026cbdab,[Données non publiées],[Données non publiées],Préparatrice en Pharmacie Hospitalière,
+6362d79b-72dc-4bf0-9e90-d23b258508ae,[Données non publiées],Pays de Montbéliard Agglomération,Fonctionnaire territorial,
+6373aad7-3892-4869-80d0-2550502d02ab,[Données non publiées],DEPARTEMENT DU HAUT RHIN,ASSISTANTE SOCIALE [Données non publiées],
+6373f829-8a11-4e12-b622-689d1859a20c,[Données non publiées],COFIDIS,CHEF D'EQUIPE [Données non publiées],
+637e78e3-ff1c-45d8-b00c-f6f1ca53aebe,[Données non publiées],néant,néant,[Données non publiées] [Données non publiées] retraité [Données non publiées]
+63886aae-7d68-4a72-af95-cb10f0c86522,[Données non publiées],Groupe CISN,[Données non publiées],[Données non publiées]
+638e02dc-b0ac-49c2-a9e4-c90fbadb4358,[Données non publiées],néant,néant,
+63a75bb3-9fa9-4a3e-9b01-b00b78b21fe9,[Données non publiées],Education Nationale,Professeur des ecoles,
+63aa25a2-83d9-4a6d-b20d-9abf708a15a9,[Données non publiées],Indépendante,Journaliste / productrice,
+63ab4309-cb65-4a13-872c-e49c1f877394,[Données non publiées],Université de FRanche-comté,Professeur [Données non publiées],
+63ae16d2-27c7-4ca5-b670-6bb522d2fd8f,[Données non publiées],Néant,Néant,
+63bfe583-2955-4691-95b9-e248a56440b4,[Données non publiées],Federation nationale des CIDFF,Directrice de [Données non publiées],[Données non publiées]
+63c12ea5-3ca8-46bd-87f8-999e76ab28a4,[Données non publiées],AUTO ENTREPRENEUR,NETTOYAGE BATIMENT,
+63c4826e-590f-4d68-9d94-dd1600ba830f,[Données non publiées],Bernard Travaux Polynésie BTP,Chef de chantier,
+63cf0195-e78b-4493-896c-a143ff09eb9b,[Données non publiées],Néant,Néant,
+63d6834f-dee0-46d9-a15d-509daeb15c4a,[Données non publiées],Education nationale,Professeur de philosophie,
+63d6834f-dee0-46d9-a15d-509daeb15c4a,[Données non publiées],Hebdomadaire [Données non publiées],Chroniqueuse occasionnelle,
+63ef252e-b066-47c1-8874-ce76221f6777,[Données non publiées],indépendant,ANTIQUAIRE,
+63fb9847-d9af-4cf9-9a03-8e37be70638f,[Données non publiées],RETRAITE,RETAITE,
+63fd40dd-7a8e-4a8f-83a4-07f0ffbb26b5,[Données non publiées],"Ministère de l'agriculture, Ecole Nationale Vétérinaire [Données non publiées]",Enseignante,
+63fd6bef-cf6c-47e5-8007-22f946e7b1c4,[Données non publiées],LIBERALE,MEDECIN GENERALISTE SECTEUR1,
+6403f00c-a6c7-459c-a7c8-62e6c20d3242,[Données non publiées],Education Nationale,Professeur documentaliste,
+6404b7c8-237e-41c3-99ca-f5248c627cb9,[Données non publiées],Département de la Réunion,Adjoint administratif,
+64076b58-0b72-43ed-9d06-3421ed2ad7cf,[Données non publiées],Gouvernement de la Nouvelle-Calédonie,[Données non publiées],
+6407a664-209d-4c59-9084-6a97252af17f,[Données non publiées],Ministère Education nationale,Professeure des écoles,
+64090941-7795-4642-9e80-51ad6944583c,[Données non publiées],Education Nationale,enseignante en lycée,
+6413a064-b975-481d-b14e-17227cde2ead,[Données non publiées],Néant,Retraité,
+641b38d1-790f-4873-9a2b-8d45ae5a4163,[Données non publiées],[Données non publiées],Directeur audit et contrôle interne,
+641dc7ab-4434-4027-af5e-b202b4a885bf,[Données non publiées],néant,Journaliste retraité,
+642902f3-4d0f-4ce8-8026-26030839b01c,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+642902f3-4d0f-4ce8-8026-26030839b01c,[Données non publiées],Auto entrepreneur,Conseil en relations publiques,[Données non publiées]
+64295c04-1095-44ba-9691-52ab5e68c0f6,[Données non publiées],Cabinet d'expertise,Expert automobile judiciaire,
+6432fbff-f037-4317-b879-2c492ab93f94,[Données non publiées],Education nationale,professeur des écoles,
+64377fa8-2504-44a5-a17d-e3222a2967ee,[Données non publiées],néant,néant,Retraitée
+644922e4-3ec7-4bf1-88fc-ce0ba385c9bb,[Données non publiées],cosy home france [Données non publiées],[Données non publiées],gérant [Données non publiées]
+644f044a-cf79-4c43-a264-e670cc9d531b,[Données non publiées],Sivom [Données non publiées],[Données non publiées],[Données non publiées]
+64523ed9-39d3-4873-b682-ec45ca383d92,[Données non publiées],Retraitée,Retraitée,[Données non publiées]
+645696f5-6c35-43c0-9fbe-9b8b42a6020d,[Données non publiées],Retraitée,Néant,[Données non publiées]
+64599b07-3872-46e4-b811-9e6a65bf6534,[Données non publiées],education nationale,professeur des écoles,en retraite [Données non publiées]
+6460f6e7-8ac2-4d9a-a5d9-751a63408782,[Données non publiées],Auto-entrepreneur,Conseiller en communication [Données non publiées],
+64628809-013e-4508-9bb0-6615a95fcd26,[Données non publiées],AUTO ENTREPRENEUR,COMMERCE,
+646bc316-0ad0-47c6-80df-76fc671e6974,[Données non publiées],néant,Retraité,
+64734cad-ca0e-4b87-9445-e2d80879127a,[Données non publiées],Ministère de l'Education Nationale,Professeur des écoles,
+647d62ec-b2b6-4777-bf69-005ff68994d2,[Données non publiées],Ville de Lourdes,[Données non publiées],
+648e87c8-456f-4d0c-84e5-72b3b5ce2f6e,[Données non publiées],néant,Retraitée,
+64940a28-48e8-4df6-b272-5e674626b692,[Données non publiées],BAR RESTAURANT [Données non publiées],SERVEUSE,[Données non publiées]
+64997c36-0016-4629-b663-16296263758a,[Données non publiées],Université [Données non publiées],Maître de conférences des facultés de droit,
+649d4e29-a9d8-4520-9fcc-17a1171d3eeb,[Données non publiées],Evel'Up,[Données non publiées],
+64a03eae-e808-48d1-8cd8-f252fe7e5a00,[Données non publiées],[Données non publiées],[Données non publiées],
+64b014ad-226d-4e29-a898-fa90ab6f8e32,[Données non publiées],GENERALI FRANCE,[Données non publiées],
+64c14e1c-28ee-4a5d-a840-4e5551cad5a0,[Données non publiées],Hôpital [Données non publiées],Ergothérapeute,
+64ccbda0-c236-44d6-8521-ed820826b73d,[Données non publiées],Caterpillar,Technicien methode,[Données non publiées]
+64da3183-92c9-4875-be2d-9750bfa82a28,[Données non publiées],Communauté de communes [Données non publiées],Responsable RH,
+64db3167-2259-4a53-9a66-eb9394165836,[Données non publiées],[Données non publiées],[Données non publiées],
+64db3167-2259-4a53-9a66-eb9394165836,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+64e243d0-797b-4cfc-9516-f3a9d7acbd80,[Données non publiées],LCDP,Directeur marketing et communication,
+64fa0d09-9af2-450b-b2e5-95168b9afa9c,[Données non publiées],Conseil Départemental 31,"Ingénieur territorial, chargé de mission [Données non publiées]",[Données non publiées]
+650b773c-6434-4d2f-9900-57577f402d95,[Données non publiées],Cristal Habitat,[Données non publiées],
+6513b385-2c23-407f-b788-10ee31eb819f,[Données non publiées],[Données non publiées],Comptable,
+652167e7-0eed-453c-a36f-1d3136aceb4c,[Données non publiées],Agriculteur,Éleveuse canin,
+6521f649-eb6e-4f80-9fab-6399427c4e01,[Données non publiées],profession libérale,psychologue,
+652263a6-bea3-480a-bcbf-5472aa89a938,[Données non publiées],profession libérale,masseur-kinésithérapeute,
+6526db11-ffab-41a3-9292-5fd8c87b61bb,[Données non publiées],néant,néant,[Données non publiées]
+6539fed7-358a-4919-9ba7-1be497be7df0,[Données non publiées],INFIRMIERE LIBERALE,INFIRMIERE LIBERALE,
+6551efb8-f8f4-46b7-96e3-242016a0cc34,[Données non publiées],TEMM CONSEIL,Gérante,
+6551efb8-f8f4-46b7-96e3-242016a0cc34,[Données non publiées],EMOTORS,HEAD OF COMMUNICATIONS,Depuis le mois de novembre 2024
+655ca1b7-8b4e-44f6-a4b8-5177b9fbc9de,[Données non publiées],aucun,sans emploi,
+6565ce1e-260c-48bb-98e2-fee96cab294f,[Données non publiées],Ville d'Aix-les-Bains,Fonctionnaire titulaire Ingénieur territorial [Données non publiées],
+65664ebd-6589-468b-bd5b-5b5e677a5fcf,[Données non publiées],SEGAT,Conseil et accompagnement des acteurs de l’aménagement et de l’immobilier,
+65713895-4f1e-42b4-a106-bd9da0cd2809,[Données non publiées],CENTRE HOSPITALIER [Données non publiées],Aide soignante,
+6571814c-9ffc-48f0-913c-b8373c4c5f76,[Données non publiées],Retraite,Néant,[Données non publiées]
+657359ad-f1f2-4163-b2df-e55d39ddda31,[Données non publiées],Activité libérale à temps partiel,Médecin cardiologue à temps partiel,[Données non publiées]
+65779ebc-94b4-4257-adee-c8a263ee9fa7,[Données non publiées],[Données non publiées],Secrétaire comptable et médicale,
+65779ebc-94b4-4257-adee-c8a263ee9fa7,[Données non publiées],Autoentrepreneur,Production audioviduelle,
+657953d0-765c-4c6c-b7ae-fcffde814506,[Données non publiées],Earl bel horizon,exploitant agricole,[Données non publiées]
+657a04e2-3526-479a-b3ef-1dc4c7b5b185,[Données non publiées],SANDERS,Employée au service RH [Données non publiées] . [Données non publiées],
+65844769-42a5-44e0-bfaf-e40f8524d1ec,[Données non publiées],Centre hospitalier [Données non publiées],Cadre de santé,
+658f1c31-1e79-4cc8-bfb6-83dd55b20892,[Données non publiées],Infirmière libérale,Infirmière libérale,[Données non publiées]
+659df15f-71c1-46ff-b2e8-b85e7da7307a,[Données non publiées],Communauté Agglomération Lens Liévin,[Données non publiées],[Données non publiées]
+65a2187e-40c2-45af-aa1b-25f770d4ff7c,[Données non publiées],Communauté Urbaine du Grand Reims,Directrice de la communication [Données non publiées],
+65a32291-4cb2-4e20-86b5-0e275f69cbff,[Données non publiées],partouche,commerciale,
+65c284fd-a78a-4940-b7c4-4c099c24879e,[Données non publiées],france television,journaliste,
+65c3390c-8e4e-4216-8952-1f1ea1f6bf53,[Données non publiées],Staffmatch,Responsable [Données non publiées],
+65d6aa39-7c21-4f1a-9c4f-a3e45ac58f18,[Données non publiées],La Fab,[Données non publiées],
+65d84ebb-546e-4a03-b5fe-ca5be52520c3,[Données non publiées],Auto-entrepreneure,"Photographe, réalisatrice de documentaires, agence artistique [Données non publiées]",
+65de2164-1099-4a72-ba2a-946c433a27af,[Données non publiées],NEANT,NEANT,
+65eaa388-1333-4980-a298-02349d6d0a0b,[Données non publiées],RETRAITEE,NEANT,
+65f1387f-9528-45d0-b722-4e8ee1da4e6a,[Données non publiées],Education Nationale,institutrice Maternelle [Données non publiées],[Données non publiées]
+65f1387f-9528-45d0-b722-4e8ee1da4e6a,[Données non publiées],Education nationale,Professeur des écoles,[Données non publiées]
+65f733f8-646c-404e-bdf7-b5dfb339219a,[Données non publiées],Education nationale,Professeur des écoles(ER),
+65f75a2d-82ef-46f6-ae70-bfd5d27eec4d,[Données non publiées],Association Pierre Noal,médecin [Données non publiées],
+6606d576-539f-401a-8989-a94f64e09b37,[Données non publiées],Rectorat de Nantes,[Données non publiées],
+6610fb0f-9c43-4c78-a946-2fa0df6715d9,[Données non publiées],General Electric,Ingénieur,
+6614be27-8589-4af5-aa1b-83ceb48b9991,[Données non publiées],Université Lille 3,Maître de conférence en Sociologie,
+661581d6-92f6-4efb-98c9-daa25db27117,[Données non publiées],Medpace,[Données non publiées],
+6615b0cb-64df-4cb5-9412-665e7a00409e,[Données non publiées],Société générale,Consultante interne,
+661e3e95-f260-40e4-af8b-4bb5b2aa7518,[Données non publiées],Parc Naturel Régional des Vosges du Nord,Chargée de mission,
+661f647d-a8a9-4610-86c6-7d668edae262,[Données non publiées],Livemore Pte Ltd,Founder and Managing Director,
+66203922-bdf5-4c1c-9686-23d5591ddce4,[Données non publiées],MARTIN ASSOCIES,Avocate,
+664427f2-e326-4c92-8aa1-aa3973e82081,[Données non publiées],Société Générale,Chef de Projet,
+664b6598-ac20-4a5a-866c-a7a2b130d23d,[Données non publiées],néant,Retraitée de l'Education nationale,
+664c1ac2-2b9c-4517-857a-26d22ea6bfdd,[Données non publiées],Formapost,[Données non publiées] . Salariée,
+664f2ce7-0e11-4ade-a9b0-ca2b36fe62a7,[Données non publiées],Christine Loir députée de l'Eure,attaché parlementaire,
+665b913d-a36a-4f3e-a030-b1c3dd8811e3,[Données non publiées],Atelier Paysan,Animatrice nationale,
+666c8637-411d-473c-8616-5cfa01313c49,[Données non publiées],Hopital,Medecin,villeneuve-sur-lot
+667455cd-fe39-43df-9905-5d4128c0de23,[Données non publiées],Clinique Mutualiste de l'Estuaire Saint-Nazaire,Médecin,[Données non publiées]
+6691c2d4-4bde-4486-b5df-c9a4bfebbf97,[Données non publiées],Ministère de l'Education Nationale,Professeur des écoles,
+66965876-7d80-4bf1-bfb5-8acacd6c8272,[Données non publiées],Caisse d'Epargne [Données non publiées],secrétaire,
+669afa92-4f42-4184-8d52-b5483e4c7252,[Données non publiées],[Données non publiées],PROFESSEUR DE DANSE,
+669c420f-fe35-4f2b-8940-f782f6d8da29,[Données non publiées],CHU de Toulouse,Praticien Hospitalier,
+66bb2e09-76cd-48b3-b695-80b249ea7d29,[Données non publiées],ORANGE,Responsable [Données non publiées],
+66bb7952-9421-4379-a8bc-feb59c7c6166,[Données non publiées],France Télécom,Néant,
+66c17921-6928-4816-a14a-2fb45812efb7,[Données non publiées],GrandAngoulême,[Données non publiées] Fonctionnaire,
+66f167c0-002f-476d-ae9f-94a7d877ffe5,[Données non publiées],CREDIT AGRICOLE [Données non publiées],employé de banque,
+66f5b900-e4a9-4491-a220-ac7bac341499,[Données non publiées],Retraité,La conjointe est actuellement à la retraite,
+6709b2c5-eaaf-4fbb-aad1-afd00ebc2647,[Données non publiées],Sans emploi,Sans emploi,
+6725dad1-4649-4184-bf51-496a95dba84a,[Données non publiées],retraite,néant,
+6725f2fb-5b4b-4ee3-95fc-110eabf95375,[Données non publiées],cave cooperative [Données non publiées],Directeur,
+67275c33-8d1c-4e1d-86ec-6a35a0df3f9d,[Données non publiées],[Données non publiées],Secrétaire de Mairie,
+672997bc-db43-442e-ae49-b7259ddd42bb,[Données non publiées],Newfund Management,Partner,
+67323353-1982-43db-aaf2-47bdb0c282a8,[Données non publiées],SAS CHADIS,[Données non publiées],
+67333017-c96e-4c5c-8c66-da6473ecc3ee,[Données non publiées],RUAG MRO,Sénior Compliance Officer [Données non publiées],[Données non publiées]
+6745cf6e-2280-4ad4-92e7-01bfa29c3c40,[Données non publiées],[Données non publiées],[Données non publiées],
+675ecb46-7f16-46ad-b351-483276eae438,[Données non publiées],Néant,Néant,[Données non publiées]
+6768a63e-ae23-474f-8deb-5fd83a5bf8d4,[Données non publiées],Education nationale,"Professeur certifiée, hors classe",
+676a53cb-d05d-48f5-8b87-e68803c56676,[Données non publiées],Education nationale,Médecin scolaire,
+67725fae-cc5b-47cd-8889-0818e3a9187e,[Données non publiées],Nouvelle Région Aquitaine,[Données non publiées],
+677e57dc-2865-4729-b356-7729347cd258,[Données non publiées],Education nationale,Fonctionnaire d'étatProfesseur d'anglais,
+6782379f-917a-479b-a7f6-d67effcc6d51,[Données non publiées],retraitée,néant,
+67905c6a-c4a0-496a-8eaa-3068e88ab55a,[Données non publiées],DGFIP,CHEF DE BRIGADE,
+6791206d-ee3d-44e1-9eea-46c5dab3adc0,[Données non publiées],conseil départemental de Mayotte,[Données non publiées],[Données non publiées]
+67950295-1d9f-4bbb-bdb3-8b43ada79b29,[Données non publiées],diocèse de Luçon,[Données non publiées],
+679fcf77-dfd5-4c5e-9857-35473bba9ff0,[Données non publiées],Département de la Seine-Maritime,Instructeur social,[Données non publiées]
+679ff0e8-a3cf-4866-90db-4df9beaca6e3,[Données non publiées],Mairie de Montrabé,Agent territoriale [Données non publiées],
+679ff830-005a-407b-b522-f5dbc5e61f55,[Données non publiées],ville de reims,[Données non publiées],
+679ff830-005a-407b-b522-f5dbc5e61f55,[Données non publiées],departement de la Marne,[Données non publiées],
+67a340ff-f40a-48a3-afe9-556b0d99d685,[Données non publiées],retraité,néant,
+67b537cf-5caf-49dd-878f-80e578666d97,[Données non publiées],[Données non publiées],Fleuriste,
+67e3d5ba-611d-4451-a8ce-697ee9ea83a1,[Données non publiées],Mairie de Loix,Attachée territoriale,
+67f0f6f7-6793-4303-9ca5-0765aa0c171e,[Données non publiées],[Données non publiées],INFIRMIERE DE BLOC,
+67f1622e-2787-4f55-a46f-ae92573a7099,[Données non publiées],Retraitée,Néant,
+67f26961-3676-4e67-864f-d6b35059df86,[Données non publiées],Retraitée,Retraitée,[Données non publiées]
+67fe4e53-c07d-434f-80c5-1e730d4185d9,[Données non publiées],EHPAD [Données non publiées],Adjointe aux cadres,
+6804c17a-dcb0-4d58-9399-83d28b84d59d,[Données non publiées],[Données non publiées],[Données non publiées],
+6804c17a-dcb0-4d58-9399-83d28b84d59d,[Données non publiées],SAS LE VAUBAN,Présidente de la société commerciale d'activités hôtelières et para-hôtelières.,
+6807a7eb-7c8b-43c9-8153-9cc777136295,[Données non publiées],néant,néant,
+680d0f9f-e935-406b-8c7d-50df5fa7c4b5,[Données non publiées],Ecole [Données non publiées],Accompagnement Enfants en situation de handicap en milieu scolaire,
+6814c603-0ec4-4f62-95dc-a2e33d5f580d,[Données non publiées],Finances publiques,Agent catégorie C,
+68178bd6-8127-47f8-ba8f-0ea32c5bed8c,[Données non publiées],[Données non publiées],Commerçant indépendant,[Données non publiées]
+681a6904-71cc-497a-973f-9de704530620,[Données non publiées],néant,Retraité,
+681a8633-254e-493a-9621-4029a3faa74d,[Données non publiées],NEANT,NEANT,[Données non publiées]
+681ca2b7-a31c-40d0-8d6b-59d780137586,[Données non publiées],Retraitée [Données non publiées] de la fonction publique hospitalière.,Hôpital public.,
+6828af03-eb26-4028-9326-7b6c9c092eb6,[Données non publiées],Genesis LAB,Chargé de Recherche [Données non publiées],
+6842b198-f510-4d47-b872-7741601de934,[Données non publiées],AUTO ENTREPRENEUR,SECRETARIAT ADMINISTRATIF,
+6849f4fa-fe9a-4fb4-b2f8-548c378ab802,[Données non publiées],Brittany Ferries,Assistante de Direction,
+6853cae2-3149-4038-a645-21738e5718ea,[Données non publiées],Profession libérale,Avocate,
+68558fab-5bf6-4607-a567-df7cc6a6e702,[Données non publiées],Cabinet d'avocat MLB (entreprise individuelle),Avocat libéral,[Données non publiées]
+685a4a49-769b-48f3-99f2-e06a21188983,[Données non publiées],[Données non publiées] Entreprise d'électricité plomberie,Artisan,
+6862d26c-8bff-40f6-8d8c-7c22b302df52,[Données non publiées],ministere de l'interieur,commandant divisionnaire fonctionnel de police,
+686d51a8-f56b-4416-a9a7-cd328d2ce1c0,[Données non publiées],PSA AUTOMOBILES,Agent professionnel,
+6877f7d4-6dca-4960-b87c-c495d788daa8,[Données non publiées],Bred,Conseiller bancaire,
+68894816-12d1-4754-8483-6f95ca1244ec,[Données non publiées],CHU [Données non publiées],Infirmier Diplômé d'Etat,
+688a9640-4ef1-49d5-becd-1a3c86cd92a9,[Données non publiées],PPA MAHE,Directeur Général [Données non publiées],
+688bf424-0c57-4196-bedc-69fad9cf7ab8,[Données non publiées],activité individuelle,Etiopathe,
+688cb2f9-2f64-4bff-aead-d6022c07241c,[Données non publiées],Ministère de la Culture,Conservatrice du patrimoine,
+688f8764-4d43-4b85-a975-ec7972f21b1b,[Données non publiées],Ministère de l'agriculture,Professeur de lycée agricole,
+689ea919-381d-421c-ba9a-14c111a549a0,[Données non publiées],NEANT,RETRAITE,À la retraite depuis le 1er février 2024
+68b62d53-5dfe-408f-abde-b1fef0c36bd4,[Données non publiées],Mairie de Decize,Agent de maitrise- fonctionnaire territorial,
+68bb509f-f5c4-42a4-ad27-afc8d8f6754b,[Données non publiées],ministère des armées,Commissaire des armées,
+68ca68ca-fc0f-4f2d-b7e4-35e1a000ad56,[Données non publiées],CRCA Brie Picardie,[Données non publiées],
+68cc613e-c99d-4a03-b566-64f9479ded25,[Données non publiées],Ville d'Etampes,Directrice de la politique de la Ville,[Données non publiées]
+68ce1728-5f00-4cb6-a5a0-9cb9b81e5022,[Données non publiées],RETRAITE [Données non publiées],RETRAITE,
+68d65c77-f596-496b-b110-ffb667a37432,[Données non publiées],Retraité,néant,
+68e2e7ab-96c6-4635-8a23-58749077d5bb,[Données non publiées],SHARP FRANCE,[Données non publiées],
+68e6e8d7-3038-46bf-baf9-30961be810ed,[Données non publiées],SEMAT,[Données non publiées],
+68f3b660-91d1-4d03-9840-89e578dfc2d9,[Données non publiées],MAIRIE CROLLES,[Données non publiées] [Données non publiées],[Données non publiées]
+69019d48-41c5-435e-8b09-c6ec84f8b14b,[Données non publiées],néant,néant,retraité
+690d69c4-40e9-45b8-811f-a1b4e17d94ce,[Données non publiées],Agence nationale de rénovation urbaine (ANRU),Urbaniste,
+69102130-0fda-4847-920b-24f951a8be61,[Données non publiées],[Données non publiées],Dessinateur dans un bureau d'études (entreprise spécialisée dans l'escalier bois et métal),
+69102130-0fda-4847-920b-24f951a8be61,[Données non publiées],AUTOENTREPRENEUR,Fabrication de petits objets en bois tourné,
+6924de76-d113-45a2-86be-d24bf59a760e,[Données non publiées],GIP FCIP de Lille,[Données non publiées],[Données non publiées]
+692567aa-2a4c-4504-b21a-bfa0ff06f054,[Données non publiées],commerçante indépendante,Fabrication de pain et gâteaux bio et négoces de produits régionaux,
+692567aa-2a4c-4504-b21a-bfa0ff06f054,[Données non publiées],Sarl Le Poher hebdo,graphiste polyvalente,
+693fb097-2207-4ff2-9c3c-17b4ef2b765d,[Données non publiées],EXPLOITANT AGRICOLE,[Données non publiées],
+6943cc80-3fda-416b-b7e2-b6800677b684,[Données non publiées],Hop,[Données non publiées],
+694aab89-370c-4cdb-977c-efab52b66395,[Données non publiées],GAEC [Données non publiées],Exploitante Agricole,
+694ddd05-b950-43f2-bce9-c79f0c256a59,[Données non publiées],profession libérale,Orthophoniste,
+694e83c3-f732-48fb-898b-07533d31b4c2,[Données non publiées],CIC,gestionnaire privé,
+695bc6ce-6fc0-4a96-aac8-780a164393fd,[Données non publiées],[Données non publiées],[Données non publiées] neant,
+695bc6ce-6fc0-4a96-aac8-780a164393fd,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+695bc6ce-6fc0-4a96-aac8-780a164393fd,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+69618edd-b8f8-4e78-801d-93088ae79a77,[Données non publiées],entreprise individuelle,commerçant,
+6976f30a-56b2-43fd-b1b5-bda706b1361e,[Données non publiées],Education nationale,Professeur de physique chimie,
+698ac63b-6a2e-4c2f-81a5-723b416b5385,[Données non publiées],Ecole [Données non publiées],Enseignante,
+6994641b-bb6c-4eb2-87d5-c41eb802bcaf,[Données non publiées],Ville de Poitiers,Agent de maîtrise [Données non publiées],
+69970fca-826a-415b-8f94-a5f02ea86827,[Données non publiées],[Données non publiées],Intermittente du spectacle,
+699ab0b0-2980-4e94-a5c5-e7e0db5b509e,[Données non publiées],Pharmacie portes des alpes,Conseillère de vente,
+699ae9d7-8e2b-4b1e-8b16-525657800c58,[Données non publiées],COMMUNE DE BEAUCAIRE,Directeur [Données non publiées],
+699b4fa1-e958-4971-afae-6f4301a03a1a,[Données non publiées],Communauté d'agglomération Foix Varilhes,Infirmière [Données non publiées],
+699b7b1b-c94f-4675-9a3e-f69ac138ffd2,[Données non publiées],Education National,Professeure [Données non publiées],
+69a0e92d-4aa3-4eac-96de-f7a4e416af8f,[Données non publiées],Parlement européen,[Données non publiées],[Données non publiées]
+69a6e554-c80c-4460-91ce-739112052a65,[Données non publiées],SDIS 974,chef d'agrés [Données non publiées],
+69aae8a4-cfb8-4e25-8fe5-a50c8507713f,[Données non publiées],EDUCATION NATIONALE,Professeure des écoles,
+69ab5341-3284-4618-a5cc-4d09f22d8502,[Données non publiées],Transports DENOUAL,[Données non publiées],
+69b6108a-9e73-4337-b590-85f382f39e6e,[Données non publiées],Maison de Santé [Données non publiées],Assistance Médicale,
+69b918a9-538e-4370-b7be-02f5a2aabc62,[Données non publiées],Retraité,[Données non publiées],
+69c0364c-214c-4768-9078-e96222a3f2a6,[Données non publiées],Sans,Retraité,
+69e0954e-2a3c-4660-9df9-f27fba477049,[Données non publiées],Néant,consultant,micro-entreprise
+69e78560-84b3-466a-8cbe-e0f1179cddc5,[Données non publiées],Education Nationale,Professeur de physique chimie,
+69ef839a-2db9-4ad3-947d-d036d3f9d3cd,[Données non publiées],Ministère de l'Economie des Finances et de la souveraineté industrielle et numérique,Contrôleuse des finances publiques,
+69f3c1bc-1c61-4475-9760-6c0d43ef1d37,[Données non publiées],"Communauté d'agglomération Saint-Dizier, Der et Blaise",[Données non publiées],[Données non publiées] [Données non publiées]
+69f4de5e-9a49-47d6-8a0d-08fbbbdc4f90,[Données non publiées],ECOLE SUPÉRIEURE D'ART DE LA RÉUNION,[Données non publiées],
+69f59d7f-8235-4dc2-aa9f-2abdc0b0262e,[Données non publiées],Néant,Néant,
+69f66ff3-4111-48d6-85b8-9cdfe3610ff5,[Données non publiées],Huilerie Richard,Colporteur vente huile et produits dérivés alimentaires,
+69f7d02c-f2db-414b-8b88-c9ba77888ffc,[Données non publiées],SARL San Firmin,Responsable [Données non publiées],
+69fd591f-760d-47ce-8c34-fe0e414d8c62,[Données non publiées],Bernard Travaux Polynésie BTP,Chef de chantier,[Données non publiées] .
+6a0a0a75-5d5d-4cb9-88ef-04977438107d,[Données non publiées],SARL BED,Gérant,
+6a206be7-1ed4-4084-8d9a-d3b20f1e3b37,[Données non publiées],Sans emploi,Sans Emploi,
+6a23b4e5-0cea-437d-a9ab-2506d5d4f3bf,[Données non publiées],neant,neant,
+6a267ff4-0dc9-44bb-aca8-8b8fd8fa08a0,[Données non publiées],[Données non publiées],[Données non publiées],
+6a2ff953-45ea-403d-b91a-b61660ffcd33,[Données non publiées],sas centre recyclage auto,assistante de direction,
+6a304e56-6986-4a9a-bf39-45d913878486,[Données non publiées],ESMPI [Données non publiées],Infirmière psychiatrique,
+6a368668-dd67-4e11-9af1-46b9d8562e43,[Données non publiées],néant,néant,
+6a3f935f-72da-4e4b-9efd-ba00fb3472f7,[Données non publiées],Chambre d'Agriculture des Deux-Sèvres,Conseillère agricole [Données non publiées],
+6a418440-a470-4762-9452-abfe16ead040,[Données non publiées],Education Nationale,Professeur des Ecoles,
+6a52bcca-8741-4382-b417-83d842624b63,[Données non publiées],MARS CHOCOLAT FRANCE,Chef de secteur expert,
+6a708cd5-bd1f-46b8-bac6-b6cea2218ac2,[Données non publiées],Retraitée,Retraitée,Retraitée
+6a79f684-4e90-4a4a-a8ef-c55349762374,[Données non publiées],Avocat,Avocat libéral.,[Données non publiées]
+6a79f684-4e90-4a4a-a8ef-c55349762374,[Données non publiées],Université du Littoral-Côte d'Opale,[Données non publiées],[Données non publiées]
+6a8b8d37-7887-4835-89fb-55d98528062f,[Données non publiées],Gauthier Fils [Données non publiées],[Données non publiées],
+6a8ef69b-67f2-4204-bec6-edf2fd9e49bc,[Données non publiées],gerante GAEC [Données non publiées],[Données non publiées],
+6a9179ae-ba5d-4d90-81f9-49d412b07151,[Données non publiées],Néant,Consultante - formatrice,
+6a962036-8788-4a8e-9990-308d71593184,[Données non publiées],Crédit Agricole [Données non publiées],Analyste [Données non publiées],
+6a9c009b-f555-4c39-b190-69c3272f14f2,[Données non publiées],travailleur indépendant,CONSULTANT VITICOLE,[Données non publiées]
+6aa11229-0a5e-4e8b-a0d1-119fd2b03bc4,[Données non publiées],"Culture, Conseil & Communication",[Données non publiées],
+6ab58759-446f-4f0e-b0ed-cabc4563a080,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] A la retraite depuis le 01/08/23
+6acaddae-bebd-4e86-9397-ac304f03bf25,[Données non publiées],néant,néant,[Données non publiées]
+6ae76ebd-5e51-4991-9e8f-9c65a2d58a4e,[Données non publiées],médecin RETRAITEE,[Données non publiées],
+6ae784b5-a74e-4816-9c66-3be276247c67,[Données non publiées],néant,retraité,
+6aee8abf-0607-445c-8d6a-7c584ca8a058,[Données non publiées],Musée des Arts Déco - Ecole Camondo,[Données non publiées],
+6af733f8-6d8c-41f7-a9e9-3e2436075ad4,[Données non publiées],[Données non publiées],Senior manager affaires institutionnelles chez [Données non publiées],
+6af7c4f3-3625-49b9-b9aa-b7921c9029e3,[Données non publiées],Groupama Méditerranée,[Données non publiées],[Données non publiées] retraite [Données non publiées]
+6afb40cc-4f33-4e22-9332-365bebbe92f3,[Données non publiées],néant,néant,retraitée
+6b02c549-8fec-4f22-bbdf-f22a47a09959,[Données non publiées],néant,néant,
+6b108db1-a981-47c8-a028-966ed4740a05,[Données non publiées],Pharmacie de BEAUREGARD,docteur en Pharmacie,[Données non publiées]
+6b13d406-a7ab-4b5b-bb9d-3649a63e1d1d,[Données non publiées],COMPAGNIE FINANCIERE [Données non publiées],[Données non publiées],
+6b16abfe-b3e6-487b-8c26-0e4f6828ab34,[Données non publiées],CABINET LEFÈVRE ET RAYNAUD,AVOCAT,[Données non publiées]
+6b16d5c4-3c05-4d18-b0db-e0d47fb5cd46,[Données non publiées],CCAS [Données non publiées],Educatrice spécialisée,
+6b193d92-bbaa-4615-9ec9-747d95c4a7dc,[Données non publiées],[Données non publiées],Enseignante,
+6b23a4cf-84dd-4cce-a39c-59b8830081d6,[Données non publiées],Intérimaire,De janvier 2015 à juillet 2020 : sans activitéDe juillet 2020 à juillet 2021 : intérimaire en tant chauffeur routier,
+6b265191-258c-4f0d-a207-cf6f37495f84,[Données non publiées],Fédération Agirc-Arrco,Responsable des instances [Données non publiées],
+6b2877da-ba50-4ae3-bb2e-4cec07488ca2,[Données non publiées],NEANT,NEANT,
+6b298b74-16ee-4c14-8852-9804207ebdeb,[Données non publiées],DAMAE medical,Ingénieur [Données non publiées],
+6b380779-b2fb-45f9-9fc2-16404592ffd5,[Données non publiées],Adobe,Ingénieur,
+6b3ae495-dd79-4bed-9784-0973bf68088a,[Données non publiées],BERRY SUPERFOS BOUXWILLER,Cadre Commerciale [Données non publiées],
+6b3cef9e-1127-4c27-9772-83215bd139a8,[Données non publiées],neant,neant,
+6b3d3d32-354e-43ca-ab89-89dcd8167042,[Données non publiées],CNFPT [Données non publiées],Formatrice,
+6b3d3d32-354e-43ca-ab89-89dcd8167042,[Données non publiées],Institut d'2tude Politiques [Données non publiées],Formatrice,
+6b3e535e-ce27-45b5-b134-9b3142df8fe6,[Données non publiées],Communauté d'agglomération Foix Varilhes,Infirmière [Données non publiées],
+6b5417f3-2093-4ab8-982c-1432fedc40d1,[Données non publiées],Education Nationale,Professeur des Ecoles,
+6b5436f2-1356-41e1-8226-8f5b2bc8bf45,[Données non publiées],Centre Hospitalier Alès,Orthophoniste,[Données non publiées]
+6b5f2feb-3be7-4ee1-90d0-d00f440da6f2,[Données non publiées],Education Nationale,Enseignante de latin et de grec,[Données non publiées]
+6b680c67-3a2b-47dd-a3e7-b5d7d0e33a30,[Données non publiées],[Données non publiées],[Données non publiées],En retraite [Données non publiées]
+6b6bdad8-bb9b-45ad-a2e0-0975c12d0f01,[Données non publiées],néant,néant,néant
+6b6cd765-aea8-47c1-9d9c-7e346e42e8fc,[Données non publiées],néant,retraité [Données non publiées],
+6b716668-5915-4ca2-9665-b44a41f77f0c,[Données non publiées],Econocom,Directeur des affaires stratégiques,[Données non publiées]
+6b7a86c8-5c7e-4164-8264-f17f1fdc3d00,[Données non publiées],SAFRAN HE,[Données non publiées],
+6b80fd64-3e72-4c2d-9656-426b5b9f8513,[Données non publiées],[Données non publiées],[Données non publiées],retraité [Données non publiées]
+6b8e6495-2b1c-4292-98b0-17b8d7baad69,[Données non publiées],STMicroelectronics [Données non publiées],Cadre [Données non publiées],
+6b9bec49-6d02-4799-9970-e3eef489171b,[Données non publiées],Education Nationale,Professeure des Ecoles,
+6b9fb4d2-83c9-451f-bbdd-ec2b4151cd7d,[Données non publiées],Néant,Retraité,
+6bb10207-325b-4a84-a9fe-46618d9f3b92,[Données non publiées],néant,retraité,
+6bb4e17a-8ada-41ad-87f7-a140193e3ba7,[Données non publiées],Banque des Règlements Internationaux (BRI),[Données non publiées],[Données non publiées]
+6bba49ec-7b55-4ed2-aa82-41537d4237a2,[Données non publiées],CHUM de MARTINIQUE,[Données non publiées],
+6bc18c12-eedf-4140-b027-e3ff758eee4e,[Données non publiées],A titre personnel,Agricultrice,
+6bc65027-be58-40f3-81c4-e6b6e3f022d8,[Données non publiées],"Commune d'Orges, commune de Pont le Ville, Syndicat des eaux d'Orges",Secrétaire de Mairie,
+6bcefedf-33cf-4035-b3a9-2b0de7a44481,[Données non publiées],profession libérale,vétérinaire,[Données non publiées]
+6be0df6c-6639-4eee-83e0-999a7af04a7e,[Données non publiées],mairie de Nice et au département des alpes maritimes,collaborateur de Groupe,
+6be9c6be-b371-4fac-b439-9c2351d9c281,[Données non publiées],Welt Hunger Hilfe,[Données non publiées],
+6bed45b0-d198-4d54-b88b-898b7da31a21,[Données non publiées],Education Nationale,Professeur des écoles spécialisé en ULIS au collège [Données non publiées],[Données non publiées]
+6bf1968c-da35-4e07-96ea-10556205e013,[Données non publiées],CERGY LOCATION SERVICES,[Données non publiées],
+6bf80ebb-fbc0-4f22-973d-1383926c1c9c,[Données non publiées],Université Grenoble Alpes,Directrice administrative [Données non publiées],
+6c01fa89-d4f6-4e8b-8f12-a5a34d5edd36,[Données non publiées],APRR. Autoroutes Paris-Rhin-Rhône,Technicienne assurances. [Données non publiées],
+6c0b3a7b-460c-4c5c-b95a-17b4adce2d6a,[Données non publiées],Parlement Européen,Député Français au Parlement européen,
+6c2a128d-610b-4a5f-a664-8a2a75852a04,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] retraitée [Données non publiées]
+6c37faaf-51fb-4e2b-ae40-b7dbc9789959,[Données non publiées],Auto-entrepreneur,Conseiller en communication [Données non publiées],
+6c3a73ba-b6a2-4593-82c0-2941f5ac5edf,[Données non publiées],néant,néant,[Données non publiées]
+6c47247e-0082-455a-8b7d-488e144223f8,[Données non publiées],SPO EMSUR FRANCE SAS,AIDE BOBINEUR OUVRIER,
+6c4f5be5-3096-4be7-95dc-b5cdebe39a59,[Données non publiées],SIVOS [Données non publiées],Directrice,
+6c55206e-8406-441d-9942-9cdf1889f5f0,[Données non publiées],Collège et lycée [Données non publiées],Professeur d'espagnol,
+6c56107a-e268-4b03-8dbd-1d2fbc653e49,[Données non publiées],MINISTERE EDUCATION NATIONALE,ENSEIGNANTE CONTRACTUELLE ETABLISSEMENT [Données non publiées],
+6c5b4dec-5456-4a6d-a086-7e2eea9be6ca,[Données non publiées],sdis,officier,
+6c6c1dc1-f963-427f-ba5d-b14484daed18,[Données non publiées],PSA AUTOMOBILES,Agent professionnel,
+6c6d6ee6-2610-49bf-91aa-adb7e3a48e54,[Données non publiées],néant,néant,[Données non publiées]
+6c6d9e03-f6fb-4560-92d2-ea5e2bd76ae1,[Données non publiées],Etude d'Avocats [Données non publiées],Secrétaire,
+6c809881-23c9-4f2c-b8e1-ccd6feb382df,[Données non publiées],néant,retraité de la fonction publique,
+6c857750-8ba3-4f16-93b2-cab75bb2cfe7,[Données non publiées],auto-entrepreneur,Conseil en marketingFormation,
+6c9ea58c-c90c-42f3-b4af-274d4cdacd88,[Données non publiées],gerante GAEC [Données non publiées],Agriculture,
+6c9f50f8-5093-408e-af3a-baaf281b5673,[Données non publiées],SARL BOUCHET,Assistante de gestion entreprise de plomberie chauffagiste,
+6ca11267-329e-473d-b687-6fc007f53ef5,[Données non publiées],PETR Adour Landes Océanes,Directrice,
+6ca17ac9-665d-461e-a072-50bd87f70bce,[Données non publiées],maison de l'architecture et de l'environnement de Dijon métropole,[Données non publiées],
+6ca7c071-10e4-48e8-830a-ea99434ef925,[Données non publiées],Néant,Néant,
+6caca9d0-d460-454c-a13c-ca3a982c7021,[Données non publiées],Neant,Neant,
+6cc32085-5d45-44f5-a7aa-3cb4719090dd,[Données non publiées],Editions 2031,secrétaire d'édition,[Données non publiées]
+6cd2bda5-5770-4f79-b752-f79ced57fccd,[Données non publiées],Mairie de Marignane,[Données non publiées],
+6cdd5f27-7777-447e-bec4-5caf8d4a5895,[Données non publiées],néant,néant,retraitée de l'éducation nationale.
+6ce2c91a-e836-4485-9ad7-afedca948738,[Données non publiées],PIROUX Indistrie,Technicien méthodes,En retraite
+6ce9c54b-1fdc-41e5-a52c-984958ed39c8,[Données non publiées],Initiative Terres d'Azur,Directrice.,
+6cea6fc5-1576-44fd-baab-7305ce8a8e77,[Données non publiées],SCHNEIDER ELECTRIC,VP Energy Transition Research,
+6ceb72c8-6830-485b-a57b-61c18d8f5ab2,[Données non publiées],CONSEIL DEPARTEMENTAL,ASSISTANTE PERSONNE AGEE,
+6cedd661-d806-4c5a-8e3e-9bd4b138d4df,[Données non publiées],[Données non publiées],Assistante parlementaire,
+6cf4ee0d-a86b-48e6-ac88-de824a28cacb,[Données non publiées],CPAM 93,Cadre de la fonction publique,
+6cf7ab5e-701e-4577-b8a2-531ceb29f71d,[Données non publiées],Ville de Rennes,chargée de mission [Données non publiées],
+6cf90517-0e97-4842-b1a8-e5ce0f1c3309,[Données non publiées],GERANT EURL [Données non publiées],[Données non publiées] DANS LE DOMAINE DE L INFORMATIQUE,
+6d0ff84d-2d2b-45bd-8586-77b1f56f3fa3,[Données non publiées],CH LA CHARTREUSE,MEDECIN HOSPITALIER,
+6d20ff3e-8800-4dc4-8693-33f617023867,[Données non publiées],NEANT,NEANT,
+6d276236-2755-4058-b871-7e330c4ed911,[Données non publiées],Intermittent,Auteur / Réalisateur,
+6d32b3c0-800b-4eb0-8296-8c2b9fe26c7c,[Données non publiées],CENTRE PSYCHOTERAPIQUE [Données non publiées],INFIRMIER,
+6d42aa5c-959b-4e8d-bf8b-6975b3891db8,[Données non publiées],AUTO ENTREPRENEUR,NETTOYAGE BATIMENT,
+6d476f0f-b9f6-49fa-aa02-480f7f954949,[Données non publiées],[Données non publiées],Retraitée,
+6d4f2089-0b64-4ed4-93a9-b26043aeb3b9,[Données non publiées],Ministère de l'enseignement supérieur de la recherche et de l'innovation,[Données non publiées],
+6d519b2e-b9ee-41c5-840d-e8f4488422f0,[Données non publiées],SEM Helioparc,Directeur,
+6d519b2e-b9ee-41c5-840d-e8f4488422f0,,RETIS INNOVATION,Président su Conseil d'administration depuis 2019,[Données non publiées]
+6d519b2e-b9ee-41c5-840d-e8f4488422f0,,APESA,Administrateur,[Données non publiées]
+6d519b2e-b9ee-41c5-840d-e8f4488422f0,,AVENIA,Administrateur,[Données non publiées]
+6d519b2e-b9ee-41c5-840d-e8f4488422f0,,NOUVELLE AQUITAINE AMORÇAGE,Administrateur,[Données non publiées]
+6d519b2e-b9ee-41c5-840d-e8f4488422f0,,NOUVELLE AQUITAINE TECHNOPOLE,Administrateur,[Données non publiées]
+6d81dbf6-c24b-43d1-bf7c-83be9fee8e80,[Données non publiées],Éducation nationale,"Professeur des écoles, [Données non publiées]",[Données non publiées]
+6d8617c7-1e8c-4923-b821-fca4c853f9d3,[Données non publiées],Conseil Départemental,Secrétariat,
+6d8d1791-5589-43da-aa22-1eb430682652,[Données non publiées],Ville de Val de Reuil,Néant,"Depuis décembre 2022 [Données non publiées] directrice ""sports, culture et vie associative"" à la mairie de Val de Reuil."
+6d8d1791-5589-43da-aa22-1eb430682652,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] conseillère municipale de Canteleu.
+6d8d1791-5589-43da-aa22-1eb430682652,[Données non publiées],Région Normandie,Conseillère régionale,[Données non publiées] a démissionné de cette fonction le 20 février 2024.
+6d8d1791-5589-43da-aa22-1eb430682652,[Données non publiées],Métropole Rouen Normandie,Conseillère métropolitaine,[Données non publiées]
+6d8d1791-5589-43da-aa22-1eb430682652,[Données non publiées],LOGEAL,Membre du conseil d'administration,[Données non publiées]
+6d8d1791-5589-43da-aa22-1eb430682652,[Données non publiées],HABITAT 76,Membre du conseil d'administration,[Données non publiées]
+6d8d1791-5589-43da-aa22-1eb430682652,[Données non publiées],CCAS de Canteleu,Présidente du Conseil d'administration,[Données non publiées]
+6d8d1791-5589-43da-aa22-1eb430682652,[Données non publiées],Centre de Gestion de la Fonction Publique Territoriale,Membre du conseil d'administration,[Données non publiées]
+6d8e0a0e-3138-4dc5-8155-63d159dd7ad5,[Données non publiées],Chef d'entreprise,Entreprise de consulting en santé et biotechnologies + entreprise de textile spécialisée pour les diabétiques,
+6d926a52-18e5-45bd-b9d0-682cfb19325d,[Données non publiées],RODEZ AGGLOMERATION,Rédacteur principal,
+6d9270b4-e9c0-40f3-8687-6e17176d6aa7,[Données non publiées],Retraitée de l'éducation nationale,Aucune activité professionnelle,[Données non publiées]
+6dac97ff-b3c4-4632-a513-4bf9ab244455,[Données non publiées],Education Nationale,Directrice d'école primaire [Données non publiées],
+6dba484e-a8ce-4bd7-997c-0c019807844a,[Données non publiées],Acanthe Voyages,Agent de voyage,
+6dbc362a-7e97-4861-a571-5e36d802abc5,[Données non publiées],SARL BOUCHET,Assistante de gestion entreprise de plomberie chauffagiste,
+6dbe0069-0768-4571-8ed8-2477082478c7,[Données non publiées],[Données non publiées],co-gerante,
+6dc8d0dd-d44b-4333-be1c-c7aa439efb5d,[Données non publiées],centre hospitalier regional d'Orléans,directeur général [Données non publiées],
+6dcebfbe-ab56-4fc2-9940-826bc34868b4,[Données non publiées],Ministère Education nationale,Professeur collège,
+6dd2a147-93d2-4e89-98e1-53d4d1834798,[Données non publiées],Retraitée,Néant,
+6dd738a6-2a54-4f8c-bb5c-ad07b1877865,[Données non publiées],Centre Hospitalier de Dieppe,Technicienne de laboratoire,
+6de70bab-5191-4179-bf14-ad5e47ede8c2,[Données non publiées],[Données non publiées],Collaborateur parlementaire,
+6de8a1f0-2785-4745-937c-73a25a26f3a4,[Données non publiées],sg menuiseries,gérant,
+6deb6ee1-61c6-4920-993f-47093fb0ed40,[Données non publiées],[Données non publiées],[Données non publiées],retraité [Données non publiées]
+6ded9fa5-c718-4ee8-8736-7f41860991cd,[Données non publiées],POLE EMPLOI,Cadre,
+6df2f55d-0347-4dcb-96c5-3a2f59daa3fe,[Données non publiées],Côte d'Azur Habitat,Cadre,[Données non publiées]
+6df97251-7336-4e58-b71b-da611c4f0841,[Données non publiées],OPHLM du Gers,Fonctionnaire territoriale,
+6e182ff8-f1c1-4752-a88c-06c88da32e80,[Données non publiées],FAUN environnement,soudeur,
+6e1ba539-3c5d-409f-b318-f25a9c49bb82,[Données non publiées],La France insoumise,Directrice de cabinet,
+6e1e7c73-10e1-4ef3-a177-2ef036fc2331,[Données non publiées],neant,neant,
+6e2b1ee8-cec1-471e-b511-abc90a4d09ae,[Données non publiées],[Données non publiées],retraite,
+6e339da9-462f-4816-9f46-a2bb0bfe6d74,[Données non publiées],néant,Néant,retraité
+6e4ee2d7-e6e7-4295-93ae-7e6c9cd38224,[Données non publiées],Macon beaujolais agglomération,Directrice de service,
+6e555450-d384-4281-937e-984033673a8a,[Données non publiées],Sony Music,[Données non publiées],
+6e58c855-8400-4afc-b03e-aad23dad14b6,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+6e58c855-8400-4afc-b03e-aad23dad14b6,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+6e58c855-8400-4afc-b03e-aad23dad14b6,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+6e58c855-8400-4afc-b03e-aad23dad14b6,[Données non publiées],[Données non publiées],[Données non publiées],
+6e58c855-8400-4afc-b03e-aad23dad14b6,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+6e605278-b1e6-4bb3-a61a-a969834fbdf4,[Données non publiées],fiducial consulting,salariée comptable,[Données non publiées]
+6e74df15-583a-478e-afb7-3697481e7d11,[Données non publiées],Haut commissariat de la Polynésie française,RETRAITÉE [Données non publiées],[Données non publiées]
+6e7da899-7bf0-453b-b851-a238ce80ef06,[Données non publiées],Medpace,[Données non publiées],
+6e7fdbed-b059-4030-af18-01b2ca69a881,[Données non publiées],retraite,néant,retraite
+6e8523de-8ca9-42e0-bbe6-57b48c5335fe,[Données non publiées],retraité,néant,
+6e91493a-0dbd-433e-93a2-9bd3e5afee43,[Données non publiées],Mairie du Coteau (42120),Maire,[Données non publiées]
+6e9c9c6b-13f9-4c50-a55d-46b913b16f51,[Données non publiées],Apiculteur,Apiculture,[Données non publiées]
+6e9e510a-f18f-4c76-b68e-6e58e02a7825,[Données non publiées],Indépendant (tns),"Photographe, réalisateurProducteur audiovisuel",
+6ea54af1-c307-4260-82da-e2bf82e44876,[Données non publiées],[Données non publiées],Assistante maternelle agrée déclarée,
+6ea75924-e8f1-42ec-b876-d5cefa3fc12f,[Données non publiées],CENTRE HOSPITALIER DE BIGORRE,Directrice adjointe [Données non publiées],
+6ea9a2e9-2eca-46e5-b4b4-158155cc185b,[Données non publiées],Retraitée-Restauratrice,Ferme Auberge,
+6eb54372-b87b-45cc-b469-536af2072e05,[Données non publiées],REGION REUNION,Agent d'exploitation,
+6ebb74a2-1c7f-4398-88aa-e7b0f51e59db,[Données non publiées],Caroline Fiat,Assistante parlementaire,
+6ebe7841-e0d9-47d4-bd14-2fac47a7482b,[Données non publiées],Néant,Néant,
+6ecbab03-6e8f-4779-b112-71d2a63da36b,[Données non publiées],AGRI-INDUS SAS,Directeur Général,
+6ed4e386-9121-4049-8cf9-f0cf96ddbef7,[Données non publiées],Profession libérale,Pédicure-Podologue,
+6ed7f5ce-50e8-4a6a-9010-153c35aea16d,[Données non publiées],Ministère de la Justice,Magistrate,
+6ee80426-7c1e-420b-9674-cea225660a8f,[Données non publiées],Education Nationale,Professeur de physique chimie,
+6ef6e33e-a0c0-4ad6-9d8b-36bd5ee942e3,[Données non publiées],Retraitée,Néant,[Données non publiées]
+6efa994c-04e5-4273-893a-0c910ddaa891,[Données non publiées],[Données non publiées],Secrétaire de Mairie,
+6f0a5ed6-0855-4e0e-a7a8-1e24509387d8,[Données non publiées],néant,néant,Retraitée
+6f10057f-fa7a-4444-a254-d8f965a8072a,[Données non publiées],à son compte,Agent immobilier sous l'enseigne SAFTI,
+6f167b79-70d8-4de8-bccc-5111ab022db0,[Données non publiées],Divers,Journaliste et autrice indépendante.,[Données non publiées]
+6f181e1f-b6cf-4310-b1be-08c1ed142854,[Données non publiées],Conseil regional Normandie,Redacteur territorial,
+6f2a66ca-5b44-4dac-91a8-68e6d01384a6,[Données non publiées],AIR FRANCE,Officier Pilote de Ligne,
+6f311c1c-b6fa-4fe2-9640-43fcee376ea7,[Données non publiées],Groupe EVALIS,DGA [Données non publiées],
+6f3282f3-6d76-4b74-abb5-11a8d6352ef0,[Données non publiées],Nantes Métropole,[Données non publiées],
+6f355d07-ec63-4705-863d-2b32b09ae48a,[Données non publiées],fonctionnaire territorial CARF [Données non publiées],[Données non publiées],
+6f37f1b8-a518-45ab-8468-3395c1a58d2b,[Données non publiées],[Données non publiées],secretaire de direction,
+6f3bb671-8846-44af-8ba5-dc9a74cd98f5,[Données non publiées],[Données non publiées],Infirmière libérale,[Données non publiées]
+6f3fee75-0db2-4f3e-b011-8637a2db9fff,[Données non publiées],Département du Lot et Garonne,[Données non publiées],[Données non publiées]
+6f46c631-ac46-476e-805e-532513f26da7,[Données non publiées],profession libérale,Médecin Généraliste conventionné,[Données non publiées]
+6f4b1f4d-86fb-471b-8c18-a65bb407465e,[Données non publiées],néant,néant,
+6f4b367c-55a4-4cba-a6b3-7490b3f50ff2,[Données non publiées],NEANT,NEANT,
+6f4bb29f-1f9c-4338-9a44-1651fee8eb97,[Données non publiées],profession libérale,Agent d'assurance,
+6f5da187-f6d7-4f32-85bc-a0533837d4e5,[Données non publiées],Département du Lot et Garonne,[Données non publiées],[Données non publiées]
+6f631ff3-7c15-487a-877e-064233126baa,[Données non publiées],SMIBA,[Données non publiées],[Données non publiées]
+6f6c7835-66aa-498e-946a-a827b713bf62,[Données non publiées],Hôpital [Données non publiées],ASH,[Données non publiées]
+6f6d4f30-0fcf-4e15-9b26-9f281b1c1678,[Données non publiées],Huilerie Richard,Colporteur vente huile et produits dérivés alimentaires,
+6f78018a-b86b-49d1-989d-a8c7502ae576,[Données non publiées],SAFIGEC,juriste [Données non publiées],
+6f7e1f32-aa4f-4c47-af84-f15f3557f802,[Données non publiées],Alstom,Retraité,"plus d'activité, en retraite"
+6f894a12-7a5b-4bf6-b0ae-78dcde8f7d3d,[Données non publiées],Néant,Néant,
+6f92a40f-7b0f-4eae-9bab-594cbf892750,[Données non publiées],ministere de l'interieur,commandant divisionnaire fonctionnel de police,
+6f9404a8-a7d4-467e-afe9-5843fa6d7c8d,[Données non publiées],Mission Locale de l'Agglomération de Limoges,Conseillère en insertion professionnelle,
+6f944351-a3ac-475a-86e8-1d76f6eba04e,[Données non publiées],Sans,Sans,
+6fa5e691-dadd-45d3-b898-e1ff4815695d,[Données non publiées],Clinéa,Psychologue clinicienne [Données non publiées],
+6fa5e691-dadd-45d3-b898-e1ff4815695d,[Données non publiées],La Croix rouge : Hôpital [Données non publiées],Psychologue clinicienne,Outre son activité salariée à temps partiel [Données non publiées] exerce également une activité de psychologue en libéral.
+6fa7b838-9821-458a-9f21-64023f23e07e,[Données non publiées],AFR ACCEUIL FRATERNEL [Données non publiées],[Données non publiées],
+6fa7b838-9821-458a-9f21-64023f23e07e,[Données non publiées],FCP FORMATION CULTURE PRÉVENTION,[Données non publiées],[Données non publiées]
+6faba5e2-1667-4d87-bfb3-6905f707dddf,[Données non publiées],[Données non publiées],COMMERCANT,
+6faba5e2-1667-4d87-bfb3-6905f707dddf,[Données non publiées],[Données non publiées],COMMERCE,
+6fad445a-d9b2-4283-825a-283c8c5749d1,[Données non publiées],STE MECAFORM,CADRE ADMINISTRATIF,[Données non publiées]
+6fb7d900-8f56-4c1b-a9b9-5fcd9de4425c,[Données non publiées],Lycée Général et Technologique et Lycée Professionnel [Données non publiées],Professeur d Education Physique et Sportive. [Données non publiées],[Données non publiées] [Données non publiées]
+6fc2fbc0-9862-4ada-8cce-b168e4a2a165,[Données non publiées],NEANT,NEANT,
+6fcd93f3-a5bf-4aaa-af10-05adbb31ba89,[Données non publiées],Artisan,Coiffeuse,
+6fd1825c-f10b-424a-b641-fcb2bee49db7,[Données non publiées],Entreprise à son nom,Architecte en profession libérale,
+6fd3d060-ebcb-45ca-844f-f92785a9f7f2,[Données non publiées],[Données non publiées],Directrice Générale,[Données non publiées]
+6fd55a00-4fa4-4857-99be-8f7b4d060b34,[Données non publiées],Ville d'Aix-les-Bains,Fonctionnaire titulaire Ingénieur territorial [Données non publiées],[Données non publiées]
+6fd59f41-57d1-4cf7-8a9a-69a0a5d0669b,[Données non publiées],Université [Données non publiées],professeur des universités,
+6fe4e1c9-ae25-49eb-91d7-ff421252f7f9,[Données non publiées],PPG INDUSTRIES,RESPONSABLE [Données non publiées],
+6fe529ea-d9e6-4e0b-a185-3cb6f195a86f,[Données non publiées],Libéral + APHP,Urgences médicales à domicile en libéral Urgences à l'hôpital en salariée,
+6ff0a567-bf8e-457a-acad-c507ae93777d,[Données non publiées],Education nationale,Professeur des écoles,
+6ff7ce57-37de-44f7-8e33-af29e43233d9,[Données non publiées],Pharmacie [Données non publiées],secretaire,[Données non publiées]
+6ff7ce57-37de-44f7-8e33-af29e43233d9,[Données non publiées],ASA [Données non publiées],secretaire,[Données non publiées]
+6ffc67b5-0d9c-4a71-92e3-4aa0f2536016,[Données non publiées],Association Pierre Noal,médecin [Données non publiées],
+7006d470-0462-4b85-b5c2-df4c4a3350ab,[Données non publiées],senat,collaboratrice parlementaire [Données non publiées],
+7009580d-4593-418e-b232-a31b66d9347a,[Données non publiées],Néant [Données non publiées],Néant,
+700ac75e-548a-46f0-b193-21b254018d56,[Données non publiées],LIBERAL,MEDECIN GENERALISTE,
+700b9a3e-1ee1-4925-9c5b-540a62152086,[Données non publiées],Éducation Nationale,Professeur des écoles,
+7016a0c5-c109-4044-bf71-bb267483ca28,[Données non publiées],Ministere de la Justice,Greffière,
+70200f18-c05a-4932-9534-91f5f10893b2,[Données non publiées],SARP OUEST,Formateur activité assainissement [Données non publiées],
+7020b8fb-271f-4732-9325-79da95e8f30c,[Données non publiées],EDF,Technicien [Données non publiées],[Données non publiées] à la retraite [Données non publiées]
+702498d9-aa37-4fc5-ba31-003cba372d04,[Données non publiées],La Poste,cadre,
+7027bf73-265c-4939-9b27-d9433604f2ab,[Données non publiées],Education Nationale,Professeur d'anglais,
+7027ec61-179f-4369-ab07-9d0dc23fa312,[Données non publiées],Conseil Départemental de l'Ain,Assistante sociale,
+702b8bb1-d050-44a3-ac33-6c480ce8d5f6,[Données non publiées],cabinet dentraire [Données non publiées],Secrétaire médicale,[Données non publiées]
+70379bf6-8f57-4037-ac59-558a081967bd,[Données non publiées],Université de la Réunion,enseignant [Données non publiées],
+704150fc-f10f-4daa-b7c6-24314872b714,[Données non publiées],Education Nationale,Professeur des écoles,
+70458f43-4ef1-4906-a28b-41eb6b19f923,[Données non publiées],Travailleur indépendant,conseil en communication [Données non publiées],
+70494f8f-a479-4303-b5d5-db78c49408ed,[Données non publiées],Retraité,Néant,
+70501932-6bf1-4fe4-9fe9-b8c8b41c221e,[Données non publiées],CNRS,Chargé de recherche puis directrice de recherche,[Données non publiées]
+70632b5f-5d74-469d-a08f-5bd912ae2908,[Données non publiées],néant,néant,
+7065043c-bcc5-496c-88a1-72b6753cd16e,[Données non publiées],néant,néant,retraite
+706ae896-36b3-4241-8aff-c31eef0288e3,[Données non publiées],Evel'Up,[Données non publiées],
+706c4dd6-082d-4a49-942b-ee463def8bb6,[Données non publiées],NEANT,NEANT,Retraitée
+706c8190-22f3-4ab7-acd4-a7212e305ef5,[Données non publiées],Mairie Sevrier,Directrice Générale des Services,
+70700a34-3516-437a-9aa8-746a8c1b8184,[Données non publiées],BNPrealestate,[Données non publiées],
+7076db21-2ea6-474a-a4d3-7049307b123c,[Données non publiées],BIOROCK,COMMERCIAL,
+7089a58b-c993-4d8a-836e-42d5cf7afc44,[Données non publiées],MAJ - ELIS [Données non publiées],ASSISTANTE COMMERCIALE,
+708e635c-edcd-46c1-a6cd-0566d93ddc6a,[Données non publiées],Musée des Arts Déco - Ecole Camondo,[Données non publiées],
+70907ba3-d317-41c3-8d6e-8ddbfa2d7468,[Données non publiées],Mairie de Montreuil,[Données non publiées],
+709fe870-fc3c-4942-a882-972a85e2c63d,[Données non publiées],néant,néant,
+70b3735e-a379-4659-9f30-0ca29f7fa884,[Données non publiées],profession liberale,professeur de danse,
+70b95aa9-d7d0-404c-9316-b59df560621b,[Données non publiées],Ensemble Scolaire [Données non publiées],Directrice Adjointe [Données non publiées],
+70bf54f4-05e7-4d16-b144-df27a3840a0e,[Données non publiées],EPCI,Attachée territoriale,
+70c4749d-269c-48fe-bc0f-fdf77ac279e5,[Données non publiées],Arthur Lyod Developpement,[Données non publiées],
+70c872f6-5228-4a30-b7e9-2bb37d5bf47a,[Données non publiées],néant,retraitée,
+70cacad1-2306-42ec-8033-7a69ec949454,[Données non publiées],[Données non publiées],gerant de la société,
+70cf50bf-a0e0-44d5-81ff-f71fbfd4f398,[Données non publiées],[Données non publiées],[Données non publiées],A la retraite [Données non publiées]
+70d52edd-6ef6-4750-97d7-f99ffff5b394,[Données non publiées],Néant,Néant,Conjoint retraité
+70db912c-bfe4-4ff3-ba37-bb0dd123de72,[Données non publiées],neant,retraitée,
+70e3cd96-9d91-444a-b8c2-58df6b9f1149,[Données non publiées],Néant,Néant,
+70e5381e-59e9-49f2-b935-1c6e8aa5ba60,[Données non publiées],CERGY LOCATION SERVICES,[Données non publiées],
+70eb888f-601f-480a-b62c-e1cf2d44ca92,[Données non publiées],CRCA Brie Picardie,[Données non publiées],
+70f24282-b857-43d8-8018-74876d462d11,[Données non publiées],[Données non publiées],Pharmacienne,
+70f98afa-7178-45e6-b78b-a000706a577a,[Données non publiées],Sans,En formation IFSI,
+710022c2-46dc-4136-b12e-58dbd6e52f50,[Données non publiées],MAERSK FRANCE,EMPLOYE DE CONSIGNATION,
+7112ffaa-918c-49cb-bfc3-f29768114f91,[Données non publiées],Néant,Retraitée,
+711ab7f9-4569-4247-9808-fcbdd0d2f489,[Données non publiées],Ministère de l'Intérieur,Préfet de département,
+711c1400-b556-4668-b873-64d16cb44053,[Données non publiées],Ministère Education Nationale,Professeure des écoles,
+711de400-9224-4495-93a6-29302449ea8c,[Données non publiées],retraité de la Fonction Publique,retraité,
+712593a3-d81a-45a6-a519-32513a760bab,[Données non publiées],CPAM 93,Cadre de la fonction publique,
+7125f111-3aeb-49e3-b29a-30485510b10b,[Données non publiées],néant,néant,
+712944f5-c862-414a-9c78-b0ca8c5f2cbe,[Données non publiées],Clinique vétérinaire [Données non publiées],Vétérinaire salariée,
+712cd25c-9c6b-4b1d-a177-e1a6f37cc2cd,[Données non publiées],CROIX ROUGE,[Données non publiées],
+7132ccd7-6b64-4fc8-99a3-c7168ac583b2,[Données non publiées],Crédit Agricole,Animatrice vie mutualiste,
+71333043-1a14-40be-aeb3-c3688c24efb9,[Données non publiées],mairie du plessis trevise,infirmiere puericultrice [Données non publiées],
+7136e507-0426-4862-8a04-685cc902d1c9,[Données non publiées],auto entrepreneur,"artisan, second oeuvre",
+713a77d9-f2ef-486a-a0b7-b0f0d842cc6a,[Données non publiées],CCMP,Ouvrier opérateur d'exploitation [Données non publiées],[Données non publiées]
+7144ac32-cdbb-4c5e-b948-5ce10b3bbf88,[Données non publiées],SELARL Hobson,Avocat Associé,[Données non publiées]
+714da41a-03aa-4671-82c8-cd57e831d77f,[Données non publiées],profession liberale,ostéopathe,
+714f2c80-4dbb-48f9-9faf-8f94767fca57,[Données non publiées],VILLE [Données non publiées],REDACTRICE,
+715db626-8509-434f-8a6f-d4f4509ff859,[Données non publiées],néant,néant,
+716bd8a8-8b46-4d87-bea7-fc5d77745386,[Données non publiées],NEANT,[Données non publiées],[Données non publiées]
+71735ec2-010f-46f8-ae48-354d876bf45e,[Données non publiées],chambre de commerce et d'industrie de GUYANE,[Données non publiées],
+7176dc47-c37d-45ec-9f95-887fa38c6c69,[Données non publiées],néant,néant,néant
+7178dbf4-9d61-4791-a9a2-91411fd73095,[Données non publiées],Ministère de l'Education Nationale,Professeur des écoles,
+71a1418c-0b1f-447c-8538-df7a79863b23,[Données non publiées],CABINET [Données non publiées],ASSISTANTE DENTAIRE,
+71a30511-8062-4867-ba7f-5a6aad328190,[Données non publiées],Néant,Néant,
+71b9fed1-f10f-4d6a-babb-19b9fd99e03a,[Données non publiées],DSDEN de la Marne,Accompagnante d'élèves en situation de handicap (AESH),
+71bbf8e2-1826-48d7-9418-169124ac17ee,[Données non publiées],[Données non publiées],AVOCAT,
+71dabfd2-e3b3-40e7-9a30-4b5b7ef74542,[Données non publiées],[Données non publiées],Maison d'hôtes,
+71ddd627-b462-486e-9b1e-837affde6c64,[Données non publiées],MSA [Données non publiées],Gestionnaire service comptabilité,
+71e99f47-a010-4309-8a3d-c7d7c67d97af,[Données non publiées],Louis VUITTON,Assistante Administratif,
+71effc4a-9a0b-40e6-a4cf-0598b09bb5ab,[Données non publiées],profession libérale,masseur-kinésithérapeute,
+71fa5503-e5a8-484f-9a23-e85964e6f47e,[Données non publiées],Commune Terre de haute Charente,Chargée de communication,[Données non publiées]
+720669f0-1a39-46d2-ba3e-a5da59c5bd43,[Données non publiées],SCEA [Données non publiées],"agriculteur, [Données non publiées]",
+720669f0-1a39-46d2-ba3e-a5da59c5bd43,[Données non publiées],BEYNE NV,commercial matériel agricole,
+7213c570-96eb-4a27-8689-c95406257442,[Données non publiées],ADMR,[Données non publiées],
+72151586-1d47-4885-97cc-b3146e1808f9,[Données non publiées],BUREAU NAVAL,dirigeant d'entreprise,
+7216e6a6-3712-4c2c-b363-0e5ed68bea0e,[Données non publiées],FAR CONSEIL,[Données non publiées],
+722084a9-f3a9-40e3-bd16-7cf663b76589,[Données non publiées],néant,néant,
+7222adba-933e-4ea8-9cb1-f0ddff958575,[Données non publiées],néant,Néant,[Données non publiées]
+72278a67-3c59-4403-86d6-e9703526c695,[Données non publiées],Groupama Nord Est Reims,Gestionnaire achats et parc,
+722aa657-a0d8-4c82-90e7-8d8a58563b94,[Données non publiées],METROPOLE AIX MARSEILLE PROVENCE,[Données non publiées],
+7238a7b6-7792-4a52-987e-6333d71f7067,[Données non publiées],Centre Hospitalier Universitaire [Données non publiées],Infirmière à domicile,
+72402300-ca16-431e-a3cb-5612f180e6f8,[Données non publiées],Retraite,retraite,
+724bf8c0-54bf-43b9-8b8e-64a140b806e1,[Données non publiées],CNAS,Directeur de la transformation,
+7255d4e2-b7c0-4a43-b23a-1c5aba0446b8,[Données non publiées],retraité,néant,[Données non publiées]
+7258c7bb-ab0d-4265-9556-c7343a4d8373,[Données non publiées],[Données non publiées],Infirmière Libérale,[Données non publiées]
+725b0892-c06a-4dbe-b893-577f7f7c9fc4,[Données non publiées],[Données non publiées],[Données non publiées],à la retraite
+725b0892-c06a-4dbe-b893-577f7f7c9fc4,[Données non publiées],à la retraite,retraitée,[Données non publiées]
+725b0892-c06a-4dbe-b893-577f7f7c9fc4,[Données non publiées],Autoentrepreneur,Mandataire immobilier [Données non publiées],
+726008e7-f75f-4ed6-b5d3-9cf702c43c5b,[Données non publiées],Education Nationale,Professeur des Ecoles,
+7264c459-56e8-4e94-b5be-a1b91ddc1626,[Données non publiées],Covea assurances,informaticien,
+72692be2-b5a6-430b-b0c0-384c533b7682,[Données non publiées],NEANT,NEANT,
+726a49cc-9b04-4a2e-bec1-f01306f85b68,[Données non publiées],Ministère de l'Education Nationale,Institutrice,
+72759cf7-799f-40b0-a2bd-fe24c8a2d421,[Données non publiées],éducation nationale,professeure,
+7277064e-3a32-45ca-a525-d5c6ebdad4e4,[Données non publiées],MAIRIE [Données non publiées],Agent administratif,[Données non publiées]
+72812b88-2a89-4642-9b1f-b0ea77cc5d50,[Données non publiées],Communauté de communes de Bievre Isère,Directrice de pôle,
+728263eb-cddc-472b-9339-d7fee6637f0c,[Données non publiées],néant,néant,
+72881025-e688-4e4e-90d6-12c4e5fcd2b0,[Données non publiées],Ministère de l'Education nationale,Professeure des écoles,
+728dd00e-08f6-4b6f-83f5-af3133b8233c,[Données non publiées],France Télévision,Journaliste,
+7294201f-09a2-483b-bdb4-3214093bf517,[Données non publiées],Associée - EURL,[Données non publiées],
+729834ee-bd80-4a52-8980-dd5be96950f6,[Données non publiées],entreprise individuel,fabrication de jeux en bois vente de jeux et jouets en bois,
+72a040c5-1fb8-4033-a603-91d58cc49521,[Données non publiées],NEANT,NEANT,
+72a5390d-c2ee-43bd-9529-0ea25bc00c27,[Données non publiées],SHARP FRANCE,[Données non publiées],
+72baefaf-b448-4a0f-b92f-dee84c806e50,[Données non publiées],Clinique vétérinaire [Données non publiées],Vétérinaire salariée,
+72bc90e7-3abb-4abe-91e3-823e62245737,[Données non publiées],associations Gymnastique Volontaire,cours de Gymnastique,[Données non publiées]
+72c0eb0e-b470-4d89-b083-5df536ab1b63,[Données non publiées],[Données non publiées],Préparatrice en Pharmacie Hospitalière,
+72c81fe6-d822-458d-8035-fc449d4f3320,[Données non publiées],Laboratoire Pierre Fabre,Directrice Congrès,
+72cb8f0f-2ecd-41f1-a6a3-398a0de47958,[Données non publiées],Associé non exploitante agroiicole,Néant,
+72dbfcec-f925-405d-9912-f4e5752e9d67,[Données non publiées],SAS [Données non publiées],PDG d’un camping familial,
+72f42b8a-7122-4d3e-9e7a-f8cd22e7dfa3,[Données non publiées],Staffmatch,Responsable [Données non publiées],
+72f950b3-44b5-494f-9ed9-27eb6c5e7a56,[Données non publiées],MINISTERE DES ARMEES,OFFICIER DE MARINE,
+7303c4f3-99c8-4c10-bba1-bb149e73d4b8,[Données non publiées],Sans,Sans,
+7305d4fd-a6b3-4f2b-aa73-3e1a0d4bdfd1,[Données non publiées],sonova audiological,Audioprothésiste,
+7307d218-be6b-4e70-acea-4a7f6af16852,[Données non publiées],Néant,Retraitée,
+73136222-7613-4373-a4b4-b39b42ee23c8,[Données non publiées],Retraité [Données non publiées],Mandats électifs : . Maire [Données non publiées] VP de la Communauté Urbaine de Grand Besançon Métropole (CUGBM),
+73153387-6e9d-475a-9ee0-fc4f6d8664a1,[Données non publiées],CRC Ile de France,Magistrat financier [Données non publiées],
+731cebdb-a37d-4b3c-8fb2-1abd65e54dbd,[Données non publiées],Crédit Agricole Centre France,salariée,
+731fa4d2-e610-4bea-a624-16be2da254d2,[Données non publiées],Néant,Néant,
+7320a2b3-75f8-418c-b1d4-3610c84aa2bc,[Données non publiées],CHU Rouen,retraité,
+7327da27-859e-4e5e-84f1-528d38dcd434,[Données non publiées],[Données non publiées],ENSEIGNANT,[Données non publiées] Maire de la commune de Villetaneuse
+7341040a-896f-4b3d-ad22-d3fc09209ca9,[Données non publiées],Conseil départemental de la Seine-Saint-Denis,Attachée territoriale en détachement [Données non publiées],
+735352e9-8d13-4e04-b07e-4bfae00ce1e3,[Données non publiées],AXA [Données non publiées],Salarié,
+735b4878-61b0-44bc-931d-4ea156b0bc7c,[Données non publiées],A.M.J.P. (L'ATELIER D'YVONNE),Chef de rang,
+73698fa0-959a-4b95-a693-7c7f1ffe66f4,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+7376e2c0-9631-4419-a1ef-bb23b0b02763,[Données non publiées],Pays de Montbéliard Agglomération,Fonctionnaire territorial,
+737f8d88-5994-4f6e-b170-9e64fe2f7acf,[Données non publiées],Centre hospitalier [Données non publiées],Directrice [Données non publiées],
+738a1e57-69a3-48ac-8b65-df36e032b80b,[Données non publiées],Centre hospitalier de Bergerac,Encadrant [Données non publiées],
+738f87b1-b310-449f-9dc3-a355b89d70a6,[Données non publiées],néant,Exploitant agricole retraité,
+739e85a7-7ad9-4999-aee0-85644bc66d56,[Données non publiées],Association [Données non publiées],Directrice,
+73a293ff-10fb-4a1f-9f79-1e36ea1b6bba,[Données non publiées],retraitée,néant,[Données non publiées]
+73a4f79c-494f-49dd-b725-f319dc229f86,[Données non publiées],Ville de Claye-Souilly,Fonctionnaire territoriale [Données non publiées],
+73a9595a-8031-4c0c-80c6-47119fabc18c,[Données non publiées],Retraitée Airbus Group,Néant,[Données non publiées]
+73aa5ddc-24c7-4259-80ec-1d4a664edd2f,[Données non publiées],Éducation Nationale,Professeur des écoles,
+73b55be2-b9cc-4870-b5a7-9abb961465d5,[Données non publiées],Icadémie éditions,formatrice [Données non publiées],
+73b729f4-957d-4289-82fa-60c3bb2ea403,[Données non publiées],CSC Les chemins Blancs,Animateur culturel,
+73bc7973-9e17-4ecf-8b7f-4d69a0779b6e,[Données non publiées],SAS DELICATESSE CONCIERGERIE,conciergerie location courte durée,
+73c108f9-2f35-40a5-a585-30d834ff6ec3,[Données non publiées],Etat (ministère de l'intérieur),[Données non publiées] cabinet du ministre de l'intérieur et des outre-mer,[Données non publiées]
+73c33a45-40ba-4244-8bcd-2209bfb59cba,[Données non publiées],soprasteria,ingenieur,
+73c6baf0-18c9-48b9-a3bf-9462334447f6,[Données non publiées],Hopital St Marie Nice,Infirmière,
+73c77ee6-87ce-4a09-b7e1-4db3012c5b02,[Données non publiées],commerçante,gestion d'hébergements touristiques,[Données non publiées]
+73cc3330-3922-4277-8929-0d2337269d1d,[Données non publiées],Artisan,Relieur,
+73e3cddf-c573-4ae2-aa5f-1b27c8507ded,[Données non publiées],CentraleSupélec,Enseignant-Chercheur,
+73eec127-26f0-4fcb-a4f4-0296346aecab,[Données non publiées],Education nationale,Professeur des écoles,
+73ef5a14-2488-4e1d-bde1-16ee990df0d5,[Données non publiées],POLE EMPLOI,[Données non publiées] EMPLOYE PATRIMOINE CDD PUBLIC,[Données non publiées]
+73f36430-60e9-41ad-85c0-93e5aefddceb,[Données non publiées],Opac [Données non publiées],Responsable [Données non publiées],
+73fb1d7b-a0f9-4f42-8e6a-9ff358584aab,[Données non publiées],Profession Libérale,Médecin spécialiste Gastro-entérologue,
+73fe41c0-d333-4381-b921-57ab2d1ce701,[Données non publiées],DSDEN [Données non publiées],Assistante de service social mise à disposition à la [Données non publiées] en tant qu'experte médico-sociale,
+740411c9-ce8b-497e-9ec7-019870b8b70a,[Données non publiées],Crédit Agricole [Données non publiées],[Données non publiées],
+740bdf80-a148-4c3b-8792-0753670adcf6,[Données non publiées],LUI MEME,VITICULTURE,
+740eb8df-7134-4049-b176-b067d2a3dcdb,[Données non publiées],Chef d'entreprise,Gérant,
+74127350-2395-48bc-9ca3-98d42853488c,[Données non publiées],Centre Hospitalier [Données non publiées],Infirmière DE,[Données non publiées]
+7413d953-c67b-4a5c-9b30-520aaefbaafe,[Données non publiées],CARTESIO,Responsable du développement,
+74292119-5424-47ab-b85d-e1c8efce3f01,[Données non publiées],centre hospitalier spécialisé Drome Vivarais,OUVRIER P 2ème classe,
+74292119-5424-47ab-b85d-e1c8efce3f01,[Données non publiées],EARL D'ARCE,Gérant associé exploitant agricole,
+742af232-b658-4315-bb86-4209d7047be9,[Données non publiées],retraitée,néant,
+7439eb39-f211-4f4a-b726-22d902c29468,[Données non publiées],SBR,SOCIETE DE VENTE ET REPARATIONS DE GROUPES FRIGORIFIQUES,[Données non publiées]
+7445509c-687c-4b9d-86bc-64b23c0a05cd,[Données non publiées],Néant,RETRAITE,
+744603c9-4164-4dcc-903f-1df26517eb04,[Données non publiées],Laiterie [Données non publiées],Assistante administrative,
+7450ae9e-f313-4c22-ac67-f09a55634bb6,[Données non publiées],néant,néant,
+745ab373-5b87-499c-80ed-bd57fd3a26dc,[Données non publiées],Société Eminence,[Données non publiées],[Données non publiées]
+745b6b25-b52a-4af1-83dc-0bced77d9a3f,[Données non publiées],Retraité [Données non publiées],Neant,
+747520f4-a10a-43cb-a5a0-bf8358e69c1f,[Données non publiées],NEANT,NEANT,RETRAITE
+74802316-f587-45d6-967b-b71c6684b534,[Données non publiées],Neant,Neant,
+74834e7e-5ff5-41a7-9d2a-f2a56400aabd,[Données non publiées],[Données non publiées],"édition du magazine [Données non publiées] , traduction et commercialisation d'espaces de salon professionnel en Allemagne",
+748a7885-7884-4a9e-a6c5-af69a0ca42d0,[Données non publiées],EDUCATION NATIONALE DE LA REUNION,ENSEIGNANTE,[Données non publiées]
+748bff1b-6646-44e7-8faf-fe4abd338606,[Données non publiées],Ville de Val de Reuil,Néant,"[Données non publiées] directrice ""sports, culture et vie associative"" à la mairie de Val de Reuil."
+748bff1b-6646-44e7-8faf-fe4abd338606,[Données non publiées],Ville de Canteleu,Maire,[Données non publiées]
+748bff1b-6646-44e7-8faf-fe4abd338606,[Données non publiées],Région Normandie,Conseillère régionale,Il ne s'agit pas d'une activité professionnelle mais d'un mandat électif rémunéré [Données non publiées]
+748bff1b-6646-44e7-8faf-fe4abd338606,[Données non publiées],Métropole Rouen Normandie,Conseillère métropolitaine,Il ne s'agit pas d'une activité professionnelle mais d'un mandat électif rémunéré [Données non publiées]
+748bff1b-6646-44e7-8faf-fe4abd338606,[Données non publiées],LOGEAL,Membre du conseil d'administration,Il ne s'agit pas d'une activité professionnelle mais d'un mandat d'administrateur (non rémunéré).
+748bff1b-6646-44e7-8faf-fe4abd338606,[Données non publiées],HABITAT 76,Membre du conseil d'administration,Il ne s'agit pas d'une activité professionnelle mais d'un mandat d'administrateur (non rémunéré).
+748bff1b-6646-44e7-8faf-fe4abd338606,[Données non publiées],CCAS de Canteleu,Présidente du Conseil d'administration,Il ne s'agit pas d'une activité professionnelle mais d'un mandat d'administrateur (non rémunéré).
+748bff1b-6646-44e7-8faf-fe4abd338606,[Données non publiées],Centre de Gestion de la Fonction Publique Territoriale,Membre du conseil d'administration,Il ne s'agit pas d'une activité professionnelle mais d'un mandat d'administrateur (non rémunéré).
+749434a5-ff09-4c5d-9deb-5c25d0ae9f5d,[Données non publiées],RETRAITE,NEANT,
+74986429-e049-4001-a000-531b1967045a,[Données non publiées],Education Nationale,Gestionnaire - Agent comptable,
+749c03ed-935f-42d9-9a0e-5e3aad68bb8e,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] retraite [Données non publiées]
+749c961b-ca6f-47ff-90e7-f3ed6cc82f40,[Données non publiées],Education nationale,enseignante en collège,
+749dfd9b-fde6-4e97-bea9-8844e7a74066,[Données non publiées],Neant,Retraitée,
+749e88c6-95ec-4bd3-a969-7fa189207eb0,[Données non publiées],ACCESS AUTOMOBILE,MECANICIEN AUTOMOBILE,
+74a411b3-d32c-4fe4-a594-5b34b08dacbe,[Données non publiées],[Données non publiées],infirmière [Données non publiées],
+74a93ad6-8ed2-4f2a-836c-7a6f978a23e3,[Données non publiées],Sans emploi,[Données non publiées],
+74ab7494-f0df-4a69-a08f-18b31e8111f8,[Données non publiées],[Données non publiées],[Données non publiées],
+74ae19b3-935c-4469-b5a1-482e3ed1782e,[Données non publiées],BOUCHERIE [Données non publiées],SALARIÉE DEPUIS 2005 PUIS COGÉRANTE DEPUIS LE 1ER MARS 2021.,[Données non publiées]
+74b159a8-a4a1-4ffb-946a-7778383ef8cd,[Données non publiées],Ferropem Montricher,opérateur [Données non publiées],
+74b3eb12-6834-4a05-aadb-9edff4b601f7,[Données non publiées],Mairie de Notre Dame de Boisset,Agent technique [Données non publiées],
+74b3fe79-de83-4f1b-a40c-1075822eca0c,[Données non publiées],[Données non publiées],Fonctionnaire Cat B Ludothécaire,
+74bcd03d-1015-44ed-93a0-4346a2349a4f,[Données non publiées],néant,Retraité,
+74d3e965-59d4-4fc5-a820-c0ada281602c,[Données non publiées],STAG - Villers Bretonneux,Assistante administrative,
+74d48e44-0392-4ec9-af94-befbc6d56cda,[Données non publiées],néant,néant,
+74d4b5ef-6261-4636-8463-b3c59915c702,[Données non publiées],neant,[Données non publiées] Retraitée,
+74dbf520-f5d8-48c9-80bd-948a1436f8b1,[Données non publiées],[Données non publiées],entreprise &gro alimentaire Directeur technique,[Données non publiées]
+74dc59bd-cf1f-478d-83dd-7acae4be0696,[Données non publiées],Association L'Hectare,Directeur,
+74dcff85-7542-4132-8919-7d8613d900d8,[Données non publiées],Jump,Directeur des Opérations,[Données non publiées]
+74dfc77e-8e47-4f7b-bf68-ece6ad07b1d0,[Données non publiées],Conseil Régional [Données non publiées],Chargée de mission,
+74e1c995-5f50-4fff-b474-6dd90f05a14c,[Données non publiées],Education Nationale [Données non publiées],Professeur d'Arts Plastiques,
+74e32614-8cd9-46b0-ae67-e28570f025ca,[Données non publiées],Epsm,[Données non publiées],
+7506f05d-a603-4a90-8bcb-4e2aab1dea4c,[Données non publiées],RODEZ AGGLOMERATION,Rédacteur principal,
+750d9f3c-6abe-4dcb-9c2a-c9be89b39433,[Données non publiées],SCEA [Données non publiées],Associée - Exploitante agricole,
+7515f59a-db68-4ede-ba7f-246c7a0e53d5,[Données non publiées],Communauté d'agglomération bergeracoise,[Données non publiées],
+75330521-2126-44d2-9d08-78d316187f39,[Données non publiées],activité libérale,Avocat [Données non publiées],[Données non publiées]
+753cb5d0-2790-43b5-81d3-ff972548888e,[Données non publiées],Pôle emploi,Animatrice d'équipe,
+754158d4-8605-49c7-a1a9-210261910137,[Données non publiées],région occitanie,agent technique des lycées,[Données non publiées]
+7542eb13-784d-4ea6-aa54-a193dedd491e,[Données non publiées],centre hospitalier [Données non publiées],praticien hospitalier,
+7549630a-8573-4682-9278-cb4219bbaab9,[Données non publiées],SITCOM,technicien supérieur,
+7552a6d5-69ac-4d78-a913-f3e86455541b,[Données non publiées],abbvie,Visiteuse médicale,[Données non publiées]
+75552483-dcda-4f6c-b717-8411f658de1f,[Données non publiées],IDEFHI,Médecin des usagers,
+7561340f-bcfe-49cb-984c-18233dd6d4c6,[Données non publiées],Ministère Education Nationale,Professeure des écoles,
+756734e3-f62f-43ec-a4d6-5cd823ae48f3,[Données non publiées],Néant,Néant,
+756963dc-53e5-4971-a2b7-cb4f86bd07dd,[Données non publiées],SUN'R GROUPE,OFFICE MANAGER,
+7569fbb0-9c5f-4fa4-a4de-404809888795,[Données non publiées],SMTP (LINGENHELD),DIRECTEUR D'AGENCE cadre dirigeant,[Données non publiées]
+7572d4c1-5330-47e7-b16c-af982445ff93,[Données non publiées],[Données non publiées],sans emploi [Données non publiées],
+75759e59-492f-4ca4-9f24-d5c78deef8dd,[Données non publiées],Lycée [Données non publiées],Infirmière scolaire,
+757bcc13-73d8-4d03-9d40-01d31ea1573a,[Données non publiées],Air France,Chef de cabine,
+75816070-c3e2-4a28-9caa-3d13e80cab96,[Données non publiées],[Données non publiées],pharmacien titulaire [Données non publiées],
+758c26a8-bd79-4809-84f3-35b90bb12d5e,[Données non publiées],VNF,Technicie,
+75a08a67-e417-4e9b-b894-4149448c9a9f,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+75a08a67-e417-4e9b-b894-4149448c9a9f,[Données non publiées],SASU ACITI,Présidente [Données non publiées],[Données non publiées]
+75a5523f-9265-46d3-84a8-49127afbb632,[Données non publiées],Mairie de FAUCON [Données non publiées],Secrétaire générale,[Données non publiées]
+75aba1c5-f62c-4d9e-bd5f-701da6cb11ef,[Données non publiées],BIOROCK,COMMERCIAL,
+75c7a780-d891-4238-96d4-abf46d6e0d19,[Données non publiées],NEANT,NEANT,[Données non publiées]
+75ccd354-2a2f-4f09-94d3-48ff40fefd41,[Données non publiées],Niort Agglo,[Données non publiées],
+75cd3a8a-71e3-4f0f-aa02-b36172e5600c,[Données non publiées],RETRAITE,[Données non publiées],
+75ce8458-5b29-4b93-b69d-b26cf186aba2,[Données non publiées],Ministère de l'éducation,Professeur des écoles,[Données non publiées]
+75cedaae-75d6-4ef1-a3c8-345b247bca43,[Données non publiées],Néant,Sans activité,
+75d0fde4-cb29-409b-ae74-5265a3db718d,[Données non publiées],néant,néant,[Données non publiées] retraite [Données non publiées]
+75d9d449-f6e9-47cf-83f2-408de9ebf9e1,[Données non publiées],SANDERS,Employée au service RH d [Données non publiées] [Données non publiées],
+75e06eda-9d60-4214-b8eb-1dce7319f927,[Données non publiées],COOPALPHA ET Association AGAPES,Coopalpha: [Données non publiées] consultant formateur AGAPES : gestionnaire des ressources humaines,[Données non publiées]
+75ecb6ed-4c49-4d6b-8d43-74eedc69f060,[Données non publiées],Retraitée,retraitée,
+75ef411c-6f33-4af6-adef-a86b9e35c778,[Données non publiées],Rectorat de l'académie de Nancy-Metz,retraité [Données non publiées],
+75f60842-08f1-469b-ba7a-1e7f4dbd6af7,[Données non publiées],NEANT,NEANT,RETRAITE
+75f7e392-e9d9-4606-a3cd-94c156dbb48f,[Données non publiées],Enedis,Gestionnaire,
+75fc61ca-fc57-470d-813b-777650c11dd9,[Données non publiées],Ministère de l'intérieur,Commissaire divisionnaire,
+75fdda0d-8c1d-4a0a-b281-5effa84b6462,[Données non publiées],Only Vet,Vétérinaire,
+760e6d4f-3960-43c9-bdea-d87ae0eac9aa,[Données non publiées],JC Decaux,Attachée commerciale,
+760fff3d-d010-46c8-bc4d-306fe8550bb2,[Données non publiées],Conseil Régional Nouvelle-Aquitaine,[Données non publiées],
+7610e4b2-9568-4fef-8c19-8ffca6d6f155,[Données non publiées],NEANT,retraitée,Retraitée
+7611a18d-ed0b-48cb-9a99-32d8acfdda92,[Données non publiées],fonction publique hospitalière,aide soignante [Données non publiées],[Données non publiées]
+7617897e-cfaf-4162-8033-3b4e8710308a,[Données non publiées],L2N,SECRETAIRE,
+7625e7ef-530e-4281-ae8a-7be46d1c22cb,[Données non publiées],EPLEFPA [Données non publiées],animateur financier,
+762e3c83-2a46-44a9-b28a-d32968e8356a,[Données non publiées],Générations Mouvement - Fédération de l'Aveyron,Agent [Données non publiées],
+7641e8d6-dd76-4f11-b898-d533cd084fb8,[Données non publiées],Macocco Ouest,Assistante commerciale,
+76420083-b8c8-4ee3-b33c-42a00389005f,[Données non publiées],CONSEIL DEPARTEMENTALE 22,Educatrice spécialisée,
+764cf3ba-1191-4bba-9fdd-7efc0ca52f22,[Données non publiées],R INTERIM,INFORMATICIEN,
+7652d507-79f1-4549-8087-c87fd0b18da9,[Données non publiées],SARL BED,Gérant,
+76716bbd-db37-473a-8e89-d473854b4607,[Données non publiées],Université UPEC Paris 12,professeur,
+7679ff3f-b023-478a-85d8-504f9d6f1fde,[Données non publiées],retraitée,retraitée,
+7688bfd8-8a8a-4951-aa21-93f2bca37bf5,[Données non publiées],NEANT,NEANT,
+7688edcc-dfe5-464f-a099-c85ce7016704,[Données non publiées],Education Nationale,Institutrice,
+768d3675-f4c1-4853-ad77-3d285dbb1984,[Données non publiées],GRADE IESS PACA,[Données non publiées],
+76933453-9495-40e7-8c1a-e5676dd82004,[Données non publiées],ORANGE,Employé de bureau,
+769abe72-17de-4711-b3ec-d3095799a5d5,[Données non publiées],Est Ensemble,Professeur de danse,
+769c1872-ab9b-4f29-937b-09cf473ccbe3,[Données non publiées],R+4,Assistante,
+76a5ad79-5738-4bfc-aea6-1f3e35ff3805,[Données non publiées],Sarl [Données non publiées],maçonnerie charpente,
+76aebf5e-3ddc-4598-a539-ae7b251bd0f5,[Données non publiées],FSEF,[Données non publiées],(infirm psy)
+76aebf5e-3ddc-4598-a539-ae7b251bd0f5,[Données non publiées],[Données non publiées],[Données non publiées],
+76c11686-bae0-4614-9a2f-a667562f5353,[Données non publiées],METROPOLE NICE COTE D'AZUR,COLLABORATEUR D'ELU,
+76c274db-8f87-4a4b-b6b8-b6e9b498528b,[Données non publiées],[Données non publiées],[Données non publiées],
+76c8640d-170b-42b6-96d5-5415e310d31d,[Données non publiées],Hilti France,Directrice [Données non publiées],
+76d2b8ea-7aea-461b-95fa-4340fa60db5c,[Données non publiées],[Données non publiées],[Données non publiées],Retraitée
+76d325a9-3a3f-4f39-bfbd-614c39592b57,[Données non publiées],AGLA,[Données non publiées],
+76ec9ea3-96e4-497a-ae71-4ca92f443b90,[Données non publiées],Conseil départemental [Données non publiées],Attachée territoriale [Données non publiées],
+76ecc319-b272-4995-90ad-01f9042e7025,[Données non publiées],Conseil départemental des Ardennes,rédacteur territorial [Données non publiées] Conseil Départemental des Ardennes,
+76f60687-e33e-4170-a08c-5f2819e1cbba,[Données non publiées],CLEMESSY,CHEF DE PROJET,
+76fdb297-054f-4280-ae63-0d522801d76d,[Données non publiées],[Données non publiées],RETRAITEE,
+76ffed12-08ec-40b2-9b27-095b51bb3690,[Données non publiées],Education nationale,Professeur de lettres modernes / collège,[Données non publiées]
+77006a32-cc80-435f-85d4-9f0f67a5e4ac,[Données non publiées],Design Concept [Données non publiées],Agencement d'intérieur,[Données non publiées]
+7702e83e-fefd-4f09-8316-96cc0ea3244a,[Données non publiées],Sarl jfsi,Activité immobilière,
+7705310e-5857-4535-a69a-904b2154c2a5,[Données non publiées],groupe safran,approvisionneuse,
+7708e0ad-5715-44b5-a6ac-10dc6677d357,[Données non publiées],Ecole de Musique Danse et Théâtre [Données non publiées],Enseignante [Données non publiées],
+7708e0ad-5715-44b5-a6ac-10dc6677d357,[Données non publiées],Ecole de Musique [Données non publiées],Enseignante [Données non publiées],
+770aa716-f6ab-467b-bc03-55f8538cc8c6,[Données non publiées],[Données non publiées],Location de gîtes,
+770ed9e9-96cd-4537-bc37-ae7e3458cb5d,[Données non publiées],BNPP,[Données non publiées],
+77111478-cc6d-46d5-aed9-1182b4b46b87,[Données non publiées],AGLA,[Données non publiées],
+7716910b-7cec-4db4-bb39-a2b681a7a73b,[Données non publiées],SELARL Pharmacie Centrale [Données non publiées],Gérante Pharmacie officine,
+771fa7ce-6217-4713-b2c6-a6e827988397,[Données non publiées],Agence [Données non publiées],Directeur adjoint du pole influence et communication,sans objet
+772ec745-b9ce-4345-a834-08f1b1f98dca,[Données non publiées],Avocate,Avocate,
+77337e4e-c770-43e3-862f-90a00ae29e01,[Données non publiées],mairie Loire-Authion,Directrice de cabinet,
+7739e18b-1cd2-4ad4-91ad-f969da40ba24,[Données non publiées],Retraitée,[Données non publiées],
+7739ed9d-5c83-41f3-88b6-4c779fc5bc22,[Données non publiées],CIAS,adjointe administrative,
+77476739-c2c8-4203-b020-0cbad01f4655,[Données non publiées],[Données non publiées],Conseillère en équipe d'appui,
+774b3b41-52d1-4838-8aa9-2e857f9fe887,[Données non publiées],[Données non publiées] [Données non publiées],[Données non publiées],[Données non publiées]
+77613495-2d57-4fb2-a741-fd41bf3c9753,[Données non publiées],retraitée,[Données non publiées],[Données non publiées]
+7763997a-3de0-4748-b450-ec38cd21d4be,[Données non publiées],chef d'entreprise,médecin généraliste,
+776ec09a-2288-4fca-bd23-fd4a0e2683db,[Données non publiées],[Données non publiées],[Données non publiées] retraitée,
+77704026-40cb-4647-9273-2923bba7d893,[Données non publiées],Agence Française de Développement,Responsable [Données non publiées],
+77776907-32dd-462f-a5f6-2ca45fa75dec,[Données non publiées],néant,néant,
+7778cbb5-abcb-41b3-8c6d-6a5935b19977,[Données non publiées],ARTISAN,Coiffure à domicile,[Données non publiées]
+7778cbb5-abcb-41b3-8c6d-6a5935b19977,[Données non publiées],ARTISAN,Location de meublé de tourisme non professionnel,[Données non publiées]
+777bf66b-cc06-4cf9-b6cf-b2827feb934a,[Données non publiées],[Données non publiées],Conseiller en immobilier autoentrepreneur,
+7784ff36-bb0e-4793-925c-9abfa0454c87,[Données non publiées],assemblée nationale et sénat,collaboratrice parlementaire,
+7786aaa3-9fd4-44bf-b24d-c32d3e7cc162,[Données non publiées],La Poste,cadre,
+778796e3-ec64-4936-9bc7-86b6bc17b8e5,[Données non publiées],METROPOLE NICE COTE D'AZUR,COLLABORATEUR D'ELU,
+7789d319-d572-43cd-8534-20568f036525,[Données non publiées],Mairie de Draguignan [Données non publiées],[Données non publiées],
+778e0612-d730-48c0-aba1-dedf111d5ee8,[Données non publiées],neant,neant,[Données non publiées]
+778f2198-7cf4-40ae-b94a-aa52c3321d40,[Données non publiées],Néant,Retraitée agricole,
+77a0b79d-6cfc-483c-bd10-6930d8d99125,[Données non publiées],Bnp paribas,Directeur de projet informatique,
+77b8e523-70c4-47c7-bb97-01bf4fc9aa52,[Données non publiées],[Données non publiées],Ingénieur RD chef de projet,
+77c33cdd-c305-468b-8811-f5518ab7693a,[Données non publiées],Groupe AHNAC,[Données non publiées],
+77ca5515-5a67-40e4-ade7-ce3ffc47f32e,[Données non publiées],LIBERAL,HUISSIER,
+77ce80ea-e80c-45f9-8cb7-e09f543a3951,[Données non publiées],commerçante indépendante,Fabrication de pain et gâteaux bio et négoces de produits régionaux,
+77ce80ea-e80c-45f9-8cb7-e09f543a3951,[Données non publiées],Sarl Le Poher hebdo,graphiste polyvalente,
+77d06ea8-4266-4bfe-b2e0-5e67d91ff4d6,[Données non publiées],LCDP,Directeur marketing et communication,
+77d8f3f3-a5e9-4df7-a773-17f5f349361d,[Données non publiées],RENAULT,RETRAITE,[Données non publiées]
+77d95c57-1767-44a9-8d67-66c18b52368a,[Données non publiées],AGEFIPH,Fonds pour l'insertion professionnelle des personnes en situation de handicap,Exerce en qualité de chargé d'études [Données non publiées]
+77e63022-522b-4be2-8a74-4029987d3dfd,[Données non publiées],Collectivité,Responsable RH,
+77eb1bd5-cc9e-4c53-bcc3-05e46a9b66d6,[Données non publiées],Education Nationale,Personnel de direction d'un collège,
+77fd1a60-9311-482a-9e5e-3c543f77f787,[Données non publiées],ministere des finances publiques,contrôleur du trésor,[Données non publiées]
+7809201e-1438-4cbd-9fab-725a3818d017,[Données non publiées],Néant,Néant,retraité
+780ba3e3-8940-4efa-9844-0b91427a26a6,[Données non publiées],Kéolis,Conducteur de bus,
+78106bf6-d10c-4240-a775-d94958e4d48d,[Données non publiées],BE sas,Presidente,
+781f8c35-536d-4d1f-8d53-5a9c32119bf1,[Données non publiées],ASSOCIATION D'ENQUETE ET DE MEDIATION,[Données non publiées],
+78204b86-ad45-4bc7-9e4b-53337bd0874d,[Données non publiées],CHU de la Réunion,Infirmier,
+78413663-1fd2-4eb1-a7b9-1d2996afeefe,[Données non publiées],Indépendant,Gestionnaire de patrimoine / Immobilier / Développement foncier,
+78427016-e513-4d7b-aacf-14745f5ab13d,[Données non publiées],CIS Bio International,[Données non publiées] - Cadre,
+78435cda-1e9f-4194-b61f-a3241e84ab9b,[Données non publiées],OWENCE ILLINOIS,VERRIER,
+784a9bed-fa1d-42cb-ba64-f723b5af3cd0,[Données non publiées],Assemblée de la Polynésie Française,Représentant,
+784a9bed-fa1d-42cb-ba64-f723b5af3cd0,[Données non publiées],Sénat,Sénatrice,
+78528a9e-501c-464c-ac5f-f24cde32844d,[Données non publiées],CARSAT,Sousdirectrice,
+78610b60-f6bc-4eeb-9f51-f3c28b11f23e,[Données non publiées],néant,néant,[Données non publiées]
+78639a4c-3264-42fc-a8fe-0134223ae830,[Données non publiées],Retraitée,Retraitée,[Données non publiées]
+786877db-4aa5-4dff-ab01-ac5f2e1e5843,[Données non publiées],Profession libérale,Masseur-Kinésithérapeute,
+786db572-7bbd-4faf-9585-9d9efe0fa491,[Données non publiées],Néant,Néant,Intermittente du spectacle
+786db572-7bbd-4faf-9585-9d9efe0fa491,[Données non publiées],néant,Néant,
+7870d0b6-1c25-4a8b-b739-43c4f9579ef8,[Données non publiées],France Télévision,Journaliste,
+787ce81f-08cc-46ad-a042-d82248e4ba80,[Données non publiées],EKATERRA FRANCE,[Données non publiées],
+787ce81f-08cc-46ad-a042-d82248e4ba80,[Données non publiées],APORIA CONSEILS,[Données non publiées],[Données non publiées]
+78833489-6a1c-4fba-b4d5-e4c5869427ed,[Données non publiées],FERMET ALU,[Données non publiées],
+7899fb89-d1c8-4f02-8d6a-126b67595995,[Données non publiées],Indépendant,agent immobilier,
+78a9e52f-a621-458f-a995-06f59dae8f12,[Données non publiées],EDUCATION NATIONALE,ENSEIGNANTE,
+78b7779e-edd8-499b-8e8b-29d77a74ef21,[Données non publiées],"Communauté d'agglomération Saint-Dizier, Der et Blaise",[Données non publiées],[Données non publiées]
+78b85ee9-6f19-49d0-bc21-5a5ed5528176,[Données non publiées],retraité,néant,
+78bc75a0-dbbc-41a5-8255-49d4749b09a4,[Données non publiées],aucun,[Données non publiées],
+78c00bea-d8dd-41eb-b9bd-588e4e4e3233,[Données non publiées],Retraitée,Néant,
+78cf155c-2c03-49a5-bc6c-51176fc299a2,[Données non publiées],Education Nationale,Professeur des Ecoles,
+78cf155c-2c03-49a5-bc6c-51176fc299a2,[Données non publiées],OGEC [Données non publiées],Chef d'établissement,[Données non publiées]
+78f4cbbe-4f4c-47ca-b562-93a98e95f515,[Données non publiées],Clinique [Données non publiées],Medecin,
+7900eb23-e189-447a-add5-ca6abc7601a2,[Données non publiées],Retraité,Retraité,
+79080748-f93e-4f5f-bf74-21d24520daa8,[Données non publiées],Sénat,Assistant parlementaire,
+790a46b8-d3d1-490e-82db-3b92b8347703,[Données non publiées],[Données non publiées],retraite,
+791d1fd2-b977-478b-87ac-51b142ef7848,[Données non publiées],Neant,médecin généraliste,profession libérale
+79222dda-1a41-4671-b8da-2c1e2adc0ea0,[Données non publiées],EDF,Cadre commercial,
+7929115c-81b2-49c0-bbf7-50fce32e71af,[Données non publiées],[Données non publiées],AGENT COMMERCIAL (PROFESSION LIBERALE) SECTEUR : PYROTECHNIE,
+7930c8ae-db76-4f3d-b650-d77d465bd821,[Données non publiées],FCPE,salarié dans une fromagerie,
+79407626-3916-42ed-acbb-748d4e7f7aef,[Données non publiées],Néant,Neant,Retraitée [Données non publiées]
+7957cd29-1c8d-4df0-bf0f-6137360d31d1,[Données non publiées],auto-entrepreneur,Conseillère en décoration d'intérieur,
+7967e29a-b985-4a2d-bbeb-cd16ae44e2f3,[Données non publiées],Mairie de dijon,[Données non publiées],
+7971a51e-3833-47ff-a605-3cf530cb79f9,[Données non publiées],EcoleSteCroix,Agentd'école,[Données non publiées]
+79747303-6723-49d6-8465-e5ab11280efc,[Données non publiées],Retraitée Airbus Group,Néant,[Données non publiées]
+797b94a8-528c-4cfa-8937-54ab26d24d3c,[Données non publiées],Centre de Gestion,Attachée territoriale principale,
+7987be9b-4680-48f9-8f63-2b4cbcfe8577,[Données non publiées],NEANT,NEANT,RETRAITE [Données non publiées]
+798958f1-d730-4162-85c0-9314d98e6ced,[Données non publiées],néant,néant retraitée,
+798c0199-c16f-46b0-ae00-b8313de7391d,[Données non publiées],Education Nationale,Enseignante,
+798fc5b5-2122-4cf1-863f-a156331dee3d,[Données non publiées],Retraitée [Données non publiées] de la fonction publique hospitalière.,Hôpital public.,
+79919de3-ede7-40a6-b47e-36b491f29601,[Données non publiées],Education Nationale,Enseignante,
+79936808-b466-4fe4-983a-3441b442380f,[Données non publiées],ARTISAN,Coiffure à domicile,[Données non publiées]
+7993f2c4-35bc-4626-a87e-c0fef446bbe3,[Données non publiées],Kéolis,Conducteur de bus,
+79953dd4-a92c-4a40-a19d-7060ac90dd11,[Données non publiées],[Données non publiées],Notaire,[Données non publiées]
+79ac5767-292e-43dc-9139-944a639f0715,[Données non publiées],Retraité,Retraité,
+79adee91-5235-4b32-a6f1-f2ffac2eabbe,[Données non publiées],NOM PROPRE,RESTAURATEUR,
+79cc9cc5-d419-4de8-942a-532f0706d727,[Données non publiées],MEDIAGEST CONSEILS,Gérant,
+79dd7ac7-4c07-4b34-a98c-fdbfab3777c7,[Données non publiées],CHRU Tours /ARS centre val de loire,Médecin hospitalier,
+79debc57-ef1e-4e2e-9681-fff2f5f19b8a,[Données non publiées],Retraitée,Fonction Publique Territoriale,
+79e60a7d-8ba3-4875-b6a6-2aec30601c95,[Données non publiées],Néant,Néant,Retraité [Données non publiées]
+79f7c9b5-0d0f-4940-8923-befb712f4c45,[Données non publiées],multi employeurs,assistante maternelle [Données non publiées],
+79f8deef-f8d1-44e0-bb92-3fd434d6ca92,[Données non publiées],Centrakor,vendeur,
+7a00f292-658a-4c0a-a087-d3b7daaac5c4,[Données non publiées],EDUCATION NATIONALE,ENSEIGNEMENT,
+7a06d4e4-ee72-48ea-95da-275846da3e89,[Données non publiées],[Données non publiées],néant,
+7a0fd5ff-1896-4c5c-b835-9cc9381e7430,[Données non publiées],NÉANT,NEANT,
+7a213dbc-0a8d-4e76-99da-b8187d5e522d,[Données non publiées],AUBAY,[Données non publiées] Cadre,
+7a21495b-6ab8-469e-8a9d-e76ca9e26667,[Données non publiées],Mairie de Brie,[Données non publiées],
+7a2f983e-2bcf-4cdd-ad9b-f0638d0d1f56,[Données non publiées],néant,néant,
+7a365943-4d88-4a4c-9c63-13bfdb94a7be,[Données non publiées],profession libérale,Sage-femme libérale,
+7a419111-6ed8-4e49-ae2d-d0049ae36f6a,[Données non publiées],OMEGREEN SARL,Gérante Stratégie commerciale,[Données non publiées]
+7a489163-09d9-47dd-b4fd-d5103cdddf60,[Données non publiées],[Données non publiées],Agriculteur,
+7a4b6dd6-cc5c-4ad3-9028-bc3fa70601d5,[Données non publiées],Département du Nord,[Données non publiées],
+7a557842-d9f2-45fc-b565-1211e9ab1423,[Données non publiées],Conseil Régional du Centre,[Données non publiées],
+7a57e21e-2ee9-459e-a08b-65f8e82df9f7,[Données non publiées],libéral,infirmier,collaborateur en cabinet
+7a6ea8b6-503c-4930-a9d5-cbd8184b0c8b,[Données non publiées],MONDELEZ,COMMERCIALE,
+7a6f5f81-0dbc-41c7-93e6-480166a7ca8b,[Données non publiées],REGION SUD - CABINET,Conseiller spécial,[Données non publiées]
+7a6f5f81-0dbc-41c7-93e6-480166a7ca8b,[Données non publiées],Ville de Nice,[Données non publiées],[Données non publiées]
+7a6f5f81-0dbc-41c7-93e6-480166a7ca8b,[Données non publiées],Métropole Nice Côte D'azur,[Données non publiées],[Données non publiées]
+7a80a6c5-04ed-432f-a3be-c79015fa264f,[Données non publiées],[Données non publiées],Préparatrice en Pharmacie Hospitalière,
+7a912e00-8c4b-465e-a68e-4e280b54354c,[Données non publiées],NEANT,NEANT,
+7a9135e9-ece0-40a7-8a51-9037cc663c56,[Données non publiées],néant,retraité,
+7a97e4a2-4d8f-4bac-a070-70dbebe2cd58,[Données non publiées],Autoentrepreneuse,Psycho-pédagogue,
+7a9807ed-7713-4b64-b4af-5a09c8a6ae21,[Données non publiées],APHM,[Données non publiées],
+7a9b74cf-a374-499b-96fb-ac856fc597e1,[Données non publiées],Néant,Néant,
+7aa4f0b3-55bd-4bb5-96f7-4a63bd7b4b68,[Données non publiées],Soveda,[Données non publiées],
+7aae4790-2aee-406f-97d1-fefd978fefdf,[Données non publiées],Education nationale,Enseignant,
+7aaf11b7-a65a-48aa-b24f-48e4914793e1,[Données non publiées],[Données non publiées],Néant,[Données non publiées]
+7ac7ad2c-6c34-481e-9b49-215c6ef3d4ff,[Données non publiées],collège [Données non publiées],animatrice pastorale,
+7aca1046-657b-4a88-a226-d34cc0a5db34,[Données non publiées],LASER OCEAN,TECHNICO COMMERCIAL [Données non publiées],
+7adb4324-7b6f-404c-b7ee-46f8d312e833,[Données non publiées],TOURING CLUB SUISSE,[Données non publiées],
+7adf4b0a-728f-42f7-8271-f0f31349c7ec,[Données non publiées],[Données non publiées],[Données non publiées],RETRAITE
+7af4f256-905d-4f54-956f-a209b98ff6c4,[Données non publiées],EDUCATION NATIONAL,Professeur d'histoire-géographie,
+7af79310-26d1-4b27-aa99-da41cfb66059,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] retraite [Données non publiées]
+7af8c04c-b81f-463b-9aad-317f1f267560,[Données non publiées],NEANT,NEANT,[Données non publiées]
+7afca97d-3477-4faf-a634-3bc850fdd052,[Données non publiées],Vétérinaire,vétérinaire,
+7b014722-434f-48cd-8acb-c198cf048ae9,[Données non publiées],Daimler Trucks,Responsable [Données non publiées],
+7b16f89d-71f6-49d1-82a7-e65905f4a320,[Données non publiées],Aggelos,[Données non publiées],
+7b188618-3ca6-4845-936b-7856b046466a,[Données non publiées],GEIE GECOTTI-PE,Chargée de mission [Données non publiées],
+7b1b3040-b0b3-40d3-bc93-8bd743caaf91,[Données non publiées],Société générale (banque d'investissement),"""market maker"" (activité de trading algorithmique)",
+7b1bbf6c-9bde-4d40-8309-4041504ae023,[Données non publiées],ACTA Vista,attachée de direction - chef de projet,
+7b1dbba1-98d2-4717-812f-60cc61d520a7,[Données non publiées],SCP David Gaschignard,secrétaire,
+7b205f11-a498-4ef5-95e3-eddc7f080e30,[Données non publiées],Education Nationale,Professeur des écoles,
+7b28843d-e1a2-4b86-85a9-782787211e68,[Données non publiées],Mairie de Montrabé,Agent territoriale [Données non publiées],
+7b383018-4c61-4b31-9a2b-c0d3e2c85752,[Données non publiées],[Données non publiées],Retraite Architecte et mi temps architecte à l'agence [Données non publiées],
+7b3e47d3-a41b-4d42-b743-9cb57db82baa,[Données non publiées],retraitée [Données non publiées],chargée de recherche au CNRS,
+7b3e47d3-a41b-4d42-b743-9cb57db82baa,[Données non publiées],CNRS,"chargée de recherche, retraité [Données non publiées]",
+7b40cae1-3e72-406d-99e4-057606be8d5b,[Données non publiées],[Données non publiées],ARTISTE PEINTRE,[Données non publiées]
+7b42d982-85cc-4095-b075-9b82565c9b6a,[Données non publiées],Education nationale,"Retraité, professeur des écoles",
+7b4c04e5-886b-4ad9-972d-226d32f908f4,[Données non publiées],MONIN SAS,Employée,
+7b940f3a-3c1a-4680-ae8c-b19473f3857b,[Données non publiées],profession libérale,"archéologue, enseignant-chercheur et expert",
+7b9b74b6-0b41-4cc3-950d-5fd83c923459,[Données non publiées],SELARL Pharmacie des Potiers,Pharmacie,[Données non publiées]
+7bac4829-fcfd-44de-bd31-cd6b61210158,[Données non publiées],centre social,[Données non publiées],
+7bbb60d3-4b7c-4989-bbcd-4141930459f0,[Données non publiées],Communauté d'Agglomération de blois: Agglopolys,Ingénieure principale,
+7bbfe58c-8ea0-482d-83af-0b58e16f23a7,[Données non publiées],Néant,Néant,
+7bc9a684-75d9-4e0a-9a1b-a9431435c5fd,[Données non publiées],néant,néant,Néant
+7bdd2292-ca5c-4aef-af99-304f69dd3c69,[Données non publiées],[Données non publiées],transaction immobiliere,[Données non publiées]
+7bdd2292-ca5c-4aef-af99-304f69dd3c69,[Données non publiées],iteva - gerant,sarl [Données non publiées],[Données non publiées]
+7c02d6dc-4349-45d5-b0f6-f875c6fbf72e,[Données non publiées],ROCKWELL AUTOMATION SAS,[Données non publiées],
+7c18993e-8241-4297-9dd4-f8e2890e0492,[Données non publiées],COMMUNE DE BEAUCAIRE,Directeur [Données non publiées],
+7c322b98-e890-42c8-9b48-d86513fe892b,[Données non publiées],APFDH,[Données non publiées],
+7c34a1b7-396e-473c-a492-690700f7947d,[Données non publiées],NEANT,NEANT,RETRAITE
+7c3af09b-8dfb-4478-87ad-3ce96a8c02ce,[Données non publiées],Fouré lagadec Rhone Alpes,Employé,
+7c4235fe-177a-4aa0-b3e0-b2424796f294,[Données non publiées],Chambre de Métiers et de l'Artisanat de région Centre Val de Loire,Responsable [Données non publiées],
+7c474d04-7a21-4062-9713-328d28d7c178,[Données non publiées],seac-pf,logistique,[Données non publiées]
+7c474d04-7a21-4062-9713-328d28d7c178,[Données non publiées],exploitant agricole,dans le domaine de la culture de la vanille,en cours d'installation
+7c474d04-7a21-4062-9713-328d28d7c178,[Données non publiées],entreprise individuelle,"travaux de finition location de logement traduction interprétariat Photocopie, préparation de documents et autres activités spécialisées de soutien de bureau",
+7c63b903-18ef-4af7-95c2-7fc44c4bd000,[Données non publiées],Egencia,Directeur [Données non publiées],
+7c6ce2d4-e72c-4152-b3a3-d8c056577131,[Données non publiées],activité libérale,Avocat [Données non publiées],[Données non publiées]
+7c7cd484-1f96-41d8-afb3-7b17ab3d1583,[Données non publiées],DGDDI,Controleur Principal des Douanes,
+7c802585-05fe-48e4-a2ac-e597fe00f2d3,[Données non publiées],ROCKWELL AUTOMATION SAS,Support avant-vente [Données non publiées],
+7c8281af-fd6e-48b7-b5af-7ae705b30526,[Données non publiées],Néant,Néant,
+7c974639-5e7a-4c8b-9d6d-6b34d11ee195,[Données non publiées],Aucun,Pas d'activité professionnelle,Gérante de la SCI [Données non publiées]
+7c9d4f5c-7bcd-4f88-9794-4df808c6aebe,[Données non publiées],SEM Helioparc,Directeur,
+7c9d4f5c-7bcd-4f88-9794-4df808c6aebe,,RETIS INNOVATION,Président su Conseil d'administration depuis 2019,[Données non publiées]
+7c9d4f5c-7bcd-4f88-9794-4df808c6aebe,,APESA,Administrateur,[Données non publiées]
+7c9d4f5c-7bcd-4f88-9794-4df808c6aebe,,AVENIA,Administrateur,[Données non publiées]
+7c9d4f5c-7bcd-4f88-9794-4df808c6aebe,,NOUVELLE AQUITAINE AMORÇAGE,Administrateur,[Données non publiées]
+7c9d4f5c-7bcd-4f88-9794-4df808c6aebe,,NOUVELLE AQUITAINE TECHNOPOLE,Administrateur,[Données non publiées]
+7ca7ccb6-9089-43c7-bab7-a1c75c85d3c8,[Données non publiées],néant,néant,
+7cab1627-b5d5-457f-ab51-5cb0be9854d4,[Données non publiées],FEDERATION pcf,employé,
+7cabb731-0a2c-4876-9ebc-49423d656196,[Données non publiées],SARL SOCA,CABINET EXPERTISE COMPTABLE,
+7cb26aad-f8f7-4ab1-a333-ce82027cbcf7,[Données non publiées],néant,néant,
+7cbcf522-f82f-404f-bec2-f0fd3e8cbe28,[Données non publiées],néant,néant,
+7cdea9e8-fe28-44de-93a2-ead172678037,[Données non publiées],Sans,Sans,
+7ce467db-8382-4c3c-a0b5-431b171f7670,[Données non publiées],Conseil Expert,Expert-Comptable manager,
+7ce779a1-9091-4375-9008-6fff2f697d08,[Données non publiées],SCP [Données non publiées],AVOCAT,DROIT DE LA FAMILLE
+7cf58839-8e46-4d5c-bb3e-30b9fe689a5c,[Données non publiées],Éducation nationale,Professeur,
+7cf75d77-71c1-4de1-90e4-dcc91c7e509e,[Données non publiées],Education Nationale,Professeur des écoles,
+7cfa9725-1133-4c16-bdec-647f375cc3d5,[Données non publiées],NEANT,NEANT,[Données non publiées] élue [Données non publiées]
+7cfa9c2f-a2f9-4664-9ccf-f8bd78bb9ef1,[Données non publiées],Inspection académique,Enseignante,
+7d04d64e-19c7-4474-9ee6-438b4b9d6467,[Données non publiées],Education nationale,AESH,
+7d0a68b9-ff8a-4c90-aef0-17ecbe25493f,[Données non publiées],Néant,Pédicure-podologue en activité libérale,
+7d14218f-ddeb-4cbc-b75b-89fcb5f031cd,[Données non publiées],Libéral,Médecin généraliste libéral,
+7d1e1d6e-c1c7-48c8-8b27-f16ee9a3296d,[Données non publiées],E-TERRA,Dirigeante salarié [Données non publiées],
+7d34ea1a-1ef0-4679-8537-57fc3484f6ab,[Données non publiées],CCI Occitanie,[Données non publiées],
+7d3ba723-d357-42f5-ba4d-e0e24bfd82eb,[Données non publiées],France Télévision,Journaliste,
+7d416794-cee0-4209-932f-f3fca67413b9,[Données non publiées],3C2A,Dirigeant [Données non publiées],
+7d45a32a-0dbf-4297-81d4-29021b7daaff,[Données non publiées],SRN EVENDAY,[Données non publiées],[Données non publiées]
+7d46b543-33f8-4855-be3e-2c661e2f26a2,[Données non publiées],Association Compagnons Batisseurs Bretagne,[Données non publiées],
+7d4748c8-d9e9-4a83-bf02-fdf2bddc6b14,[Données non publiées],Université Bretagne Occidentale,Enseignant-chercheur,
+7d55320a-8a71-4ed6-8e0f-64e91e38a01c,[Données non publiées],Ministère de l'Education nationale,Professeure des écoles,
+7d55d6fe-b724-4f0b-a138-3d60f1c82738,[Données non publiées],VILLE ARRAS,[Données non publiées],
+7d58b22c-3f26-4460-b2aa-6ac82750326d,[Données non publiées],EELV,chargé de mission,
+7d620ebe-f57d-44b8-9f52-0e23e6273711,[Données non publiées],Travailleur non salarié,Agriculteur,
+7d6ca868-bd29-4683-9f00-cbcd60f0b8b2,[Données non publiées],Groupe France Télévision,journaliste,
+7d6d6d68-ffd8-480e-b674-379d771bca3e,[Données non publiées],Retraitée,[Données non publiées],
+7d6f96e3-ddb2-46a7-ab75-5de24592cfc7,[Données non publiées],DHL,Responsable du service après vente [Données non publiées],[Données non publiées]
+7d6ff840-ef44-498c-9bb7-7fcd1ff64415,[Données non publiées],SOFIPEL,[Données non publiées],
+7d71c4d5-7c70-49a2-99b0-3f9b3914d91a,[Données non publiées],SNCF,TELECONSEILLERE AGENT SERVICE COMMERCIAL,
+7d7e2dd9-d5b7-42cf-9ca6-39842afbba09,[Données non publiées],éducation nationale,enseignant à la retraite,
+7daab1a4-6b14-44a1-a6b8-bd63f4294ca6,[Données non publiées],Centre hospitalier de la Bresse Louhannaise,infirmière,"[Données non publiées] . En profession libérale depuis mars 2022, en tant que remplaçante d'infirmières libérales à Branges"
+7dbd5a92-5218-4256-bd3c-daeeea48108f,[Données non publiées],CEREP,Arthérapeute,[Données non publiées]
+7dccb568-9fbe-4453-a675-77351e7385b2,[Données non publiées],SNECMA,Cadre [Données non publiées],
+7dd50213-3f4a-45ef-94cc-1b98eb27ea06,[Données non publiées],[Données non publiées],Conseil en Gestion de Patrimoine [Données non publiées],
+7ddbeff9-3ebd-4b95-90d7-6051fd65eac3,[Données non publiées],swisslife,[Données non publiées],
+7de171be-3a0d-42b6-98f0-ecc7e3fc4d4b,[Données non publiées],Communauté d'agglomération Grand Paris Sud,[Données non publiées],
+7de1a9c0-28df-459e-874a-d9c25035567b,[Données non publiées],Ministère de l'Intérieur,Haut-fonctionnaire du ministère de l'intérieur,
+7df6af12-0101-49be-a49c-b47066cddfd5,[Données non publiées],EDUCATION NATIONALE,professeur,retraité
+7e1906a4-cc86-410d-a754-182b541e3ec3,[Données non publiées],Assemblée nationale,[Données non publiées] [Données non publiées] député [Données non publiées] [Données non publiées],
+7e41ba2a-a408-4f35-a116-484275d8a6a1,[Données non publiées],néant,néant,Néant
+7e51d18e-57a2-4398-bf00-b23a87dfcadb,[Données non publiées],FLOWBIRD,Comptable,
+7e5b74d9-b65c-437b-97e9-b231c2edd216,[Données non publiées],Enseignement privé,Professeur d'allemand [Données non publiées],
+7e5c2800-d281-4add-8c9c-fbb474cab520,[Données non publiées],Ville de Rennes,[Données non publiées],[Données non publiées]
+7e601974-3c10-4e78-bc5f-fcaeb78d1592,[Données non publiées],Néant,Néant,Retraité [Données non publiées]
+7e674ea5-eb4b-4ca9-9984-85b24d4481bc,[Données non publiées],GROUPE OPTIMETRIE,[Données non publiées],
+7e674ea5-eb4b-4ca9-9984-85b24d4481bc,[Données non publiées],ASSOC FESTIVAL INTERNATIONAL DE PIANO,[Données non publiées],
+7e6c49e4-a152-4470-a80d-23d20085465f,[Données non publiées],SNCF,[Données non publiées],
+7e6c8018-025a-4430-b55a-084966852038,[Données non publiées],ENEDIS,Responsable d'équipe,
+7e7d43f4-d39c-49bf-8509-4f715bb69832,[Données non publiées],[Données non publiées],Chauffeur de bus,
+7e8c4f2a-aafd-40f0-96f4-566002213a04,[Données non publiées],[Données non publiées],Ingénieur dans le domaine des technologies médicales,[Données non publiées]
+7e8ce0ac-d70b-422a-ac02-149776c2d566,[Données non publiées],Mairie de Montluçon,Educateur sportif [Données non publiées],
+7e8cff58-d420-4a9e-8606-8565ffb65de8,[Données non publiées],Mairie de Paris,[Données non publiées],
+7e9bd977-7fbc-4c3b-9d1a-24a34d578169,[Données non publiées],Université [Données non publiées],Adjoint technique,
+7ea59c34-aa4e-4041-be68-e47c87697174,[Données non publiées],Artiste,Artiste plasticienne,
+7ea91410-4cb0-4936-9fc7-cbcc62a29f3b,[Données non publiées],EDUCATION NATIONALE,Professeure certifiée d'Histoire-Géographie,
+7eb50312-ce0a-49ac-8ff2-377a8e4be2ba,[Données non publiées],Assemblée nationale,Assistant parlementaire,
+7ec63dec-0e8b-4db3-b864-1249a99fc137,[Données non publiées],Communauté de Communes du Champsaur Valgaudemar,Salariée Responsable de la Maison de Services au Public du Champsaur Valgaudemar,
+7ec89ab5-6a57-4374-b695-dd69e254d765,[Données non publiées],Quincaillerie CCPF,Magasinier,
+7ecae4fd-045c-4e03-9ea8-39d23df72aa5,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+7ecc2c91-38c6-4347-887f-2d1f321d5459,[Données non publiées],SARL SD CONSULTING,[Données non publiées] société de conseils.,
+7ecccdf8-7ef2-4460-8917-aa8925eed7c2,[Données non publiées],CGR,Aide-soignante,
+7ecfd0bc-ba78-4bb9-9902-4a683a184835,[Données non publiées],Néant,Néant,
+7edeb950-559b-499a-ac89-6b760f3bab93,[Données non publiées],[Données non publiées],Consultante,
+7eee5934-6f68-4302-bd41-3b39854d4a7a,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+7eee5934-6f68-4302-bd41-3b39854d4a7a,[Données non publiées],Association l'Oiseau Bleu,chef de service [Données non publiées],démarrage le 4/07/2022
+7eef8875-752f-48c5-b252-acb454ba4b27,[Données non publiées],CENTRE HOSPITALIER DE BIGORRE,Directrice adjointe [Données non publiées],
+7efbda17-4fa8-4e39-a634-22c24f3bff51,[Données non publiées],chu [Données non publiées],Aide soignante,
+7f061efb-d15a-4ce9-bc9e-c089a0cc1c60,[Données non publiées],TRIXELL,Ingénieur,
+7f061efb-d15a-4ce9-bc9e-c089a0cc1c60,[Données non publiées],[Données non publiées],Conseil en entreprise,Activité de conseil crée en 06/2020 [Données non publiées]
+7f06a79f-887b-4c5c-abed-695265ce8aa8,[Données non publiées],[Données non publiées],Sapeur pompier,
+7f073e41-a73e-44ff-9921-4cfa42e017ce,[Données non publiées],[Données non publiées],[Données non publiées] neant,
+7f073e41-a73e-44ff-9921-4cfa42e017ce,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+7f073e41-a73e-44ff-9921-4cfa42e017ce,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+7f0c9a64-c32f-49bc-9692-889cdddabc0c,[Données non publiées],Education nationale,Professeure des écoles,
+7f3abda7-478c-4658-b988-7cd083b7635a,[Données non publiées],Rectorat de Nantes,[Données non publiées],
+7f3c528d-5781-47a3-a83a-34dd376352b0,[Données non publiées],[Données non publiées],Fonctionnaire,
+7f49cc27-a960-4374-bf4c-8e52529f37ce,[Données non publiées],ASLRA Grenoble,Cadre [Données non publiées],
+7f5a9609-487a-40a2-b95d-c9d5b07b1337,[Données non publiées],Education nationale,Professeure de Mathématiques / Physique-Chimie en lycée professionnel,
+7f600ea3-2a33-421f-8ad3-02277e19cb75,[Données non publiées],néant,néant,
+7f6f32b7-9347-47c7-9cc6-dcddf8635681,[Données non publiées],Communauté de communes Coeur Côte Fleurie,Fonctionnaire [Données non publiées],
+7f727f6e-78b2-49ee-80b2-d3598db8ab27,[Données non publiées],CENTRE HOSPITALIER [Données non publiées],Aide soignante - HAD,
+7f73128c-44f0-4849-a057-23c2c287d654,[Données non publiées],lui même,journaliste Président et directeur du journal Le petit mag Lens Liévin exploitant agricole [Données non publiées],[Données non publiées]
+7f896b87-9a55-4524-b0ad-9b2249f91019,[Données non publiées],entrepriseindividuelle,soutien au spectacle vivant evenementiel,
+7f9d1f9c-4daa-447c-ab7d-4c70830a07b8,[Données non publiées],GRAND REIMS,Responsable [Données non publiées] - [Données non publiées],
+7fa67e51-6db8-4721-b3c9-4d44c5c697c3,[Données non publiées],Education nationale,Professeur des écoles(ER),
+7faad869-585f-4b2a-aa5c-ab2410f1a54f,[Données non publiées],Mairie de Paris,cadre administrative [Données non publiées],
+7fad94f1-3208-4b02-a08e-8c02983e70fb,[Données non publiées],Education Nationale,Retraitée,
+7fb0d261-43e2-45ec-8e2a-649be3de68f5,[Données non publiées],GALEO/SNV,Préparatrice,[Données non publiées]
+7fb27ff7-4195-4399-8506-7f12950a0f20,[Données non publiées],Néant,Néant,[Données non publiées]
+7fb517b4-8029-4654-9279-2ed1c29af3d8,[Données non publiées],Assemblée_Nationale [Données non publiées],Attachée_Parlementaire,
+7fb5fe9a-c8c2-4ec0-ad97-7bff3126abe3,[Données non publiées],Mairie de Montmorillon,[Données non publiées],
+7fb604c2-b253-4838-b152-7062190b09c6,[Données non publiées],Crédit Mutuel,Chargée de clientèle dans une banque,
+7fc1ae18-638a-40f0-902e-6be0b168bbac,[Données non publiées],ICV,[Données non publiées],
+7fce77a3-0dfa-4c94-bd24-48ba4594f186,[Données non publiées],EA DECO,Commerce gros,
+800081c7-bb08-4366-93f0-0ba2049ed138,[Données non publiées],Retraité,Néant,
+800e4e0f-712a-4d6e-9e2a-0a0aa7a81a87,[Données non publiées],Conseil départemental du Cantal,[Données non publiées],
+801bbdc1-be52-4f92-89a1-dea2bf8994f0,[Données non publiées],ADI KALFA,Mécanique de précision chargé d etablir les prix des pièces à usine,[Données non publiées]
+801e1158-dd6d-4ffe-9239-6592d7785a58,[Données non publiées],[Données non publiées],Collaboratrice notariale,
+80497073-39ec-4e16-8cde-4dc305101393,[Données non publiées],CDG76,Secrétaire médicale [Données non publiées],
+8049c59f-dbff-4087-8d49-ec3666cd3634,[Données non publiées],VILLE [Données non publiées],Attaché principal,
+80541ea5-24de-4549-b565-e43fbd0623b3,[Données non publiées],OGONA,[Données non publiées],
+805a08f7-3817-4e46-8cc5-0daa59d1d652,[Données non publiées],[Données non publiées],Masseur kinésithérapeute,
+805edfbc-6ca8-4f0a-a712-eb72314b17cf,[Données non publiées],néant,néant,
+805efadf-c052-45a0-80cb-f2fc48916409,[Données non publiées],Banque Populaire [Données non publiées],Conseillère clientèle,
+806088e1-8cc7-4e2a-ac04-d2a46f260924,[Données non publiées],Keolis Lyon,[Données non publiées],
+806152a6-1b79-4fdf-8e60-55d6d599f89d,[Données non publiées],Ministère de l'Intérieur - PRIF,Fonctionnaire Catégorie A - Cheffe de Bureau [Données non publiées] [Données non publiées],
+80622154-e198-4b63-843f-017b6bd5987a,[Données non publiées],Chef d'entreprises,gérant des sociétés : [Données non publiées],
+806248fb-006c-4a66-984c-d79a28eef864,[Données non publiées],Néant,Retraitée,
+80643858-e1a8-4594-a1b2-4d58522af651,[Données non publiées],[Données non publiées],Responsable qualité fournisseurs,
+80693b4a-68f8-4592-96a5-92e84917e86f,[Données non publiées],Retraitée,Retraitée,
+8070e813-78e4-4239-bb91-20bf3065bc78,[Données non publiées],neant,retraité,[Données non publiées]
+8072f0dd-c524-48a3-8be6-8f86116d2a71,[Données non publiées],Retraité [Données non publiées],[Données non publiées],
+8078f55e-54e8-4242-ad64-89802240a117,[Données non publiées],micro entrepreneur,"micro entreprise , conseil en intelligence économique",
+807d968c-c67c-4957-90ec-c3455dec5f77,[Données non publiées],travailleur indépendant et salariée,[Données non publiées],
+809ced62-420b-4630-af37-a0f272b02bce,[Données non publiées],Maison de retraite SAS L'Hespérie,[Données non publiées],
+80a95257-8f7d-4afc-acf5-02982c959bf5,[Données non publiées],Kabaret + Dergermann,[Données non publiées],
+80c0bd91-a72c-4719-a796-a1b749eff748,[Données non publiées],Département de la Réunion,[Données non publiées],
+80c6dcc1-67fe-4a72-851e-e08f0ad46ba2,[Données non publiées],ministere des finances,agent des impots,
+80c7820d-74c6-4244-9716-1a4347efafb6,[Données non publiées],néant,Retraité,
+80d92f42-bb18-4358-ba5a-c3b4d3e39c5b,[Données non publiées],Commune de Grenay,Chargé de communication,
+80dca525-d517-4a96-ad72-f2ce778d6adf,[Données non publiées],Crédit Agricole [Données non publiées],salariée,
+80e6949b-9321-4dc9-bf80-c801841b5bbc,[Données non publiées],Mairie de Luc-la-Primaube,[Données non publiées],
+80e9cec6-2a17-4252-885a-0b562cae3b51,[Données non publiées],statut SARL,entrepreneur,
+80eb3dae-4dd1-41a2-921a-1021edea97ce,[Données non publiées],France Télévision/Autres média,Journaliste,[Données non publiées]
+80ee3807-eb1f-424c-bb5a-dbaba40393bd,[Données non publiées],Retraité,La conjointe est actuellement à la retraite,
+80eea2b9-cc58-416e-8b40-cb75c74b8b97,[Données non publiées],Ville de Pantin,[Données non publiées],
+80f3476f-cff5-4703-b91f-9ecc513b6fbb,[Données non publiées],NEANT,NEANT,
+80fe25e3-0bb6-4967-ba11-43fd066e93b6,[Données non publiées],Blue enerfreeze,[Données non publiées],
+810d1f0a-98c5-45d7-8bf2-f61b2051cb41,[Données non publiées],Centre de Gestion,Attachée territoriale principale,
+811b6e91-26ef-4359-8341-06b6d89d6c98,[Données non publiées],SAS SLTS,[Données non publiées],[Données non publiées]
+811d3c6c-1e89-4e05-aa46-3be50a9054de,[Données non publiées],Intermittente du spectacle,[Données non publiées],
+81269a45-507b-4871-a877-56ba67d07262,[Données non publiées],Profession libérale,Médecin angiologue,
+8130a090-9427-43a8-bab6-e84b6f7961ae,[Données non publiées],Education Nationale,Professeure des Ecoles,
+8138656f-e0ee-4ef6-a103-78c1402166de,[Données non publiées],co-gérant du Gaec [Données non publiées],co-gérant d'une société agricole,
+81392252-6c50-4809-bebe-c44c6f48a476,[Données non publiées],Caisse de prévoyance sociale,Secrétaire médicale,
+81392252-6c50-4809-bebe-c44c6f48a476,[Données non publiées],caisse de prévoyance sociale,sécurité sociale,
+813a54f9-3946-4e94-a730-4ffd26254477,[Données non publiées],néant,néant,
+8141f37d-5d68-4d66-96ff-ebe128730c81,[Données non publiées],AUTO ENTREPRENEUR,CONSULTANT EN COMMUNICATION,
+814523ce-ab42-467c-a304-9f7e266cf843,[Données non publiées],[Données non publiées],Gérant,
+814dd623-1312-47a1-adff-4629af2e539b,[Données non publiées],EIFFAGE TP,[Données non publiées],[Données non publiées]
+815bb6db-cac6-48f7-9895-e06f80031d2d,[Données non publiées],SARL [Données non publiées],Gérant du garage,
+8166b5c2-3bd1-46cc-a8c4-d3778d9e85b1,[Données non publiées],IMMOBILIERE DE L'ABBAYE SARL,Secrétaire,
+816ce0de-9dbf-49dd-a097-0859df06db44,[Données non publiées],Medecin Libérale,MEDECIN GENERALISTE SECTEUR1,
+816ecd5c-0576-4429-957b-6234c0bc7bd5,[Données non publiées],néant,néant,néant
+81700eb4-3bcb-4176-ae7c-64b2768037d9,[Données non publiées],[Données non publiées],Assistante vétérinaire,
+81706f5f-11ac-48d9-ad08-0f10075d77fc,[Données non publiées],Intermittente du spectacle,Intermittente du spectacle,[Données non publiées]
+8181cd68-ec73-47dd-bb83-bcea48a0d8c5,[Données non publiées],Autoentrepreneur,Brocante,
+8184cbbc-fb27-4023-9644-e1300cba3333,[Données non publiées],[Données non publiées],[Données non publiées],En retraite [Données non publiées]
+8189654a-407d-4774-986f-fb5b7e967644,[Données non publiées],Département de la Haute-Garonne,Conseillère juridique [Données non publiées],
+8192c0c8-0315-480e-b924-a48c8811ae11,[Données non publiées],Sas monin sports,Presidente,
+819f75c0-3b8b-4e35-b97d-7402b1491c37,[Données non publiées],Mairie [Données non publiées],Chargée de communication [Données non publiées],
+81a3bcff-db8e-497f-adf3-de40a7fba8ae,[Données non publiées],Néant,Néant,Retraité [Données non publiées]
+81a59352-1419-4386-8bec-c09c7cf208fb,[Données non publiées],2M conseil,gérant,
+81a6a76e-df00-4804-825b-a19929db36fa,[Données non publiées],Parlement européen,Députée européenne [Données non publiées],
+81a6a76e-df00-4804-825b-a19929db36fa,[Données non publiées],Conseil régional de Nouvelle-Aquitaine,Conseillère régionale [Données non publiées],
+81ada33d-811e-4f70-98d1-454ea0c842cf,[Données non publiées],Syndicat National des Acteurs du Marché de la Prévention et de la Protection (Organisation interprofessionnelle),[Données non publiées],
+81b29823-a75e-452a-8675-a508f341ae9c,[Données non publiées],Conjointe collaboratrice d'exploitation agricole,[Données non publiées],
+81b31b02-c3cb-4eef-81d0-75e9f8fd8f57,[Données non publiées],[Données non publiées],Gérant d'une société de production audiovisuelle - [Données non publiées],[Données non publiées]
+81cf6997-dc4c-47e9-907d-844917c18f54,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+81d05d64-6fb1-4bd8-aa92-c7f93097ffd0,[Données non publiées],Entreprise individuelle,Infographiste,
+81d31e7e-bc19-4a14-a2b5-50993c3bb2ee,[Données non publiées],néant,néant,[Données non publiées]
+81ea71d2-76d5-4463-bb4e-9ff3f392d4dd,[Données non publiées],Assemblée nationale,Député,[Données non publiées]
+81ee7021-ae98-48db-8367-0451837829e6,[Données non publiées],EducationNationale,ProfesseurCertifié,
+82031e2c-4d4e-478f-9c0a-adc527f23947,[Données non publiées],Etablissement [Données non publiées],Commerciale,
+82081111-8255-496f-a3cc-a7db9271953e,[Données non publiées],EDISYS,Chef de projet Etudes et Développement [Données non publiées],
+820cd380-695a-4666-8697-1b042b80a267,[Données non publiées],Assemblée nationale,Assistant parlementaire,
+820f62a3-8e48-49f9-83cf-c0df18f89c9e,[Données non publiées],CABINET [Données non publiées],ASSISTANTE DENTAIRE,
+822246d6-0fd8-473f-a424-5584ba44a729,[Données non publiées],GRIEPS,CONSULTANT FORMATEUR,
+822313fd-8d6b-4433-b684-e23e329a941c,[Données non publiées],profession libérale,médecin généraliste,
+822596cf-dc06-4e07-a483-2a524d6d3927,[Données non publiées],NÉANT,NEANT,
+8227bfaf-6fa3-40c8-9dc4-4843cac23ac2,[Données non publiées],Sans emploi,[Données non publiées],
+823b3f88-64ad-4115-9d57-418a4658acc5,[Données non publiées],SNCF,[Données non publiées],
+82523e50-b7f0-44ca-a66c-86e926d0e286,[Données non publiées],Néant,Néant,
+8256e38c-6e5e-4440-9c48-a03cab9e66d3,[Données non publiées],mairie du plessis trevise,infirmiere puericultrice [Données non publiées],
+82580302-f9f5-4473-be54-ab967ed1ee28,[Données non publiées],Les Transméduses,Chargée de projet,
+82628aac-e91d-4b73-990a-eaa41eb90fdf,[Données non publiées],SAFIR Consulting,Chef de projet [Données non publiées],
+8272805b-dbf2-417e-9a44-103035037fcd,[Données non publiées],MAIRIE,COLLABORATEUR DE CABINET,
+82795093-518e-4068-806e-9537935f39b8,[Données non publiées],Ville de Plan de Cuques,[Données non publiées],également : Vice-président de la Métropole Aix Marseille Provence depuis le 20/10/2022; Vice-Président du Conseil de Territoire de juin 2020 à juillet 2022
+827a80f9-df19-4fd3-85e8-334201acf541,[Données non publiées],Néant,[Données non publiées],Retraité
+827ef8e8-ce9f-4bd9-8638-abe3af4489b6,[Données non publiées],Université [Données non publiées],Adjoint technique,
+82889a03-fa0c-41e2-947b-1833ab61f136,[Données non publiées],Infirmière D.E Libérale,Activité d'infirmière libérale,
+829cc9fc-0386-4043-9385-767c1158a141,[Données non publiées],Caisse des Écoles [Données non publiées],Directeur,Fonctionnaire titulaire - Attaché des administrations parisiennes détaché dans un EPL
+829d63e2-77d9-4954-ab32-9dcda0871bcd,[Données non publiées],GIE ELEVAGES DE BRETAGNE,Sauvegarde et promotions des races animales bretonnes à petits effectifs,
+829da260-5702-4fc2-97b2-07ae08107674,[Données non publiées],neant,neant,
+829f91fd-d25e-4ed9-99c4-8d162ef1fc22,[Données non publiées],Retraitée Education Nationale,[Données non publiées],
+82a16685-8566-4017-9d3e-335ed8d87402,[Données non publiées],Université [Données non publiées],Professeur Agrégé,[Données non publiées]
+82a4f9ef-7434-4a14-b7fe-83739bf4dd09,[Données non publiées],néant,néant,retraité
+82ab5232-4c05-4b83-b182-73fa8dde5b0c,[Données non publiées],[Données non publiées],CADRE DE BANQUE,
+82ac415e-4933-4bae-9bdc-111b179b6277,[Données non publiées],France Télévision,Journaliste,
+82acdb49-3858-4ad2-b87f-60a8f9581197,[Données non publiées],Profession libérale,Médecin généraliste,
+82b590e3-bbe0-4e51-95c5-5e14a2eef762,[Données non publiées],Anne Ventalon,Attaché parlementaire,
+82b590e3-bbe0-4e51-95c5-5e14a2eef762,[Données non publiées],Mathieu Darnaud,Attaché parlementaire,
+82bf67e3-f4df-49f2-8053-735ee650cdc9,[Données non publiées],Les Celliers Jean d'Alibert,Conducteur de chaine d'embouteillage,
+82c9dcbb-1047-4f67-8769-d086be4b0990,[Données non publiées],NEANT,NEANT,[Données non publiées]
+82cc7d87-7025-4db0-a319-fe190a32c6c3,[Données non publiées],SEMPRO et SPL 92,Aménagement et promotion immobilière,
+82cc7d87-7025-4db0-a319-fe190a32c6c3,[Données non publiées],SAIGI,Président Directeur Général,
+82d0dfad-fc90-4a7d-9d5b-41b3a48c5380,[Données non publiées],[Données non publiées],deviseuse dans une imprimerie,[Données non publiées]
+82d0dfad-fc90-4a7d-9d5b-41b3a48c5380,[Données non publiées],[Données non publiées],Deviseuse en imprimerie,[Données non publiées]
+82d4bd9c-6e07-44ba-b7f1-2b08edf5ffcb,[Données non publiées],retraité,retraité fonction territoriale,
+82d652c1-e140-4652-adad-cdb05010f4bd,[Données non publiées],Néant,Gestion de son parc immobilier et de son patrimoine financier,[Données non publiées]
+82d84692-c789-44b4-94a0-f8e37fdd0ab0,[Données non publiées],Valtech,Consultante,
+82e18d3d-fa60-4a55-acd4-11713f33734e,[Données non publiées],ASSOCIATION LE RULEAU,Aide Médico Psycologique en EHPAD [Données non publiées],
+82e49a08-b65b-4cc9-9de0-5dbd7e92171b,[Données non publiées],STMicroelectronics Tours SAS,Ingénieur,
+82f953ba-8e70-4944-801c-39c361d03474,[Données non publiées],CHU [Données non publiées],psychologue,
+82fa0dae-46a7-4997-9998-97104f7f78cb,[Données non publiées],Cabinet Kléber Avocats,Avocate,
+82fdef85-0ca7-4958-8c37-d421cba6052f,[Données non publiées],Education Nationale,Professeur de Sport,
+82ff35f0-f2a6-4860-a9de-8458f076625b,[Données non publiées],[Données non publiées],Chargé relation entreprise,
+83078168-36e8-4a6a-867d-3d1dc5d6397b,[Données non publiées],GENERALI FRANCE,[Données non publiées],
+831d8252-f809-497e-bac7-656c472a9156,[Données non publiées],Education Nationale,AVS Assistante de vie Scolaire,
+831dd152-bb22-449e-b6b2-bd328d31820c,[Données non publiées],Nespresso France,"Cadre commercial, responsable de secteur [Données non publiées] pour les établissements de débits de boissons, hôteliers et de restauration.",
+832ca758-d822-4035-8fff-45ecfbf81082,[Données non publiées],SEMMARIS (Marché international de Rungis),[Données non publiées],
+83302e48-d059-4c35-b3bc-3d2437f18bd4,[Données non publiées],[Données non publiées],Pharmacien [Données non publiées] officine de Cherveux,
+83314b3b-0d61-40cf-9e8a-5574325ac0f2,[Données non publiées],néant,retraité,
+833a4a6e-c464-487f-8f15-865f18938a3b,[Données non publiées],SYSCO FRANCE,assitante de direction,
+83454d02-56e7-4ef0-b2d1-3e6587c1a8f7,[Données non publiées],[Données non publiées],RAS,RAS
+834822b7-6efe-47db-85fb-9bb4da8fe964,[Données non publiées],Fonction Publique Hopsitalière,Retraitée,
+83487b7a-69db-4396-a576-d401c7dbf49e,[Données non publiées],Viticulteur ( son propre employeur),Viticulteur,
+83622e10-f2c1-4613-a55e-7997efbd8894,[Données non publiées],Vergers de la tesserie,Arboriculteur salarié,[Données non publiées]
+836c1e0b-c72a-451e-91f4-4c99abf9c5f7,[Données non publiées],Centre Hospitalier de ROUBAIX,archiviste,
+83772e0f-9806-4139-9e1d-eeeb8d6e289a,[Données non publiées],[Données non publiées],SANS ACTIVITES [Données non publiées],
+8379c1e3-4e0d-44a9-bdf0-256263d54a9a,[Données non publiées],retraitée éducation nationale,Retraitée,[Données non publiées]
+8380ef2b-567f-4961-9aab-db57d3a48ef7,[Données non publiées],NEANT,Retraité,
+838384ee-054d-4a92-b321-e772b0002a38,[Données non publiées],Région Auvergne-Rhône-Alpes,[Données non publiées],[Données non publiées]
+8398006e-7ccd-42bb-aabf-2e09ce2d3486,[Données non publiées],Banque de France,Juriste,
+839da299-84d9-4580-b4c3-3f928db9d021,[Données non publiées],[Données non publiées],Retraitée,
+83ae2ff8-b3a0-4e07-b2ef-b97083b6a8a9,[Données non publiées],CMD,Ingénieur,
+83b1158d-f5ec-4b44-b2c2-1622f137ae89,[Données non publiées],Mairie de Notre Dame de Boisset,Agent technique [Données non publiées],
+83b159ed-1356-49f9-9ddd-84cb42d44532,[Données non publiées],SEMITTEL,[Données non publiées],
+83b995d5-c39a-4660-a695-05d153efedcb,[Données non publiées],[Données non publiées],Comptable de copropriété,
+83d3c65d-1e5a-418e-b241-2ce46df5b89e,[Données non publiées],Pharmacie [Données non publiées],secretaire,[Données non publiées]
+83d3c65d-1e5a-418e-b241-2ce46df5b89e,[Données non publiées],ASA [Données non publiées],secretaire,[Données non publiées]
+83d73a43-8e92-40c8-9f68-20fafa42fa0f,[Données non publiées],[Données non publiées],retraitée,[Données non publiées]
+83db184a-0595-465e-b5f5-7adaa4cdd4c9,[Données non publiées],Néant,Artiste,
+83e449b3-cedb-412a-9d41-0f47a3c0d278,[Données non publiées],Conseil départemental,dirigeant de musée,
+83e55c4b-d9d9-4dd3-b1bc-7b59bfc1e8f4,[Données non publiées],Constructions Idéale Demeure,[Données non publiées],
+83e5e9a2-b0cb-467c-801a-b271c9356fc6,[Données non publiées],Néant,Néant,
+83ef8ec2-661f-4ab2-90cb-aa71851da6c0,[Données non publiées],Roofmart,[Données non publiées],
+83f43f9b-6b65-4d28-920b-f27d25a63261,[Données non publiées],Département de l’Isère,Infirmier,
+83f63dcb-9c4c-49eb-99ec-f31afa2f2e57,[Données non publiées],GAUTIER MATERIAUX,[Données non publiées],
+83ff20aa-96f3-4b54-a330-fd9458a192ca,[Données non publiées],Université de Bordeaux -IUT,[Données non publiées],[Données non publiées]
+840b5ade-9354-4370-928e-1dc9dd1b1170,[Données non publiées],Education Nationale,Professeur des Ecoles,
+841d9ad7-d20c-41ac-bfe3-de77810ac764,[Données non publiées],auto-entrepreneur,Conseil en marketingFormation,
+8421a08f-1038-41e0-b9d1-025c8d26a00a,[Données non publiées],LA POSTE,Fonctionnaire Postier [Données non publiées],
+8435583f-b662-40ab-ad28-3a8e5712f2f3,[Données non publiées],néant,néant,retraitée
+844597be-9e3b-4e70-ad4e-bd36eb2c6520,[Données non publiées],quantum,[Données non publiées],
+844b6773-a726-4cfe-9b92-a10829368cf8,[Données non publiées],[Données non publiées],Directeur associatif,
+844df553-80ed-45f6-ae0c-38700da4dacb,[Données non publiées],Neant,Salon de beauté,
+8458de57-2a70-40d8-84fe-12e323882b91,[Données non publiées],MINISTERE EDUCATION NATIONALE,ENSEIGNANTE CONTRACTUELLE [Données non publiées],
+8458de57-2a70-40d8-84fe-12e323882b91,[Données non publiées],OGEC [Données non publiées],[Données non publiées],
+846223fb-0d08-454f-8a01-bea6584c43a3,[Données non publiées],Education nationale,Professeur des écoles [Données non publiées],
+84708f1c-bdd7-4d24-aa1a-071c5dcb2487,[Données non publiées],Crédit Agricole Consumer Finance,Directeur Financier,
+848f69ad-114a-4413-9314-806ed831078f,[Données non publiées],Activité Libérale,Architecte,[Données non publiées]
+84920d2d-29e9-42df-954e-c01fd409f209,[Données non publiées],Campus France,Chargée de mission auprès de la directrice de Campus France,[Données non publiées]
+8493581a-569b-4a8d-8615-ac4a66f96cf6,[Données non publiées],Indépendante,Vendeuse à domicile,
+8497c7c0-24d6-48d3-ab51-c5368eb1b05c,[Données non publiées],retraité,retraité,[Données non publiées]
+8497c7c0-24d6-48d3-ab51-c5368eb1b05c,[Données non publiées],néant,activité de location de gites [Données non publiées],
+8499510a-c45f-458a-9653-a42b8868d7b0,[Données non publiées],Institut Lumière,Responsable de [Données non publiées],
+84a4d6f4-c6c3-44b5-bdb4-71e531b4959d,[Données non publiées],Ministère de la Défense [Données non publiées],Ingénieur des études et techniques d'armement,
+84a52b32-44be-4c28-935b-6127d462ea02,[Données non publiées],Autoentrepreneur,Chargée d'affaires privé,
+84a991a5-4e2f-4005-aa93-c3ee71fef3c9,[Données non publiées],Cabinet Guerrier Assurances,[Données non publiées] employée d'un Cabinet d'assurance.,
+84ad58a4-8683-4be6-b1bd-9a8d1933ad0e,[Données non publiées],Conseillère régionale,Mandat électif,
+84b23300-244e-4d53-ae56-6fb93777b7e1,[Données non publiées],-,-,-
+84dd8414-c8c0-4730-8b9a-d56f88adacc8,[Données non publiées],retraitée,[Données non publiées],
+84e6a3c4-983e-4e47-9b86-3f4f910a8eeb,[Données non publiées],Education Nationale,Professeur des écoles,
+84fdd5ec-358e-4e8a-992b-cbb9580e3731,[Données non publiées],Retraité,arbitre : chambre arbitrale internationale de Paris,
+8503f4db-43db-4fb0-8044-17441db85e03,[Données non publiées],EPCI Brest métropole,[Données non publiées] [Données non publiées],
+85072c80-d738-4504-9d06-60004f1e15da,[Données non publiées],Onrangetout,Gérante [Données non publiées],
+850f0684-e9f5-46f6-9bc6-4741589cb467,[Données non publiées],Communauté de communes Périgord Vert Nontronnais,[Données non publiées],
+85107c0a-cf3c-40fc-b9ff-d1c3efc7b032,[Données non publiées],Atelier Mima,[Données non publiées],
+8528a758-1a00-463c-97e4-c11f60a7fc78,[Données non publiées],WESER,Assistante direction [Données non publiées],FABRICATION DE PRODUITS BETON POUR LE BATIMENT
+8532cbf9-433a-467e-8733-feb2be66f52a,[Données non publiées],Association ABCM zweischprachigkeit [Données non publiées],Professeur des écoles et Directrice maternelle,
+8544cec1-ab75-4b99-bf59-b381c3a0c909,[Données non publiées],Néant,Néant,
+85457399-da68-4d17-901c-54d3da805162,[Données non publiées],Education Nationale,Professeur d'Allemand,
+854acd5c-76f0-46b2-ba1b-164b95f86a96,[Données non publiées],RATP,Directeur d'unité opérationnelle,
+854acd5c-76f0-46b2-ba1b-164b95f86a96,[Données non publiées],Pantin Habitat,Membre du CA,
+8563c0ac-25f0-4226-8690-b6c9bb5bc82c,[Données non publiées],[Données non publiées],technicienne de laboratoire,
+856abcac-cba3-4e74-92c0-35afe93c630a,[Données non publiées],Sénateur,Collaboratrice parlementaire d'un sénateur [Données non publiées],
+856c080b-c1bf-4550-964a-4752361e995b,[Données non publiées],Néant,Néant,
+857408ef-be32-4e0d-bca3-4072e0b0f35d,[Données non publiées],néant,retraitée,
+857c8fb2-ddf8-47ba-a54c-6102a378458f,[Données non publiées],RETRAITE,RETAITE,
+858f99d6-7c68-4f23-b6b2-7be41019744c,[Données non publiées],retraitée EN,retraitée,
+858fdde2-8464-4559-ac3a-16a36746e9d5,[Données non publiées],Lee Hecht Harrison France,"Consultante senior, salariée",
+8591a442-5610-4d2b-b5c2-8fae0bf8747f,[Données non publiées],Ministère Education nationale,Professeure des écoles,
+8593c389-83a7-4be5-8c2c-82ca15a3bb8f,[Données non publiées],Néant,Médecin généraliste,
+85ae5530-bd62-44c2-b3e4-6e99483ba1d5,[Données non publiées],profession libérale,masseur-kinésithérapeute,
+85b0699b-d931-4ace-a3cc-f6a3cf68431e,[Données non publiées],ECOTEC,Assistante commerciale,[Données non publiées]
+85b264c7-fd57-489e-8ce6-037f7192d67c,[Données non publiées],Centre hospitalier de Carcassonne,Infirmière,
+85b9a178-6032-4bb0-b903-f8d4109109f9,[Données non publiées],Intermittente du spectacle,[Données non publiées],
+85c5018a-27c4-4893-bc9a-4a8eeee620da,[Données non publiées],[Données non publiées],[Données non publiées],retraité
+85cb76a6-32f7-4089-adff-8e04415908e8,[Données non publiées],France Télévision,Journaliste,
+85d04dd1-bbee-4c93-b998-f0b05a0069a4,[Données non publiées],Multiples particuliers employeurs,Assistante maternelle,[Données non publiées]
+85d31fe6-704c-41de-af45-b6a8598063af,[Données non publiées],CHU [Données non publiées],Chargé de communication,
+85daa0b1-f019-4329-b3b1-6232c4b08852,[Données non publiées],Alsatis Entreprises,Chef de projet [Données non publiées],
+85e8a92c-7665-4dfa-b31f-0a54b5c058ff,[Données non publiées],Mairie [Données non publiées],Chargée de communication,
+85edc479-70af-412f-a091-72bc44472936,[Données non publiées],Sénat,Assistant parlementaire,
+85fbbd58-e703-413e-8791-a8b69c53e2bb,[Données non publiées],LIBERAL,MEDECIN GENERALISTE,
+860bb2fe-6523-4c84-aed9-74ae8ff31b96,[Données non publiées],néant,néant,
+860ca1e4-122a-4b95-b0c2-778e81096658,[Données non publiées],Lui même,Auto-entrepreneur en location de meublés,
+861294f8-a465-425a-a5d4-46477adf6d55,[Données non publiées],ADS LORRAINE,EMPLOYEE ADMNISTRATIVE,
+861435e6-0a98-4c7e-8716-fcd746b0593d,[Données non publiées],EELV,chargé de mission,
+86155469-7224-4177-9677-db6ed2072338,[Données non publiées],Crédit Agricole [Données non publiées],Analyste [Données non publiées],[Données non publiées]
+861d0c74-bf8d-4ee9-935b-349daa93d745,[Données non publiées],éducation nationale,enseignante titulaire,
+86266b43-7202-4466-a02c-eb0be3ef6e42,[Données non publiées],Néant,néant,retraitée
+863af01f-cfb0-4ded-8ab3-45a2743c5a53,[Données non publiées],NES FRANCE,[Données non publiées],
+863cb5ba-36fd-4f27-bf9d-6c49673b4604,[Données non publiées],NEANT,NEANT,
+863d8a0f-62f0-4d74-8976-71af4d67a465,[Données non publiées],GRETA 21,Conseiller en Formation Continue,
+864ce3c9-169a-412f-934a-7842765275af,[Données non publiées],ARFIS-OI,[Données non publiées],
+864d00f6-7703-411f-a38c-b5ba16328a4f,[Données non publiées],France Télévision,Journaliste,
+86593c1c-53d7-4ede-95e0-17ea64452409,[Données non publiées],ministère des transports,contrôleur aérien,
+865db57e-69b9-4fb0-b9ac-c078e99dd03a,[Données non publiées],Cigair Distribution,directeur général,
+86628100-bcf4-43f2-9afd-94676a7739ab,[Données non publiées],NEANT,NEANT,[Données non publiées]
+868bccd0-3ecb-4782-ac1b-ef33e66fb0dc,[Données non publiées],Entreprise GABARE,Cadre,[Données non publiées]
+868d0832-c23e-4c89-baf5-e702fd301b9e,[Données non publiées],Conseil départemental [Données non publiées],[Données non publiées],
+868e37c7-94e2-463c-bd9f-d6acb280da1e,[Données non publiées],Mairie de Draguignan [Données non publiées],[Données non publiées],
+868ee953-35a4-4b5d-9349-8a7a41297d53,[Données non publiées],[Données non publiées],Ergonome/Psychologue du travail [Données non publiées],
+8694b3d8-a790-4f54-b3a8-2e9565799067,[Données non publiées],Ville de Claye-Souilly,Fonctionnaire territoriale [Données non publiées],
+86996c80-a4d7-44d6-83ec-29d7482ee44b,[Données non publiées],Greta de l'Aisne,Formateur en formation continue,
+869b8976-d1fb-477a-a5c6-bbc48a999f69,[Données non publiées],selarl vétérinaire [Données non publiées],Auxiliaire spécialisée vétérinaire,
+86a4c97c-7746-4e0e-8b1e-5c597cfbd0f5,[Données non publiées],Conseil Régional,Directrice Territoriale,En retraite [Données non publiées]
+86b1818f-4712-49f1-850d-592d0a92b668,[Données non publiées],Musée des Arts Déco - Ecole Camondo,[Données non publiées],fin de contrat en janvier 2021
+86b1818f-4712-49f1-850d-592d0a92b668,[Données non publiées],Stone Holding,[Données non publiées],embauche le 18 janvier 2021
+86b1818f-4712-49f1-850d-592d0a92b668,[Données non publiées],Cabinet Hoche Avocats,[Données non publiées],depuis novembre 2021
+86b822d7-589b-4404-92c6-8eff9319b4c3,[Données non publiées],néant,néant,
+86be33da-5ec7-4c96-9886-64c9db692882,[Données non publiées],Néant,Néant,
+86c18872-6d1d-423b-ad67-e7ccce6193c8,[Données non publiées],[Données non publiées],Conseiller en immobilier autoentrepreneur,
+86ccc04e-6040-47ff-b499-26d30e51352f,[Données non publiées],Ecole [Données non publiées],Accompagnement Enfants en situation de handicap en milieu scolaire,
+86d65e04-a825-4d2e-a7a5-ee75b33f758d,[Données non publiées],Education nationale,Formatrice [Données non publiées],
+86d8898f-c2aa-401a-be38-6ce446b57853,[Données non publiées],Education nationale,Professeur de philosophie,
+86d8898f-c2aa-401a-be38-6ce446b57853,[Données non publiées],Hebdomadaire [Données non publiées],Chroniqueuse occasionnelle,
+86dceca4-7f4b-42f4-b5bb-3b4ed93c74a8,[Données non publiées],Albingia,Directrice Générale,Depuis octobre 2020
+86dd9c5d-41ec-44aa-b664-f8d8ba099348,[Données non publiées],Mairie de Draguignan [Données non publiées],[Données non publiées],
+86e5c7f1-886b-495d-a42d-16cd0a3ceeac,[Données non publiées],Arundo,gérant,
+86f16b83-d99b-4793-9867-c197bf07543e,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] pensionnée Fonction Publique
+86f867c1-ab25-44b1-90de-ac0d00026a4c,[Données non publiées],GAMA [Données non publiées],directeur [Données non publiées],
+86fef0dc-a2e8-4909-8f49-dfdc98dfcc78,[Données non publiées],ASTBTP,Secrétaire Médicale,
+86ff97b7-5958-4ed2-baa8-1bccc856783d,[Données non publiées],NEANT,NEANT,
+870d5e97-d22d-4788-897c-574e189102f7,[Données non publiées],NEANT,Historien de l'architecture,[Données non publiées]
+870d6862-e079-417e-8980-edc260cd38dd,[Données non publiées],IMMOBILIERE DE L'ABBAYE SARL,Secrétaire,
+87104951-6702-431f-a42c-4bcf0504867d,[Données non publiées],Néant,Retraitée,
+87278dd2-d23f-49c7-a9f9-eecff2e63c14,[Données non publiées],Infirmière libérale,Infirmière libérale,[Données non publiées]
+87477165-a3c3-466e-ac43-e82f56acb446,[Données non publiées],neant,neant,retraite [Données non publiées]
+874b3686-54c1-4a09-a112-086560936985,[Données non publiées],aucun,[Données non publiées],
+874f1472-c10e-4d51-a2b7-eded33657afa,[Données non publiées],Néant,Néant,
+8751f9ba-ebb3-43ad-ae26-c84bad1c8394,[Données non publiées],Ville de Marseille,[Données non publiées],
+87583ef5-25d7-4db3-bc3f-8e4d27500c80,[Données non publiées],Commune de FAAA,Agent administratif communal,
+875ae4d3-cd82-46dc-b7a4-4c001dd5e627,[Données non publiées],Education Nationale,Professeur des écoles,
+8764ecea-f150-415e-a059-f38e6249297f,[Données non publiées],[Données non publiées] Régie communautaire de l'eau et de l'assainissement de la Cacem,[Données non publiées],néant
+877a74fe-4876-4583-8f03-dc7a7c4cf747,[Données non publiées],Procivis Maisons Individuelles,Assistante de Direction,
+878107f8-5f28-49ae-a1a1-e5b4d42a0c6b,[Données non publiées],Ministère de l'Education Nationale,Institutrice,
+87816db8-ee21-479a-9059-78d186ba189b,[Données non publiées],BPALC,[Données non publiées],
+8784fb6a-14f3-436a-8931-9f8bb3500326,[Données non publiées],ETAT,[Données non publiées] DOUANES,
+8785beb3-4a52-4b17-afff-04ec08b0d621,[Données non publiées],SELARL docteur [Données non publiées],Chirurgien Orthopédiste,
+8786f9d1-d25c-4357-8736-016ff05e9db6,[Données non publiées],SNCF,[Données non publiées],
+878f2667-b5b8-4106-b46b-d17e6cd5f656,[Données non publiées],Neant,Neant,Mon conjoint a cessé toute activité professionnelle depuis 2001 et n'occupe que ses fonctions electives de maire et president de communaute des communes hava'i
+8799bee9-392d-42ce-88fa-07fbbb7a7b1e,[Données non publiées],OGEC [Données non publiées],Responsable de la pastorale,
+87a0eccf-b8a4-4383-80dd-4e414f0b841a,[Données non publiées],Boycott Hitt,agent de maitrise,
+87a11dcf-4f46-4bd3-bf1d-e388b57603e8,[Données non publiées],Assemblée nationale,Député,[Données non publiées]
+87a82cd8-7887-4278-9f91-396e55a4f6d8,[Données non publiées],Néant,Néant,
+87b49d4f-8952-4787-8b8b-617db05839a4,[Données non publiées],Education National,Professeure [Données non publiées],
+87b914b1-e7fd-47ea-82ce-4b5c9c127184,[Données non publiées],[Données non publiées],Aide-Soignant,
+87c101c3-b918-43fb-99ce-c8b4f1ca9e18,[Données non publiées],[Données non publiées],Responsable Mission Jeunesse,
+87c2b915-ed29-454a-a7b7-3f45858693d0,[Données non publiées],profession libérale,médecin généraliste,en retraite depuis le 01/0.1/2019
+87c2b915-ed29-454a-a7b7-3f45858693d0,[Données non publiées],ADOPS 85 ( association départementale pour l'organisation de la permanence des soins en Vendée ),médecin régulateur pour les généralistes au centre 15 de la Vendée (régulation téléphonique ),médecin généraliste retraité depuis le 01/01/2019
+87c8ec0a-aeae-4828-8c9b-c44d0ad6fa73,[Données non publiées],NEANT,NEANT,[Données non publiées]
+87d88aaa-a914-4340-9f52-568ee99bfad0,[Données non publiées],Centre hospitalier spécialisé de la savoie,Directeur [Données non publiées],
+87dd39cf-83c9-4ab2-951d-8635143d3bd4,[Données non publiées],PSA,[Données non publiées],
+87e31768-73fd-4fda-a96e-7db0963b966e,[Données non publiées],Cabinet expertise comptable [Données non publiées],Comptable,
+87e67092-be20-4dfa-9278-d306af8885c7,[Données non publiées],Ministère dela justice,Secrétaire administrative [Données non publiées],AUCUN
+87e8fc02-4ff2-4a12-9ce6-19d6ccb7a661,[Données non publiées],Moody's France SAS,Analyste financier,[Données non publiées]
+87ecb86d-84ed-4311-8abd-803221566220,[Données non publiées],EURL [Données non publiées],gérant majoritaire d'une société de lavages automobiles,
+87f3cfe8-0fe5-4d81-9d4b-2c1085984300,[Données non publiées],Groupe parlementaire à l'Assemblée nationale,Secrétaire générale,
+87f3d113-6f96-4ffd-bccf-1d7a15027fa5,[Données non publiées],[Données non publiées],AUTOENTREPRENEUR,[Données non publiées]
+880a2ac2-3bdf-4304-8694-6fd98febf8cd,[Données non publiées],Ministère des Armées,officier de carrière,
+880aee11-9aba-40ae-9a55-d8d6753749a0,[Données non publiées],Retraité,[Données non publiées],
+88175595-22dc-49ba-9d12-3c78d2bb9238,[Données non publiées],NEANT,NEANT,RETRAITE
+881d7539-6585-41ea-9275-1f620147851d,[Données non publiées],Vice Rectorat de la Polynésie Française,Gestionnaire financier,[Données non publiées]
+88330d75-a86d-4211-8288-2d190bee3eae,[Données non publiées],Education nationale,Professeure,[Données non publiées]
+8833533e-1fab-47d4-9402-5cd7bd230df3,[Données non publiées],RETRAITE,[Données non publiées],
+884635f6-f733-4b84-a3eb-2c914204b645,[Données non publiées],Education nationale,Professeur du secondaire,
+885856d9-745f-4245-a4f6-2e8be89454a4,[Données non publiées],COLLEGE [Données non publiées],Professeur Certifié,
+885dde88-4bbf-42ea-b678-89403fd10bb8,[Données non publiées],BNPrealestate,[Données non publiées],
+887b934e-7f48-417b-a93c-8262ab295b77,[Données non publiées],CNRS,Chargé de Recherche [Données non publiées],
+887e3a0a-3bbb-42ff-bde1-2ebac533a866,[Données non publiées],[Données non publiées],Comptable Agricole,
+888679e6-0165-49d6-81f5-383a600faf13,[Données non publiées],Ville de Nice et Métropole NCA,[Données non publiées],[Données non publiées]
+8892523e-89f9-49c3-a1a4-7541a5a5253e,[Données non publiées],CHU Rouen,retraité,
+8895b605-9c3f-4750-89ac-c9bac9cd4e7f,[Données non publiées],ASSOCIATION MEDICALE LA TEPPE,MONITEUR D'ATELIER,
+889ca547-33f0-40b8-9e83-003a1816c6bb,[Données non publiées],Le Revenu,journaliste,
+88a97dda-c0aa-4f9a-907b-2d0a6a6ed17d,[Données non publiées],néant,néant,[Données non publiées]
+88bbb934-fa65-45ad-93a4-30f90914050d,[Données non publiées],Lycée [Données non publiées],Professeur agrégée de lettres classiques,
+88c10433-4ef3-4eea-b68d-8e7dbed257de,[Données non publiées],Education Nationale,Enseignate,
+88d1c7e0-2fcb-4f8c-b13c-d7c296148cb0,[Données non publiées],RATP DEV,[Données non publiées],
+88e7f136-1264-4c7e-b342-943d18deef94,[Données non publiées],exagrid,Ingénieur informatique [Données non publiées],
+88f1aba5-479a-43ae-ba84-38a17145ddde,[Données non publiées],Infirmière,profession exercée dans un cadre libéral,
+88f3009b-fa1d-44d0-990f-6332bb000ecf,[Données non publiées],MEI,conseil juridique,[Données non publiées]
+88f616ae-37fd-4333-acb4-29a93d02387f,[Données non publiées],Conseil Départemental de Haute-Garonne,Chef de service [Données non publiées],
+88fdc177-7999-4811-858a-e11d94c2ce9e,[Données non publiées],Boulevard Voltaire,Journaliste,
+89027a96-6702-48ff-bebe-8f732d4100c5,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+89027a96-6702-48ff-bebe-8f732d4100c5,[Données non publiées],NEANT,NEANT,[Données non publiées]
+890a5186-d924-4b23-8d9e-ee6149ce4a0d,[Données non publiées],Gérant de la SARL AGENCE COMMERCIALE CANTIN,[Données non publiées],
+890e3c1e-3c56-4127-b887-0e5f2608592c,[Données non publiées],Ville de Vaires sur Marne 77,Directrice Générale des Services,
+89242d74-d8a7-4705-91e5-a5d27cca88f4,[Données non publiées],Pierre Cuypers,[Données non publiées] Exploitante agricole,
+892a1f17-24eb-4601-a9bc-5fa6ede48ad8,[Données non publiées],[Données non publiées],Responsable Mission Jeunesse,
+8932a2f6-929f-44ce-bc2b-4dbeef214410,[Données non publiées],gérante de société [Données non publiées],conseil,
+893fc566-3309-439c-a81c-31fdfda54336,[Données non publiées],Néant,retraité,
+8945170b-6ecf-4d79-8761-62695f956ae4,[Données non publiées],AGLA,[Données non publiées],
+8950ebf4-4663-4ea2-bf3f-fe36f4073868,[Données non publiées],Groupe Majorité CD 45,Collaboratrice [Données non publiées],[Données non publiées]
+89662708-4457-4b71-8492-8fef740695f6,[Données non publiées],Néant,Néant,
+8968e6d4-763f-4d9d-87d0-f889fd0fff3e,[Données non publiées],Neant,Artisan jardinier,ARRET DE L ACTIVITE [Données non publiées]
+8978a025-2203-4a43-85bb-3027f0e14390,[Données non publiées],Retraité,Retraité,
+897c9c85-562b-498f-97f7-4d4f8c048e80,[Données non publiées],CMSE,CHAUFFEUR SUPER LOURD,
+89a158ee-316f-44c1-b191-4d212f6f8e2a,[Données non publiées],Education nationale,professeur des écoles,
+89aab55f-45e8-40dd-92f9-6cada9a21f0c,[Données non publiées],MAAF,Gestionnaire de sinistres / matériels automobiles.,
+89aec986-adc0-4a0b-9518-9adaf4f6cd63,[Données non publiées],DGAC,Ingénieur [Données non publiées],
+89b425f2-8c72-423e-a08d-036f43cafd75,[Données non publiées],[Données non publiées],[Données non publiées],à la retraite
+89b425f2-8c72-423e-a08d-036f43cafd75,[Données non publiées],[Données non publiées],retraitée,[Données non publiées] [Données non publiées] [Données non publiées]
+89b425f2-8c72-423e-a08d-036f43cafd75,[Données non publiées],Autoentrepreneur,Mandataire immobilier [Données non publiées],
+89db6233-e53d-4f1f-b2d0-8f11f32b44a8,[Données non publiées],néant,néant,
+89e02d4e-c02a-48b9-8ff0-8c1523954e38,[Données non publiées],néant,retraitée,
+89ea6832-a093-438d-a9ef-d0c19babd6c8,[Données non publiées],Fonctionnaire territoriai,Agent Administratif [Données non publiées],
+89ec6d69-560e-43f2-9066-de940f970975,[Données non publiées],Mairie [Données non publiées],Directrice générale adjointe,
+89f802a3-6d89-4bb1-accb-7f26c9dc9ad0,[Données non publiées],Retraité,Retraité de l'Education Nationale.,
+89f8c2fb-c625-45a0-87ca-2796268e5743,[Données non publiées],[Données non publiées],Chauffagiste en [Données non publiées],
+8a038468-e428-4506-85ab-6d8dcb8bcc54,[Données non publiées],TSO,Directeur commercial,
+8a0602fe-6df8-4e29-87c3-7fda2669e158,[Données non publiées],MMA IARD,Responsable Conseils juridiques. [Données non publiées],
+8a10089d-4098-4567-9801-4ae214c4af27,[Données non publiées],ADENE HAD,TECHNICIEN COMPTABLE,
+8a11f5ea-3d44-42df-9127-e1050682422f,[Données non publiées],Ministère de l'agriculture et de l'alimentation,[Données non publiées],
+8a1924c8-27f5-4e07-95d5-6481fe01af33,[Données non publiées],Courtois Janine,pharmacien titulaire [Données non publiées],
+8a1a7bf9-ad65-41b4-88d8-788a6b077884,[Données non publiées],Département 13,Fonctionnaire [Données non publiées],[Données non publiées] association ES13 (loisirs des séniors)
+8a251442-307b-4b72-9bf2-78af61f4b2cf,[Données non publiées],Mairie Loroux Bottereau,Agent Maitrise [Données non publiées],
+8a3548ce-562d-4f57-b92d-6812691c0e33,[Données non publiées],Ville de Nice et Métropole NCA,[Données non publiées],[Données non publiées]
+8a48f9a9-d7e7-48da-919b-b8ee32c21212,[Données non publiées],NEANT,NEANT,[Données non publiées] ELU LOCAL
+8a50d156-fd85-4244-9657-db465f919066,[Données non publiées],TERRE DE LIENS,[Données non publiées],
+8a51165a-2616-4f53-8e14-8a4ea96311a3,[Données non publiées],Inspection académique d'Ille-et-Vilaine,Professeure des écoles,
+8a536dcc-5898-4fff-a735-dc479af4985d,[Données non publiées],Profession libérale,Médecin généraliste,
+8a540d69-caa1-4254-98ac-f00f9be1831a,[Données non publiées],Tennis Club Dijonnais,Responsable [Données non publiées],
+8a540d69-caa1-4254-98ac-f00f9be1831a,[Données non publiées],micro entreprise,prestation d'enseignement de tennis,
+8a557bde-0b25-4153-988b-84379744267a,[Données non publiées],Animation 94- Centre de formation,Directrice [Données non publiées],
+8a70ef5e-db89-4cac-bddd-584a498af406,[Données non publiées],BIORYLIS,Secrétaire,
+8a775d14-219c-44a0-8b44-37f9718b244f,[Données non publiées],Retraité,Retraité,
+8a7949d6-af76-490e-9795-d64c7deca18d,[Données non publiées],SAMUEL VINCENT,DIRECTEUR,
+8a8e60c7-d9b6-4525-ace1-df6a55e7495d,[Données non publiées],SCHNEIDER ELECTRIC,HOTESSE ACCUEIL,[Données non publiées]
+8a9d6b61-c2d1-4ec3-a69e-c8140b27edba,[Données non publiées],NEANT,NEANT,[Données non publiées]
+8a9e92ff-664f-4e44-acc8-8c51b93d1bb3,[Données non publiées],néant,néant,[Données non publiées]
+8aa16f48-d4c4-43d4-ae2e-7f72328d148f,[Données non publiées],SARL BOUCHET,Assistante de gestion entreprise de plomberie chauffagiste,
+8ab123b8-a04f-421b-8a71-e33186585de7,[Données non publiées],Mairie de Gennevilliers,Professeur d'enseignement artistique [Données non publiées],
+8abacc08-2265-4014-afd3-bcf65dfd5c14,[Données non publiées],NEANT,NEANT,
+8acb13c4-eb06-4f56-ba02-779916d80e65,[Données non publiées],Centre de gestion [Données non publiées],Adjoint administratif,
+8acbd8f0-9d54-4bb1-af9e-ef049554eb4b,[Données non publiées],Chef d'exploitation,Exploitant agricole EARL HERAUD [Données non publiées],[Données non publiées]
+8ad618fc-4e6e-46f6-b115-34ed5e142307,[Données non publiées],lui même,journaliste Président et directeur du journal Le petit mag Lens Liévin exploitant agricole [Données non publiées],[Données non publiées]
+8ad6e247-b23c-477d-b25f-dd6471b65deb,[Données non publiées],Titre individuel,Masseur Kinésithérapeute,
+8adaebfc-6663-4fce-bb6f-f8c7ee8babb2,[Données non publiées],Néant,Néant,
+8aea639f-703b-4d47-9f23-a7b912f40015,[Données non publiées],[Données non publiées],Agriculteur,
+8aebaeed-6a53-4eb8-abf8-1e8d68cbf6c6,[Données non publiées],FERTÉ PARE BRISE,[Données non publiées],
+8aee20db-68f6-4e63-b39b-15e111f28a2e,[Données non publiées],Vivendi,[Données non publiées],
+8aee35c5-8af6-4c0b-a35d-e1a9652d0421,[Données non publiées],Pharmacie [Données non publiées] [Données non publiées],Pharmacienne,
+8af5ee08-9b1e-40bd-a629-7683e31bc74f,[Données non publiées],Conseil Départemental de l'Isère,[Données non publiées] - Fonctionnaire territoriale.,[Données non publiées]
+8af69fc5-f8d3-42ba-aa26-03dbc0380312,[Données non publiées],néant,néant,[Données non publiées]
+8af979f4-6b88-4b0e-9ad9-aa9589602ec3,[Données non publiées],LPCR,Directrice de crèche,
+8af9ab03-8a02-4a94-bf73-54036e6406e4,[Données non publiées],AIR TAHITI NUI,Chef de cabine,
+8afc6163-aa9e-41a0-9212-b0c7ec486c45,[Données non publiées],Retraitée,Secrétaire médicale,
+8b1e7d81-8f63-42c5-a1de-f59eabc840f5,[Données non publiées],CREAPT,Sociologue,
+8b273a5a-77a6-49eb-a3af-ebf40a9ea10f,[Données non publiées],néant,néant,
+8b32b8f4-f168-4a47-8a97-455623ae5619,[Données non publiées],SCHAEFFLER FRANCE,Agent Logistique Transport,
+8b37cb8a-ea23-4daa-8dc4-e13a80b9790a,[Données non publiées],Retraitée,Retraitée,
+8b4d0299-57a7-4e9d-97fb-14b62b85c3e0,[Données non publiées],Eriks SAS,Responsable approvisionnement et stocks,
+8b5684e2-1576-4a28-893f-2e6cd2d75dda,[Données non publiées],néant,sansprofession,
+8b593814-eb1a-4299-b684-bf181daeccaa,[Données non publiées],Profession libérale,Médecin angiologue,
+8b62a480-e92e-46fa-a889-12417b8158e6,[Données non publiées],Neant,Neant,
+8b64a135-a4d1-4920-9e30-cf12a501845e,[Données non publiées],[Données non publiées],magasin de vetements,responsable salariee
+8b6cbc07-437c-4e78-9d25-b3f1c3338958,[Données non publiées],AS NORMANDIE,[Données non publiées],
+8b72678b-729b-42b5-bced-e21a94cb041b,[Données non publiées],Contact Battais,Couvreur spécialisé,
+8b7335bc-0ddf-4bbf-83cf-89337f880f4f,[Données non publiées],néant,néant,[Données non publiées]
+8b75b1fb-c816-4f13-a61a-512f2d0516d4,[Données non publiées],SARL [Données non publiées],vendeuse commerce électroménager [Données non publiées],[Données non publiées]
+8b7975ab-56ad-4cfc-a52b-277d9ae64307,[Données non publiées],Neant,Neant,
+8b819ac9-64fe-451b-9e09-a81949b5fdfc,[Données non publiées],Néant,Retraité,[Données non publiées]
+8b9649ba-b8e1-4b7a-8409-8831f891295e,[Données non publiées],A son compte,Fabrication de fusil de pêche + vente,
+8b97098e-9714-4185-890d-f011ba2642df,[Données non publiées],Ministère Education nationale,Professeure des écoles,
+8b9b21f2-14b6-41e1-ad5c-10419b5a14ad,[Données non publiées],néant,néant,retraité
+8b9f14c9-9188-4f28-a3c0-6c73e9b96f05,[Données non publiées],Centre hospitalier spécialisé de la savoie,Directeur [Données non publiées],
+8bb1a02e-1e20-4f6b-96f4-16d5d60912a8,[Données non publiées],CHEF D'ENTREPRISE,"ACTIVITES COMMERCIALES, DISTRIBUTION SPECIALISEE ACTIVITES IMMOBILIERES",
+8bb8a8cb-3ec6-480e-aae6-61b85d744349,[Données non publiées],UFAST,[Données non publiées],chantier naval
+8bc628ff-1e22-4bbb-8e51-45449c7162c0,[Données non publiées],[Données non publiées],Directeur de maison de retraite,
+8bc628ff-1e22-4bbb-8e51-45449c7162c0,[Données non publiées],[Données non publiées],Gérant,
+8bc6f1ce-e5aa-4d12-b647-f49d45198e7d,[Données non publiées],Exploitant agricole GAEC,[Données non publiées],[Données non publiées]
+8bd0007f-60e0-497e-97b7-a043c52c9db5,[Données non publiées],Pharmacie [Données non publiées],pharmacie,préparatrice en pharmacie
+8bd21ec9-0e79-4541-9149-a64a0a0615bd,[Données non publiées],Libérale,Infirmière,
+8bd7ef5e-dd7c-4025-9a51-a6c275669380,[Données non publiées],ENEDIS,Responsable d'équipe,
+8be199fa-2e43-4787-8db1-5dcb544b3924,[Données non publiées],Région Auvergne Rhône Alpes,[Données non publiées],
+8be5dc83-aa0b-4a3c-9033-14076f6eb7f4,[Données non publiées],PPG INDUSTRIES,RESPONSABLE [Données non publiées],
+8be630af-976d-4e8a-bd54-a7f694bff1c2,[Données non publiées],Aménagement et territoires,Directrice [Données non publiées],[Données non publiées]
+8bef1e4d-c68d-4b92-b8e1-9379ccdb3387,[Données non publiées],[Données non publiées],Plomberie. [Données non publiées],
+8bf18f19-3544-4737-b778-70f52ed177dc,[Données non publiées],P & O Ferries,Employé de caisse,
+8bf791f3-1ebd-452a-b8f0-910b7ca77ea4,[Données non publiées],Mairie de Canéjan,Collaboratrice de cabinet,
+8bfccbdc-0233-4bea-9331-5a454d42a06f,[Données non publiées],Néant,Néant,
+8bfe0701-18b7-4357-961a-bda28762ec2a,[Données non publiées],Travailleur non salarié,Agriculteur,
+8c0434e5-a12f-45c0-a90d-9894bb2097c5,[Données non publiées],Ministère Education nationale,Professeur collège,
+8c0ad1d4-1614-4c69-b458-fe553732acfd,[Données non publiées],[Données non publiées],néant,[Données non publiées]
+8c2317ce-0473-4b62-9049-a13645d438b7,[Données non publiées],Lee Hecht Harrison France,"Consultante senior, salariée",
+8c2aa484-381a-46a8-b87a-28a21c5dbb1b,[Données non publiées],Néant,Néant,
+8c2ab391-b011-47f9-92d8-5979a96ed05d,[Données non publiées],Retraitée,Retraitée,
+8c2ba449-2ddf-40d4-93d1-615b9d40b0fd,[Données non publiées],[Données non publiées],président d'une société de formation [Données non publiées],
+8c389233-496f-4225-a341-1139ac9a22fa,[Données non publiées],KEOLIS DIJON,Conductrice receveuse,
+8c5a4499-2260-4af5-b41d-8c048962e57c,[Données non publiées],Indépendant,Avocat,
+8c6d5381-0e95-412b-bb43-1ff9b0be5f9f,[Données non publiées],SARL [Données non publiées],Gérante de la Société,
+8c6d5381-0e95-412b-bb43-1ff9b0be5f9f,[Données non publiées],SCI [Données non publiées],Gérante de la société,
+8c724b30-4c56-427e-9ec7-dd9b20ed8118,[Données non publiées],Entreprise individuelle,Attachée de Presse,
+8c759a0f-9197-440c-b2b4-d91f384cb0b6,[Données non publiées],[Données non publiées],infirmière coordinatrice [Données non publiées],
+8c783b94-44de-4ad9-9038-0c8c21e743c5,[Données non publiées],[Données non publiées],vendeur,
+8c788d32-95ee-4341-976d-9c707f3c9a16,[Données non publiées],REPUBLIK MDC,senior key account manager,[Données non publiées]
+8c7a965c-5f5c-4603-91c3-69410e6889b9,[Données non publiées],[Données non publiées],Cadre,
+8c8081c5-e071-4a91-b4b6-d3fb8892e087,[Données non publiées],Ministère de l'Education Nationale,Administrateur de l'Etat détaché à l'IGESR,
+8c85d541-796b-414d-823d-cdacb4389c86,[Données non publiées],EDUCATION NATIONALE,Professeur d'allemand [Données non publiées],[Données non publiées]
+8c8ab065-c136-4ae9-8f8e-e2d67c5cadbe,[Données non publiées],Rectorat de Nantes,[Données non publiées],
+8c917df1-6584-4148-a80d-e89f233ba562,[Données non publiées],COLLECTIVITE DE CORSE,COORDONNATRICE ADMINISTRATIVE [Données non publiées],
+8c977202-ceae-4ea3-9c41-4a23256c9285,[Données non publiées],AGCAG,Association de gestion et de comptabilité Cabinet expertise comptable,[Données non publiées]
+8c992671-63fd-44de-bed5-d2d6b7543367,[Données non publiées],[Données non publiées] [Données non publiées],"[Données non publiées] [Données non publiées] AUTOENTREPRENEURE EN FORMATION : CULTURE, TOURISME ,COMMUNICATION . [Données non publiées]",
+8c9ca3e0-681f-4346-bf01-fd361596c7ec,[Données non publiées],CAPGEMINI [Données non publiées],Consultant en informatique [Données non publiées],
+8ca711c4-46af-4788-a7b1-2b129e67313e,[Données non publiées],Finaduc,[Données non publiées] Ressources Humaines,
+8ca98fdc-b4b8-40d9-82c5-717ec9f12648,[Données non publiées],Lycee [Données non publiées],Educatrice,
+8caaa020-00c4-449f-8560-b544c7762880,[Données non publiées],Néant,Retraitée,
+8cb7f0e2-1de5-4456-ba4a-87e22f4043a5,[Données non publiées],Ville [Données non publiées],ATSEM [Données non publiées],
+8cc53c55-3790-48fa-b933-e8bb403c25cc,[Données non publiées],Néant,Néant,[Données non publiées] Conseillère régionale en région Centre-Val de Loire [Données non publiées]
+8ccf2adc-fd38-4b58-8964-5a663118b2c9,[Données non publiées],SNCF Voyageurs,Opérateur assistance,[Données non publiées]
+8cd6c69c-d2f9-4ee4-8362-58a2d3291f91,[Données non publiées],Alpha Laval,[Données non publiées],
+8ce58c3a-241a-40c7-a868-d16e6f191534,[Données non publiées],Département de l’Isère,Infirmier,
+8cea1d00-a435-4bc4-8225-2492c1395178,[Données non publiées],honewell aérospace toulouse,responsable [Données non publiées],[Données non publiées]
+8cecbbde-abbd-4f4b-a766-42187240bf45,[Données non publiées],[Données non publiées],CONJOINT COLLABORATEUR,[Données non publiées]
+8cf0b729-d285-409e-a049-359bbc08741f,[Données non publiées],Gérante,Commerçante,
+8cf3371e-b6df-4796-b4f1-7d8141012f40,[Données non publiées],SEMC,Graphiste,
+8cf48874-441c-4e51-ac5f-6b2a1d5f270e,[Données non publiées],profession libérale,médecin généraliste,
+8cf5e3af-1ec7-4ea3-ac6f-36b2e28a2aa1,[Données non publiées],retraitée,NEANT,
+8cf6020f-fcd9-4a37-add0-b7c10f3fe6f1,[Données non publiées],Profession libérale,Médecin généraliste,
+8cf94ddf-b8d4-43be-866d-36d3de669327,[Données non publiées],Compagnie Océane,Maître d'équipage [Données non publiées],
+8cfdfd8a-7000-42e4-bcc3-7413c6ec79a0,[Données non publiées],Procter et Gamble,infirmière en santé au travail,[Données non publiées]
+8cffae2c-90a1-40ac-b49e-47109b25e533,[Données non publiées],HOPITAL [Données non publiées],INFIRMIERE,
+8d0d497e-9587-46d1-8308-51acd446430f,[Données non publiées],Travailleur indépendant,conseil en communication scientifique et journaliste,
+8d147819-15c1-40f7-8ef4-22bd538f40f7,[Données non publiées],INTERCONTACT,Employée,[Données non publiées]
+8d17bcd0-856e-470d-a689-54322436edb0,[Données non publiées],ASSOCIE CLINIQUE VETERINAIRE,VETERINAIRE LIBERAL,
+8d1cd606-17c9-4a44-b6fa-9eca23760525,[Données non publiées],pum plastiques,[Données non publiées],
+8d2626e4-d21d-4a4e-8ba2-fc57e1d5f3af,[Données non publiées],Programme des Nations Unies pour l'Environnement,Chargée de Programme - Fonctionnaire internationale,
+8d30acbd-5897-482f-a289-1db8bc40cb75,[Données non publiées],Education Nationale,Institutrice,
+8d3381a4-b195-4f2c-b166-3ca0c882d438,[Données non publiées],BALT INNOVATION,RESPONSABLE [Données non publiées],
+8d3d8433-4bf4-4bbd-8f05-0b37926dfac6,[Données non publiées],PPG INDUSTRIES,RESPONSABLE [Données non publiées],
+8d50b67a-9077-4ee4-a981-3d88931d6068,[Données non publiées],MISSION LOCALE REGIONALE DE GUYANE,[Données non publiées],
+8d57450b-0423-49c9-b3d7-ebccc5098461,[Données non publiées],Fluid Automation System (Suisse),Directeur de site,[Données non publiées]
+8d5893fa-d322-4235-8a15-7d95703199bc,[Données non publiées],France Télévision,Journaliste,
+8d58d514-bdb8-4d1c-8f19-cadab39a542e,[Données non publiées],néant,néant,
+8d59415d-ceab-49d5-bd69-4c607a825768,[Données non publiées],région occitanie,agent technique des lycées,[Données non publiées]
+8d5e21b2-27b9-433f-bfe8-9da8320ba730,[Données non publiées],COMMUNE DE CASTELCULIER,DGS,
+8d6038f2-aa79-4812-b41c-27faa124d50d,[Données non publiées],Ecole,Enseignante,
+8d6893ab-ceb4-4428-abc2-de1d46de4612,[Données non publiées],MAGASIN MARIELLE,COMMERCE,
+8d6893ab-ceb4-4428-abc2-de1d46de4612,[Données non publiées],SARL MARIELLE MAIRE,COMMERCE,
+8d68f31b-059f-4797-b29a-773b7ef01ef8,[Données non publiées],La Poste,Ingénieur [Données non publiées],
+8d70e644-2c7e-461c-9185-0c34525c9f61,[Données non publiées],AXEAU,[Données non publiées],
+8d72f865-b853-4850-bb58-f6d4a71a9531,[Données non publiées],ministère education nationale,Gestionnaire matérielle [Données non publiées],
+8d73f050-f8fa-46fc-b9d6-1126fc312f96,[Données non publiées],GROUPE OPTIMETRIE,[Données non publiées],[Données non publiées] cessation des fonctions le 10 mai 2022
+8d73f050-f8fa-46fc-b9d6-1126fc312f96,[Données non publiées],ASSOC FESTIVAL INTERNATIONAL DE PIANO,[Données non publiées],
+8d73f050-f8fa-46fc-b9d6-1126fc312f96,[Données non publiées],CCI MARSEILLE PROVENCE,[Données non publiées],
+8d73f050-f8fa-46fc-b9d6-1126fc312f96,[Données non publiées],CITE DES METIERS,[Données non publiées],
+8d77a3fe-03c6-44bd-96e8-545d511e2f06,[Données non publiées],Aucun,Consultant,
+8d7ebc67-b388-48de-a583-63067822781d,[Données non publiées],SARL [Données non publiées],Gérante,
+8d800323-abd5-45bf-b1dd-bbb2b727e9b4,[Données non publiées],Education Nationale,Personnel de direction,
+8d80d355-6f41-46a5-a8a5-278e2e0ce75d,[Données non publiées],retraitée,[Données non publiées],[Données non publiées] Médecin vacataire PMI pour le compte du conseil Départemental
+8d8dbb59-af6f-4c01-b1f4-dd1740a6126e,[Données non publiées],Maison de quartier [Données non publiées],Directrice adjointe,
+8da1708d-9991-4bb6-8302-5a4faf02b559,[Données non publiées],néant,néant,
+8dab9ab0-5c08-49cc-8f06-a360aa67af8f,[Données non publiées],Association pour La développement en Région du Cinéma ( ADRC),Présidente Bénévole,[Données non publiées]
+8db0abb6-647c-41f7-81da-63212e019518,[Données non publiées],ATLANTIC INGENIERIE,[Données non publiées],
+8dc4fe54-945b-446d-b349-c0f07077ab88,[Données non publiées],GAEC [Données non publiées],Salariée d'élevage et administratif,
+8dce855d-e0cb-4c97-becf-1b5d8d875755,[Données non publiées],Mairie de Vaulx en Velin,Directrice du développement urbain,
+8ddcf9b4-52db-4647-970a-14ea0e8c31b6,[Données non publiées],[Données non publiées],AGENT COMMERCIAL (PROFESSION LIBERALE) SECTEUR : PYROTECHNIE,
+8de390d3-54fe-4419-bef6-7a0e0f5d9345,[Données non publiées],Néant,Néant,
+8dfe3732-6046-4f28-b009-0a9fab06bc1d,[Données non publiées],[Données non publiées],Retraité [Données non publiées],Plus aucune profession salarié depuis la retraite.
+8e119ea3-10d5-4f74-88c7-ff2ecc712b4c,[Données non publiées],retraitee,fonctionnaire territorial,
+8e134881-b1e4-4fe6-aa62-8373a335f02a,[Données non publiées],NON SALARIEE,GERANTE SOCIETE,
+8e1c7f02-f704-4249-990d-986d53d97041,[Données non publiées],MATMUT,GESTIONNAIRE SINISTRE,
+8e320149-803a-4d22-bc93-ea4d3115a1b4,[Données non publiées],professeure des écoles,[Données non publiées] dans l'enseignement privé,
+8e4f2c33-4819-4e92-aee6-5d77e388d982,[Données non publiées],NEANT,NEANT,
+8e54a0ef-c364-4441-be42-d45010fa83ef,[Données non publiées],néant,néant,
+8e704e47-60d2-489e-bf7c-61a143255324,[Données non publiées],Libérale infirmière,Infirmière,
+8e79d3cd-94fb-4cbb-9891-b28e25bf76ca,[Données non publiées],Education nationale,Professeur des écoles,[Données non publiées]
+8e8182a2-ebd7-4b97-84ef-ab01dd6b6c9d,[Données non publiées],Harmonie mutuelle,Analyste programmeur,
+8e859a2e-ebd4-4b00-a4ea-d835309b9b46,[Données non publiées],EDF,Cadre de formation,
+8e8d9e2b-24f3-4185-ac3f-351daf49e5d5,[Données non publiées],Crédit Agricole Nord-Est,Chargé de développement [Données non publiées],
+8e92c80c-816a-4b23-9eb7-02b767c418ba,[Données non publiées],Aucun,Consultant,
+8e9a4973-6e4d-4b35-a840-fbbb5d17d25b,[Données non publiées],CENT ET PLUS Sarl,CONSEIL EN GESTION,[Données non publiées]
+8ea10f38-d202-44fe-bf25-37b64a9eb97d,[Données non publiées],DRSM,[Données non publiées],
+8ea17109-3076-458d-92f9-7d0f1defd46f,[Données non publiées],Conseil départemental de la Haute-Loire,Médecin [Données non publiées],
+8ea196a3-2e3e-4c63-8176-74362ebb7465,[Données non publiées],GEIE GECOTTI-PE,Chargée de mission [Données non publiées],
+8ea29147-09e7-45a5-b405-a5e4388340f9,[Données non publiées],Lycée [Données non publiées],Comptable,
+8ea4ed4c-f037-47b3-8b2d-92c6037074a7,[Données non publiées],France Télévision,Journaliste,
+8ea8df45-a528-429e-9100-ecfa2781bd99,[Données non publiées],LA POSTE,FACTEUR,
+8ea9de29-ff8d-4847-b455-89bfe264c8fc,[Données non publiées],[Données non publiées],"Photographe, réalisatrice de documentaires",
+8eb57e4a-fe34-4595-8718-595db5c8f07b,[Données non publiées],ASTRAZENECA,Responsable Médical Régional,
+8eb6f01c-74e1-425a-9b1e-6f7781c33c6b,[Données non publiées],sncf,agent polyvalent,
+8ed70ac7-6941-4472-8db9-6db77ff43eda,[Données non publiées],[Données non publiées],Architecte du patrimoine,[Données non publiées]
+8ede55aa-7a06-4cc7-bbc4-3b2b7f77a22f,[Données non publiées],Sans employeur,Retraitée,
+8eedc923-fd0a-432c-a0cf-780ba291e59a,[Données non publiées],EDUCATION NATIONALE,Retraité,
+8eef55c9-ad75-4707-a063-e890624b85b7,[Données non publiées],ENTREPRENEUR INDIVIDUEL,PSYCHOLOGUE CLINICIENNE,
+8f114e01-ded0-4c3a-864c-1dcefc8134e3,[Données non publiées],profession liberale,Dentiste,[Données non publiées]
+8f118e67-0daa-4fb9-a03a-8054ad422f30,[Données non publiées],indépendant,ingénieur du son et DJ,[Données non publiées]
+8f2bef83-8e97-41c6-a4b8-58364ccef99f,[Données non publiées],Alstom,Retraité,"plus d'activité, en retraite"
+8f3173e4-170a-48e4-87c0-5aa1094f1950,[Données non publiées],MINISTERE DE LA JUSTICE,SURVEILLANT PENITENTIAIRE,
+8f335f21-b671-4706-a0f5-b8b2bb206f6d,[Données non publiées],EDUCATION NATIONALE,Proviseure adjointe,
+8f48a970-d4cb-4886-b087-dd22a8b74d50,[Données non publiées],EBEN,[Données non publiées],
+8f4e53a0-2d47-4784-b65e-4a375b4edfe2,[Données non publiées],SELARL Pharmacie des Potiers,Pharmacie,[Données non publiées]
+8f4f3ae4-5efa-4983-94e0-1fbb631859b8,[Données non publiées],Etablissement [Données non publiées],Commerciale,
+8f5133a3-66a6-486f-afa3-290ef872abb1,[Données non publiées],gerante GAEC [Données non publiées],[Données non publiées],
+8f54bd78-3cd9-458f-8131-9a63e10e5557,[Données non publiées],néant,[Données non publiées],
+8f655223-6f37-4662-a385-664f7fb017bc,[Données non publiées],Banque Populaire [Données non publiées],Conseillère clientèle,
+8f677a85-3904-4da6-8d13-360ee93cfecd,[Données non publiées],Retraité [Données non publiées],[Données non publiées],[Données non publiées]
+8f6a9de8-0882-4e1c-b2de-62b7a89218e3,[Données non publiées],Centre Electrique Entreprise,Animateur Prévention Sécurité,
+8f70e3ab-e426-4afe-aa04-7b6f10c7d444,[Données non publiées],Sans emploi,[Données non publiées],
+8f80ec4d-11f9-4054-adf2-1b109fa01082,[Données non publiées],CONSEIL REGIONAL DE NORMANDIE,COLLABORATEUR DE GROUPE,
+8f905551-052d-4186-b27d-ab37974180d9,[Données non publiées],Mairie de Bobigny,Directrice [Données non publiées],
+8f98b062-320e-4f0b-8c29-f8db923a0f91,[Données non publiées],Neant,Néant,[Données non publiées]
+8fa71c9b-feed-4f65-8d29-12390ba14a25,[Données non publiées],INTERMITTENT DU SPECTACLE,COMEDIEN,
+8fadb55a-3c24-4c3b-ad9a-e38325d317a4,[Données non publiées],Syndicat mixte du Parc naturel régional du Morvan,[Données non publiées],[Données non publiées]
+8fadc6ef-5ec7-4562-9b8e-b66803084c9d,[Données non publiées],Educaiton nationale,retraitée,
+8fcab61a-684b-45b3-beb2-6b5c49961fc4,[Données non publiées],Retraité,Aucune activité,
+8fcef6ab-4333-42ba-88f2-d0587bae7206,[Données non publiées],Centre Electrique Entreprise,Animateur Prévention Sécurité,
+8fd40d4e-6b93-402d-a93e-32d663232617,[Données non publiées],[Données non publiées],Dessinateur industriel [Données non publiées],
+8fd92f61-e784-4f59-98ca-864247853346,[Données non publiées],EDUCATION NATIONALE,ENSEIGNEMENT,
+8fe7aba7-4c66-4d4c-9a40-83b49ec15cfa,[Données non publiées],[Données non publiées],néant,Plus d'activité professionnelle à ce jour.
+8fe7d66f-0674-4cce-810d-b3493fbd551a,[Données non publiées],Fondation Bon Sauveur,[Données non publiées],
+8feb75d5-45e9-43ae-82e8-09cbcbf028c9,[Données non publiées],CCAS Bégard,Directrice d'EHPAD,
+8ffc1ac8-46ce-43c7-9093-8c7a5e45ccc6,[Données non publiées],néant,néant,[Données non publiées]
+8ffcd680-5e86-434f-82d2-6536a34a9fc5,[Données non publiées],NEANT,NEANT,
+90043354-a569-40e0-aaa3-6df78953b9ae,[Données non publiées],Société générale (banque d'investissement),"""market maker"" (activité de trading algorithmique)",
+900e1c2b-91a1-487a-9d03-fbe1ae6831bf,[Données non publiées],[Données non publiées],psychiatre attachée en tabacologie et expert de justice [Données non publiées] [Données non publiées],en retraite [Données non publiées]
+90179295-7737-4260-932e-d88a17936f25,[Données non publiées],SNCFConseil,Présidente,
+9017d670-845a-4028-a7ad-8e8bbe37e92c,[Données non publiées],retraité,retraité,[Données non publiées]
+9024165b-a8bb-40ac-9c73-c5916a8fb677,[Données non publiées],[Données non publiées],MENUISERIE,
+9024165b-a8bb-40ac-9c73-c5916a8fb677,[Données non publiées],[Données non publiées],MENUISERIE ALU,
+9033aa88-a23d-4e8f-8dde-92188e1dfcef,[Données non publiées],Caisse d'allocations familiales de la Haute-Marne,[Données non publiées],
+903c3ac0-320c-4ced-8f9e-14344cc024ce,[Données non publiées],sdis 34,adjoint administratif,
+903d1c86-d11b-4a46-b163-ac97aacb11a5,[Données non publiées],MAERSK FRANCE,[Données non publiées],
+9045c0c6-0573-469f-9aad-9e7e7b008c46,[Données non publiées],NEANT,Retraitée,
+9052580e-e4cc-4804-969c-78528837c93e,[Données non publiées],Coopérative Pannier,"Responsable œnologie, marketing et communication",
+905c467b-66e8-4797-b8aa-b64e87631070,[Données non publiées],RETRAITE,NEANT,
+90608096-8430-4a4e-880b-9374973700ca,[Données non publiées],MSA GRAND SUD,Expert [Données non publiées],
+906aa001-f38d-4590-807b-519daa43047e,[Données non publiées],intermarché,manutentionnaire,[Données non publiées]
+906b8fa4-b7af-417a-81af-606ed9170562,[Données non publiées],TRICOTAGE DES VOSGES,assistante marketing,[Données non publiées]
+9084d3c2-e3fa-44f0-bcde-2db2c9570300,[Données non publiées],[Données non publiées],SECRETAIRE D'ACCUEIL,
+909301a8-5fcb-44d6-8b32-a21806d88dd1,[Données non publiées],Auto-entrepreneure,"Photographe, réalisatrice de documentaires, agence artistique [Données non publiées]",
+909ab50a-68a8-4a7a-a544-b430ba1ebb75,[Données non publiées],Néant,Néant,
+90a0edf2-2063-4ae1-9d50-e561174bf397,[Données non publiées],Fondation Aung San Suu Kyi (Fondation de droit américain),Secrétaire générale bénévole,
+90a0edf2-2063-4ae1-9d50-e561174bf397,[Données non publiées],Comptoir nouveau de la Parfumerie (Hermes Parfums),Membre du Conseil d'Administration,
+90aeba71-39ce-4adc-aa82-86d0e17cbd2e,[Données non publiées],RETRAITE,NEANT,
+90aeba71-39ce-4adc-aa82-86d0e17cbd2e,[Données non publiées],consultant,consultant sous le régime de MICRO ENTREPRISE,[Données non publiées]
+90b5a097-63a6-4625-9bd7-3c2f642064d7,[Données non publiées],CGSCOP,Directeur [Données non publiées],
+90c387b0-80e3-41ee-8dab-37e884e2109e,[Données non publiées],BNP PARIBAS,Chargé d'affaires Commerce international,
+90d41b40-fbf4-4732-84e0-1d12708ba816,[Données non publiées],néant,néant,
+90da6ba3-8565-4985-aa34-cfee19f3b7d1,[Données non publiées],ORECA,Référent Comptable,[Données non publiées]
+90eee682-7c67-42f5-bc16-ed07f4960c75,[Données non publiées],Retraite,retraite,
+90f8a4b2-1aa3-4880-bf85-3a90972865e2,[Données non publiées],Polyclinique Navarre,Infirmière,
+90f8c1d9-3f5f-4db2-92bb-0b5b772dca62,[Données non publiées],[Données non publiées],Aide-soignante,
+911eeb57-416f-4e9d-b5cc-2f3b37b955c2,[Données non publiées],Education nationale,Professeur vacataire,
+91298692-b576-45a3-94d3-1aff716b3cc1,[Données non publiées],CGG SERVICES SAS,[Données non publiées],
+91373dee-fee0-4e8d-88dd-c84f7829e781,[Données non publiées],Education Nationale,Professeur des écoles,
+914a1157-077e-47b9-a6ed-4d410d1941da,[Données non publiées],néant,néant,retraitée
+914eceac-647c-490d-bcf9-66bbd89844db,[Données non publiées],LINDT & SPRUNGLI,Technicien,
+9157be34-a0aa-482a-b912-fb0700805e9f,[Données non publiées],independant,activité services annexe a l'elevage,Entrepreneur
+91598df5-83e1-406a-9c12-09bc55dbe404,[Données non publiées],SELARL Hobson,Avocat Associé,[Données non publiées]
+916862a6-546b-4b5b-ae1e-a14c05d5d108,[Données non publiées],snc aremiti ferry,officier [Données non publiées],
+9177ffb8-b226-4055-98c3-4b3990cf25b0,[Données non publiées],"ESSEC, GEM, SKEMA, ESA",Enseignant vacataire en grandes écoles.,
+91801d1d-c3d0-47bb-b5ba-0c0249fdd14d,[Données non publiées],La Poste SA,Directeur juridique,
+9181c3a1-9e8a-4fa4-b3e9-6db4cae12cf6,[Données non publiées],BULLE DE LINGE,[Données non publiées] - [Données non publiées],[Données non publiées]
+91829533-f7ae-4cc5-9ac5-15b5c3c75bf8,[Données non publiées],sarl [Données non publiées],gérante expert comptable commissaire aux comptes,
+918a26fe-f816-494e-adab-befce514917a,[Données non publiées],Education nationale,Professeur [Données non publiées],[Données non publiées]
+918befe0-02f8-4aae-baa7-ccee686d90ce,[Données non publiées],NEANT,NEANT,[Données non publiées] élue [Données non publiées]
+918d2c4d-9004-47c9-81e8-95f278db52eb,[Données non publiées],Education nationale,[Données non publiées] accompagnant d'élève en situation de handicap [Données non publiées],
+918dff17-6488-474b-9888-04844a66c3b4,[Données non publiées],[Données non publiées],Comptable,
+91a7446b-7c49-4952-bc0a-8dab8fa13a0e,[Données non publiées],Agriculteur,Exploitant Agricole,associé dans le GAEC [Données non publiées]
+91aaa6a4-16df-4ace-b731-489bc381b739,[Données non publiées],CANON FRANCE DIVISION COPIEURS,TECHNICIEN SAV,
+91b0193a-9364-4c7e-bb3c-f7421d34828e,[Données non publiées],SARL SD CONSULTING,[Données non publiées] société de conseils.,
+91b49ea9-c8fd-4686-972f-9fc0f4f94716,[Données non publiées],CONSEIL DEPARTEMENTAL DE LA SOMME,Adjoint technique Chargé de maintenance [Données non publiées],[Données non publiées]
+91b905d8-1847-4dd6-9f56-ecb8be695f77,[Données non publiées],CGT,Administrative,
+91ba1839-7d4d-4e4b-9b9d-f70da007e871,[Données non publiées],VNF,Technicien,
+91bce966-77b7-44ab-9304-51e3e4908c47,[Données non publiées],sarl chaussures Mireille,[Données non publiées] collaborateur,
+91d5d24a-b8b0-4009-b6b4-c745d8a642df,[Données non publiées],Néant,Néant,
+91db5397-8239-4ef3-90f2-4b522d27d7ff,[Données non publiées],SASU,Ebéniste agenceur,[Données non publiées]
+91de79e2-97e4-48a0-a299-02462a83e5d7,[Données non publiées],Conseil départemental du Val de Marne,Cheffe de projet [Données non publiées],[Données non publiées]
+91fec696-6001-4e51-a55a-dce9abeab909,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] retraite [Données non publiées]
+9203db34-8d0a-4b44-9d20-bfdaa4836237,[Données non publiées],Communauté de communes Périgord Vert Nontronnais,[Données non publiées] [Données non publiées],
+920bf17d-1794-4f8e-96a8-2b32368f6563,[Données non publiées],NEANT,NEANT,
+920c213f-f5c6-499a-bf09-2958842c38f6,[Données non publiées],REGION OCCITANIE,[Données non publiées],
+9215fc45-ac89-4d6f-86b5-286f12fe1d78,[Données non publiées],CCAS d'ARCANGUES,Agent de service hospitalier,
+9220cbba-b751-4a84-b4f0-cfacdb7be749,[Données non publiées],Éducation Nationale,Professeur des écoles,
+923a0dbb-8f11-4fae-bd49-63f4fe033c38,[Données non publiées],Entreprise [Données non publiées],Auto entrepreneur petits travaux,
+924a846e-86c9-40ad-b513-eac4b6af97c3,[Données non publiées],Ministère du Travail,Inspectrice élève du travail,
+924c72b5-9638-468e-9390-fab72e892d22,[Données non publiées],FPH Centre Hospitalier de Briey,[Données non publiées] Adjoint Administratif [Données non publiées],
+92580508-34fc-4e2d-81bc-029c298652bb,[Données non publiées],Université de Pau et des Pays de l'Adour,Gestionnaire scolarité,[Données non publiées]
+9258b4a6-b5e9-4b2e-8508-8bccfebbafc0,[Données non publiées],mercedes CAVAILLON,[Données non publiées],[Données non publiées]
+92598cbf-b861-428c-a68e-07eab6494cc2,[Données non publiées],ETS SARRAZIN [Données non publiées],MONTEUR SOUDEUR,
+9267050a-415d-4ae4-a106-6be9bdf670ec,[Données non publiées],néant,rétraitée,
+926e9057-c8cc-415d-b2c0-27e68d36eabe,[Données non publiées],Sans,Aucune,
+926fe1df-72b4-42aa-b035-cb34fee414ca,[Données non publiées],Communauté d'Agglomération Hérault Méditerranée,Responsable du Service [Données non publiées],
+92722ee5-6a9f-4f34-911f-188dc8d98737,[Données non publiées],UBS,Banquier d'affaires,
+927c044c-f4af-4b05-8fb4-97f9c74d4b1b,[Données non publiées],éducation nationale,professeur des écoles,[Données non publiées]
+927c4397-7b2a-4a34-be27-a4da90b71dcb,[Données non publiées],SARL PLUS 6,Communication publicité,[Données non publiées]
+92801ea4-3fe5-4e9f-953f-606e7e5b4679,[Données non publiées],[Données non publiées],Pharmacien,
+9286d1f4-163d-443c-b60d-9ceb1d509ef4,[Données non publiées],CCMP,Ouvrier opérateur d'exploitation [Données non publiées],[Données non publiées]
+92882b32-888e-401c-8c63-42fd0abde994,[Données non publiées],néant,néant,
+92896563-ab14-4bad-ae2a-424214b7d497,[Données non publiées],[Données non publiées],Conseillère en formation,
+929aa0fc-cf83-492c-8b79-36ef3fe8ebe6,[Données non publiées],[Données non publiées] Gérante,Conseil en Communication,
+92a17b96-1519-4216-bf30-d89e01f19d83,[Données non publiées],éducation nationale,professeur de l'enseignement secondaire,[Données non publiées]
+92abbefe-c327-4b46-a0f3-14c884914bab,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] pas d'emploi.
+92ae59fb-9f2c-4b56-abf0-338b0575726a,[Données non publiées],ENTREPRENEUR INDIVIDUEL,PSYCHOLOGUE CLINICIENNE,
+92ba5d7a-bab4-4852-b36e-bee2d996bea2,[Données non publiées],AIRBUS SAS,[Données non publiées],
+92c1201d-4361-4a18-a5b2-bb4a48f8f7ef,[Données non publiées],Éducation Nationale,Professeur des Écoles,
+92cc268c-0833-4299-8b6b-a0064681a54f,[Données non publiées],Initiative Terres d'Azur,Directrice.,
+92ece175-bab0-40b2-981b-5787c2525018,[Données non publiées],Néant,néant,retraitée
+92f70b9a-0e49-490e-bd69-2076d381a6a1,[Données non publiées],Nantes Métropole,Conseillère municipale de Saint Sébastien sur Loire Conseillère Métropole de Nantes,
+92fbba6c-402d-42ce-8329-0b4f8f47cfdb,[Données non publiées],France Télévision,Journaliste,
+93055646-2a66-4e30-91ec-da85b0084bdd,[Données non publiées],INRAP,assistante d'études,[Données non publiées]
+93088301-fc00-4d18-8ec4-a7528fefe6b6,[Données non publiées],Hopital [Données non publiées],Psychologue,
+930ddcf1-7133-428e-a8af-16c69f65d1de,[Données non publiées],Retraité,[Données non publiées],
+9320a40b-3730-4020-a0e5-ad48b086f287,[Données non publiées],SARL JAG HAUT VERDON VOYGES,GERANT,
+9320e692-5037-4061-87f3-ee346d8de707,[Données non publiées],[Données non publiées],[Données non publiées],retraitée
+9323a6fa-0f53-43cb-bf12-6e88475c75a1,[Données non publiées],éducation nationale,enseignante titulaire,
+932528d3-c443-4172-b935-31d0c38cc4b0,[Données non publiées],ALES VIANDES,[Données non publiées],
+933f95bf-02aa-4c26-abdd-db2b0e284708,[Données non publiées],[Données non publiées],[Données non publiées],
+93443ccd-948d-41e0-94fa-41d93c31ac6b,[Données non publiées],CEPAC,employée de banque,
+9345f61b-5a24-4c6c-b088-adfe3e15335d,[Données non publiées],N/A,Sans activité,
+9348c6fa-8595-40bb-8a09-2b5941595c6e,[Données non publiées],RETRAITÉE,[Données non publiées],[Données non publiées]
+934c525b-758b-4d81-9ee9-b5bc8e8f333a,[Données non publiées],ASSOCIATION DES MAIRES D'EURE ET LOIR,[Données non publiées],
+93594e14-38d8-4c7d-8194-68db71327882,[Données non publiées],Etat,Professeur des Ecoles,
+935a529d-68fe-447b-959d-b5f84f104fff,[Données non publiées],néant,néant,[Données non publiées]
+935bd3ea-557f-408d-8a85-d83e0134c334,[Données non publiées],OGONA,[Données non publiées],
+936ca7f7-780d-4b53-92ee-1ab015765811,[Données non publiées],RETRAITE,NEANT,
+93720a13-e5da-44a1-8e30-79fcdb41a2fe,[Données non publiées],COMMUNE DE LES BORDES,SECRETAIRE DE MAIRIE,
+93742af9-d60a-4578-afcb-22318fcb06da,[Données non publiées],ANPAA,SECRÉTAIRE MEDICALE,
+937feda0-eba3-4975-a37f-8f25ceb507b3,[Données non publiées],Celtic Wisky Comagnie,[Données non publiées],
+9386de37-c97a-4415-94ce-7e8271e95c24,[Données non publiées],[Données non publiées],Infirmière libérale,[Données non publiées]
+9387a4f8-7db2-41f3-a697-3f85669d19a4,[Données non publiées],Agence Française de Développement,[Données non publiées],
+93944483-011e-409b-824f-3b326fc31896,[Données non publiées],ACORUS,Chargé d'étude de prix.Agent de maitrise.,
+93963093-f842-4a05-bb74-ef884353eeb9,[Données non publiées],[Données non publiées],RETRAITEE,
+939d5239-5261-49c2-99d9-9e71dfe13171,[Données non publiées],Gifi,Responsable [Données non publiées],
+93b27c64-bf9f-4ed1-88ad-6cf2d4090efb,[Données non publiées],COTELAC,Directrice déléguée,
+93cc699d-f299-467e-874a-038ab845ab7a,[Données non publiées],[Données non publiées],Location d'immeubles,[Données non publiées] Président [Données non publiées]
+93d3c093-92c2-4822-bac9-8dc85a6f13e3,[Données non publiées],Etablissement Public Départemental de l'Enfance et de la Famille,[Données non publiées],
+93e05997-d155-4c33-9380-0c07dc5f0068,[Données non publiées],néant,Journaliste retraité,
+93e71c9f-2661-42cd-928f-ef4beb5d85a9,[Données non publiées],ASTBTP,Secrétaire Médicale,
+93ea594f-8847-45a4-a2e8-97841b051c20,[Données non publiées],Hôtel Dieu,Technicienne,
+93fb8fd1-5364-421c-ba09-1445309268f1,[Données non publiées],[Données non publiées],Esthéticienne,
+94033047-5132-4fc4-bca6-00aceb18f219,[Données non publiées],Digital district,Superviseur VFX,
+94034211-49fc-47e8-b500-ef61a62dd63e,[Données non publiées],Geodis,Directeur [Données non publiées],
+940ba90d-a0e6-431a-b482-0989ef6e4a90,[Données non publiées],NEANT,NEANT,RETRAITEE
+940f15f2-ca2d-4f20-bb92-442a44661952,[Données non publiées],CHU [Données non publiées] et Faculté de Médecine [Données non publiées],Professeur des Universités-Praticien hospitalier,
+941286a0-8907-4370-aa5c-06f63e92f21b,[Données non publiées],Accenture,Consultante,
+941a9377-99eb-46e2-a651-96f6e69d9786,[Données non publiées],Arkéa Banking Services,Responsable [Données non publiées],[Données non publiées]
+941b1ff7-13ac-4169-a4cb-41fe481d6013,[Données non publiées],PROFESSION LIBERALE,infirmiere liberale,
+942036d1-8d8c-4941-a199-e6d2b27c81cc,[Données non publiées],ABACA,Activité de photographe professionnelle. [Données non publiées],
+94241aa1-9552-47a7-ab57-0bc55eead481,[Données non publiées],néant,Gérante de sociétés Loueur en meublé,
+9428fcbd-c020-4257-b027-b36c1e0c4424,[Données non publiées],Hôtel Dieu,Technicienne,
+94325618-8325-4395-ba73-551546bfb6fc,[Données non publiées],Education nationale,enseignant [Données non publiées],
+94325618-8325-4395-ba73-551546bfb6fc,[Données non publiées],Mairie d'Unieux,[Données non publiées],
+94325618-8325-4395-ba73-551546bfb6fc,[Données non publiées],Saint Etienne Métropole,Conseiller communautaire,
+943e1688-bf12-47e7-8931-b082f4fdeb77,[Données non publiées],SPL Océan Marais de Monts Tourisme,Responsable du Pôle [Données non publiées],
+9448fc1b-e081-431f-b7f8-4dd685ea5bc7,[Données non publiées],AUCUN,AUCUNE,
+944d6095-f641-46bf-a23f-a632169e9a10,[Données non publiées],Communauté de Communes du Champsaur Valgaudemar,Salariée Responsable de la France Services du Champsaur Valgaudemar,
+94529624-8645-462d-b3e1-de696614ef08,[Données non publiées],[Données non publiées],[Données non publiées],retraité
+945b6363-4017-4705-92c5-d66343d47cd9,[Données non publiées],Retraitée,Néant,
+9468734c-1f96-4ce5-8b52-4907a2afeee9,[Données non publiées],France Télévisions,Journaliste spécialisée,
+94699463-009f-4e2b-9637-50e6d2cdc6df,[Données non publiées],Education Nationale,Enseignant,à la retraite
+9469ea25-2663-4900-98e4-02223b2b5593,[Données non publiées],communes de Jainvillotte et Tilleux,[Données non publiées],
+946c8f5b-fbcc-4b80-8d44-fee10e1f845f,[Données non publiées],ADDSEA,EDUCATRICE SCOLAIRE SPECIALISEE,
+946ed4e1-dfd5-4761-a2fc-e893f1867ff7,[Données non publiées],Neant,Retraitee,
+9475e11f-548c-48d9-b2d6-c4a247f98e8e,[Données non publiées],CRAM,Retraité,
+9488aaee-290b-4de1-9a69-1ea19cad155a,[Données non publiées],Entreprise individuelle,Infographiste,
+9488b455-f807-4fd7-86b1-3fe3743bf954,[Données non publiées],OPHLM du Gers,Fonctionnaire territoriale,
+94a1be92-3607-4c92-9980-7014591eeb7a,[Données non publiées],SARL [Données non publiées],Assistante de direction,
+94a818e9-75d2-427d-8687-a2158dedf0e7,[Données non publiées],NEANT,NEANT,
+94a87bc0-942a-4640-a317-047dbdf8491b,[Données non publiées],CPAM 93,Cadre de la fonction publique,
+94b71af1-c855-4669-8748-1af2aabe04a1,[Données non publiées],BNP PARIBAS,Assistante de Direction,
+94c00b04-4849-4f8a-b2e0-5c6379c42402,[Données non publiées],CHCB,Activité de vaccinateur [Données non publiées] centre de vaccination à Pontivy,
+94c48ca8-6a02-443a-901f-813b6ead06f9,[Données non publiées],ENTREPRENEUR INDIVIDUEL,FORMATION CONTINUE D'ADULTES,[Données non publiées]
+94c68174-4a93-4129-b8fa-e5c0b69412d5,[Données non publiées],retraitée,retraitée,
+94e1a16e-877a-480c-847c-c0bcb68bac67,[Données non publiées],Pharmacie [Données non publiées],pharmacie,préparatrice en pharmacie
+94e75d1d-f327-4963-9a30-1809bc0f928b,[Données non publiées],Covéa Finance,[Données non publiées] [Données non publiées],
+94eb9ce3-3b09-4cc3-8545-91f6dec1c0a5,[Données non publiées],Laboratoire Defrance - Maison de Santé du Pays Neufchâtelois [Données non publiées],Secrétaire Médicale [Données non publiées],
+94ed2db8-af7c-4413-9256-8ab04e7d308f,[Données non publiées],Ministère de l'Intérieur,[Données non publiées],
+94f090d9-37f3-4267-afa0-4ce5d5b03b47,[Données non publiées],Ministère des finances,Inpectrice des finances publiques,
+94f5726f-47b9-429f-b154-f4571e9fd6be,[Données non publiées],Université Grenoble Alpes,[Données non publiées],
+94f75fa9-3668-4ef2-8ef0-bd71451f5ab1,[Données non publiées],Artiste - Gérante de Société,Artiste Plasticienne sous la signature [Données non publiées] . Gérante de La société [Données non publiées] qui a un magasin de vente de vêtements au détail.,
+9503ded1-1f57-4c36-abd7-ff0d67ce589b,[Données non publiées],CNFPT,[Données non publiées],[Données non publiées]
+950a3b37-e2e7-44c9-bc52-9b409ad22c44,[Données non publiées],Département Morbihan,Gestionnaire,
+951bf4dd-2273-4468-821e-19b58482d968,[Données non publiées],Ministère de l'Economie et des Finances,[Données non publiées],
+951f9343-470c-4280-bea9-0a1fcf5f3e35,[Données non publiées],Crèche associative,Directrice de crèche,[Données non publiées]
+95236cbd-4954-4bba-a4de-870739fd3124,[Données non publiées],neant,neant,[Données non publiées]
+95316915-38c7-408d-9cf9-0aa3fbe76fbf,[Données non publiées],Avocat,Avocat,Profession libérale
+95396d28-d087-4b5b-8297-40204cb61293,[Données non publiées],MARINE NATIONALE,OFFICIER DE MARINE,
+953c37bf-8cca-4aff-b8e9-37b6a2c93435,[Données non publiées],Territoires Formation et Conseil TFC,Dirigeant [Données non publiées],
+953d671f-8216-45f2-90bb-23218f0e1dea,[Données non publiées],Centre des Monuments Nationaux,Directrice des Ressources humaines,
+953d73ec-0cfe-4ed3-bf56-ad2fee71f683,[Données non publiées],Centre Hospitalier Universitaire [Données non publiées],Infirmière à domicile,
+954726b4-feea-47b8-bfd3-cf84c6502ed7,[Données non publiées],KTM Advance,[Données non publiées],
+954726b4-feea-47b8-bfd3-cf84c6502ed7,[Données non publiées],Holix,[Données non publiées],
+9554343e-7dd7-4ae2-8ba9-6be04f3cd3d0,[Données non publiées],sarl chaussures Mireille,[Données non publiées] collaborateur,
+955a8d05-a11c-44c2-9fcd-4eae68fdb6e3,[Données non publiées],retraitée,[Données non publiées],
+955cb890-b86e-419e-9fac-9178a6a33bf9,[Données non publiées],Profession libérale,Masseur-Kinésithérapeute,
+9567982e-96a3-453e-9cab-4c743d6a8c68,[Données non publiées],Compagnie Océane,Maître d'équipage [Données non publiées],
+95815af5-1d01-486c-96f0-a60d8be9460c,[Données non publiées],DIOTSIACI,Directeur Général [Données non publiées],Groupe de courtage et conseil en assurance
+95889ae1-5ded-4760-8701-e3104daebc86,[Données non publiées],LUNETTES GRASSET,CHEF DE PRODUITS LUNETTERIE,
+9590a17a-a979-4f6f-9e7f-100eac421622,[Données non publiées],[Données non publiées],"Etiopathe, activité libérale",début de l'activité en juin 2021
+9591876e-3793-41b4-860e-30cf22f648e9,[Données non publiées],Value Retail Bicester,Directrice [Données non publiées],
+9598502d-541e-4080-9b43-9ad9e9c43c2c,[Données non publiées],[Données non publiées],[Données non publiées],Arrêt [Données non publiées]
+95b08bcb-f7f5-4a2f-87fc-2aac82a81152,[Données non publiées],avocate exerçant à titre individuel,[Données non publiées] avocate pénaliste au barreau de Paris. [Données non publiées],
+95bb0f1c-aaff-45cc-96cd-3c0cf9526e34,[Données non publiées],Communauté de communes des 4 rivières,Animatrice de Relais Petite Enfance,
+95c932de-e054-4b84-9684-073570f5e87a,[Données non publiées],[Données non publiées],[Données non publiées],
+95d9d0f1-2808-4d58-9727-f13ceb3428fe,[Données non publiées],Ministère des finances,[Données non publiées] Inspecteur divisionnaire hors classe.,
+95e34023-67e4-41e8-baad-8846deda6d81,[Données non publiées],SAS [Données non publiées],"Directrice [Données non publiées] , cabinet d'assurance.",
+95ee8c7d-6c06-44aa-8d56-837267bfbe20,[Données non publiées],COMMUNE DE LES BORDES,SECRETAIRE DE MAIRIE,
+95f187ce-5184-4086-a9c3-7d54f832de4e,[Données non publiées],Auto entrepreneur,Mandataire financier AXA,RETRAITE ET AGENT MANDATAIRE AXA DEPUIS JUILLET 2017
+95f28309-bfdb-4ff2-8eee-7fb69d599747,[Données non publiées],ministère education nationale,Gestionnaire matérielle [Données non publiées],
+95f52d96-7f35-4676-b3c7-973eac5e3044,[Données non publiées],CLINIQUE CLAUDE BERNARD,Secrétaire médicale,
+95f9109b-cc57-4869-9dce-b4b22c51f0dc,[Données non publiées],retraitée,aucune,[Données non publiées] retraite depuis le 1/09/2020
+95fdbec9-20f7-4b8c-b847-20f2c6d5c329,[Données non publiées],Decathlon France,Directeur [Données non publiées],Cadre dirigeant
+95fe39a5-fec2-4941-bcb3-a4f73a7912c5,[Données non publiées],VILLE DE NIMES,[Données non publiées],
+9603adbe-d0e6-48f4-ad18-a56774de5c4b,[Données non publiées],Assemblée nationale,[Données non publiées],
+96062c5e-df89-4399-9a21-431c5652d6a3,[Données non publiées],Centre-Sevres-Faculté-Jésuite-de-Paris,doctorat-en-théologie,[Données non publiées]
+960fd841-1f8a-43e4-8bbe-519edc654652,[Données non publiées],Education Nationale,Directrice d'école primaire [Données non publiées],
+9612f821-bd6e-4a8c-a880-0811a991f108,[Données non publiées],Hopital Foch [Données non publiées],Masseur-Kinésithérapeute salariée,
+9620be6d-9671-43fd-afc1-a23534c0e7a2,[Données non publiées],FONDATION DE LA CHIMIE,Directeur Général [Données non publiées],
+9635728b-defc-43cc-bebd-7e426c1f2e17,[Données non publiées],Profession libérale,Pédicure-Podologue,
+96372b13-6830-497b-876b-9baadd7d3427,[Données non publiées],Métropole du Grand Nancy,Directeur général adjoint,
+9637b28e-1b04-428c-baa8-a6cedb7b750a,[Données non publiées],BALT INNOVATION,RESPONSABLE [Données non publiées],
+96393779-0de3-4965-a3fa-843729ccd94b,[Données non publiées],lui même,conception graphique,
+963c7de6-1258-4988-b3dd-7682bf779cf5,[Données non publiées],keller williams,transaction immobiliere,[Données non publiées]
+963c7de6-1258-4988-b3dd-7682bf779cf5,[Données non publiées],iteva - gerant,sarl [Données non publiées],[Données non publiées]
+96401726-40f9-41be-a611-b9ece587a57f,[Données non publiées],CCAS d'ARCANGUES,Agent de service hospitalier,
+964064d2-e76a-444c-a4fa-edb85b6783c7,[Données non publiées],UDAF [Données non publiées],MANDATAIRE JUDICIAIRE A LA PROTECTION DES MAJEURS,[Données non publiées]
+9650fea3-8f19-49a1-a561-9830132e31b0,[Données non publiées],camping [Données non publiées],Gerant,
+965c2982-75d7-430d-bad7-3f338c64a4d6,[Données non publiées],IFEAP,Formatrice,
+965e2b8d-e381-4c94-bff7-e5b3ffda84fc,[Données non publiées],SARL Le chaudron d'or,Assistante de direction,
+965e6aac-bcf8-4656-9ae2-c5c100f9f90c,[Données non publiées],Profession libérale,Chirurgien ORL,
+966c2e1a-d91b-4943-9ea3-e3437effd92d,[Données non publiées],EARL (associé exploitant),agriculteur,
+968cf94f-c606-422d-941d-1451c9c6d436,[Données non publiées],Handicap international,Psychologue,
+9690c589-359e-4075-8946-5d1e51bb2316,[Données non publiées],Mairie [Données non publiées],Secrétaire Administrative,
+9698aba9-0a4f-4873-a2cc-757399098c8d,[Données non publiées],Profession libérale,Profession libérale,
+96990322-f9e6-4fff-84ab-365a71275b68,[Données non publiées],néant,néant,[Données non publiées]
+9699d1fa-a491-4162-91c9-bd81aaa2dbbb,[Données non publiées],R INTERIM,INFORMATICIEN,
+969de224-8ba5-4623-a037-41cbf1ad87d0,[Données non publiées],néant,retraitée,
+969ec7d5-05f9-42c3-bb73-d585339d5ebb,[Données non publiées],néant,néant,retraité
+96aa5361-a841-43f3-9056-c6e7220beaa0,[Données non publiées],Congrès de la Nouvelle-Calédonie,[Données non publiées] [Données non publiées],
+96aa76b2-5fc0-4106-9369-c6e908d5da54,[Données non publiées],MAM'AISON VERTE,ASSISTANTE MATERNELLE,
+96b16914-6cf9-4d0a-8908-2228d536960a,[Données non publiées],EDUCATION NATIONALE,Enseignant Professeur des écoles,
+96c4b322-2da3-4f69-9f78-2bacc212752d,[Données non publiées],Commune de Champlan,[Données non publiées],
+96cc8893-41c4-48bd-9765-8bce2838ac43,[Données non publiées],La Fabrique de patrimoines en Normandie,[Données non publiées],
+96d4243a-6961-4774-9be5-c6759892c7fb,[Données non publiées],societe [Données non publiées],commerce,[Données non publiées]
+96d69065-75f6-497c-a8c1-fb8c7fc30e4e,[Données non publiées],Néant,Néant,[Données non publiées]
+96d906c3-8b70-4a5b-a7cf-38ab9b037532,[Données non publiées],ECOLE SUPÉRIEURE D'ART DE LA RÉUNION,[Données non publiées],
+96dcc977-7d21-49c2-a1fc-a586b7c913ab,[Données non publiées],Pharmacie [Données non publiées] à Le Mée sur Seine,pharmacien,
+96dd9da2-0fb5-43eb-9f9a-cb0a76fd77bf,[Données non publiées],néant,néant,
+96ddc314-19fc-48c6-86a1-8e3abd45398d,[Données non publiées],SELAS LPACGR,Avocat,
+96de29c2-e29b-4491-bf49-2913c96c3a4b,[Données non publiées],Trucks car services,[Données non publiées],
+96e3f057-ed4e-4ff2-8846-57dd70eede8b,[Données non publiées],[Données non publiées],Assistante d'avocats,
+96ef2cd7-ba36-4652-b3ab-4e57ed373b57,[Données non publiées],neant,retraité,[Données non publiées]
+9707d2fc-403e-4ba4-b7f5-7217c944bc1d,[Données non publiées],GRS VALTECH / VEOLIA,[Données non publiées],
+9710aa85-9332-4c49-a33c-4d3bcbeca543,[Données non publiées],Musée des Arts Déco - Ecole Camondo,[Données non publiées],
+97131b18-3d48-45d0-b47f-c8399a586828,[Données non publiées],La banque postale,Assistante de direction,Néant
+971781f6-6774-4422-afe9-98b39dd86889,[Données non publiées],Directeur commercial de la société [Données non publiées],"vente de récompenses sportives (trophées, médailles...)",
+97182990-e07b-45f7-8550-5f9c99d04599,[Données non publiées],néant,retraité,
+97182dfb-07d5-41be-acf4-36835c548290,[Données non publiées],néant,néant,[Données non publiées]
+971eb7c5-16e4-430f-aed1-76e2bb7ade17,[Données non publiées],SARL [Données non publiées],RESTAURANT,
+972ce81e-3e26-40b8-94d3-3eb1a5b4f616,[Données non publiées],Hôtel Dieu,Technicienne,
+9734653d-3546-46ef-8442-9231b3798ebc,[Données non publiées],Education nationale,Professeur des écoles,
+973b94b3-8b8c-4a37-b6b8-d3ddd47ef006,[Données non publiées],Ministère de l'intérieur,Officier de Police,
+974360bf-7514-4062-ae60-d303ae1b35ee,[Données non publiées],Ministère de l’éducation nationale,Professeure dans le secondaire,
+975dacb1-7601-4c1f-8168-2747b57cf3a9,[Données non publiées],NEANT,RETRAITEE,
+97691c78-c334-4f3c-ad9f-df4ae0042fb5,[Données non publiées],Ville de Rennes,chargée de mission [Données non publiées],
+976a6794-79f0-4899-a06f-3c8c0cd4d73e,[Données non publiées],néant,néant,
+9778eb26-6250-43fb-8a15-517153617288,[Données non publiées],CHRU de Tours,Cadre de santé,
+9784c725-4aa4-4c6c-9aee-5001ba80be50,[Données non publiées],[Données non publiées],Aide soignante,
+978fe5f8-51e5-4380-bfe3-354e09816fb1,[Données non publiées],ASSEMBLEE NATIONALE,COLLABORATEUR,
+97984193-be10-46d2-9eb1-b3a261bef816,[Données non publiées],Education Nationale,Inspectrice de l'Education Nationale,
+979dffcd-e02e-4bbf-9f48-e67f4a064901,[Données non publiées],Lycée [Données non publiées],Comptable,
+979fc9a7-d7d7-4feb-9e0e-ae486e61350c,[Données non publiées],NANTES METROPOLE,agent,
+97a5706e-36c2-4826-9b74-99bba189a7e4,[Données non publiées],Groupe Mongreville,PDG Climatisation,
+97aa915a-a1df-4445-b88c-ce0e564b8b68,[Données non publiées],Home Ouest Immobilier,Agent immobilier [Données non publiées],
+97ad5bfc-20a8-4bb7-a8de-f3c5d51d1743,[Données non publiées],Toulouse School of Economics,Doctorat [Données non publiées],
+97aebda4-fae1-4ccd-9071-eaa01009d293,[Données non publiées],Gouvernement de la Polynésie française,Conseillère technique,
+97afc158-4c55-4844-9942-e785930a1414,[Données non publiées],Armony Saveurs,[Données non publiées],Restauratrice indépendante [Données non publiées]
+97b6b968-06f7-48e2-8888-ca14db6e21c2,[Données non publiées],CHRU Tours /ARS centre val de loire,Médecin hospitalier,
+97c2d48c-2300-4339-a9ad-c9f0a3ca0795,[Données non publiées],néant,néant,
+97c9f625-8463-4e16-a479-5a5a4780ef3e,[Données non publiées],Etat,professeur des écoles,
+97ca615f-c430-487c-9ea3-1abada29675e,[Données non publiées],[Données non publiées],Coiffure à domicile en auto entreprise,
+97e304e7-edba-4ef4-b675-4fde536623b1,[Données non publiées],Néant,Neant,
+97e41478-151e-461b-9a6a-95398eb24ad0,[Données non publiées],Néant,retraite,[Données non publiées]
+97f58b41-b6cb-40c1-b1da-f99122ee8f59,[Données non publiées],OC2IOI,[Données non publiées],[Données non publiées]
+97f7bf7c-51ee-4264-b740-a5b4d8a9aaf0,[Données non publiées],La Poste,[Données non publiées],[Données non publiées]
+97f87fe3-b50a-4424-8652-5382019ed7f0,[Données non publiées],EDUCATION NATIONALE,PROFESSEUR DES ECOLES,
+9805e471-5f07-4ce1-8a18-8369ac1f9347,[Données non publiées],SNCF,Cadre statutaire SNCF,
+98081aad-b7fb-4934-a11e-2d6eb4c43c3e,[Données non publiées],DK Propre,Agent d'entretien qualifié.,
+980eb03e-ee0d-4836-a240-1522568c8673,[Données non publiées],Ville d'Evry-Courcouronnes,cabinet,
+9812a3ad-a4ea-45e0-98ba-f983c5678ca6,[Données non publiées],Libéral,Médecin généraliste,[Données non publiées]
+981415ae-5a8b-4d14-949d-8eec464926ed,[Données non publiées],CDOS 59,Secrétaire,
+98144fcd-a197-4dc1-be2b-7e6406333b6f,[Données non publiées],St-Etienne Métropole,Ingénieur Territorial,
+9816ad93-3193-4da0-9a41-05f464c02aad,[Données non publiées],CABINET LEFÈVRE ET RAYNAUD,AVOCAT,
+98171f27-e24f-48fe-ba96-3658ed5ea40d,[Données non publiées],Mairie [Données non publiées],[Données non publiées],
+981a57b8-d903-4839-a7a4-4366fdc2b0b0,[Données non publiées],ADAPEI ARIA 85,[Données non publiées],
+981a57b8-d903-4839-a7a4-4366fdc2b0b0,[Données non publiées],AUTOENTREPRENEUR,PRESTATIONS DE SERVICE,
+981b6866-dcd8-469b-a533-7912da35c2fe,[Données non publiées],EDUCATION NATIONALE,Professeure des écoles,
+98258255-1012-40f0-bcad-9ce2e87a0126,[Données non publiées],Néant,[Données non publiées],
+98275a95-8eab-4bdc-89c4-f5fa0e8cc6a7,[Données non publiées],neant,retraitee,
+982d851f-4aff-44c0-8d5f-4673854fb892,[Données non publiées],neant,neant,retraité
+98386d0b-b8c7-4499-b7a3-094071727e5f,[Données non publiées],EURL Transport Genest,Gérant,
+98396f80-9869-4fb0-b4a5-67c44c6b714a,[Données non publiées],[Données non publiées],Direction de la sureté région Occitannie,
+983c27bc-1977-4665-bca3-796ac3fcf157,[Données non publiées],SASU [Données non publiées],VENDEUSE DE MEUBLE ET DECORATION,
+98417d10-49da-455e-87a3-48ada54064bc,[Données non publiées],Safran Electronics & Defense,Gestionnaire [Données non publiées],
+984faf55-8ff1-40f7-ba62-dc0af4002f26,[Données non publiées],Médecin Libéral,Médecin Ophtalmologiste,
+985b6ddc-fd24-431e-98ce-5ce7321a5257,[Données non publiées],SELARL IMAGERIE DE LA PORTE DES FLANDRES,Radiologue,
+985b6ddc-fd24-431e-98ce-5ce7321a5257,[Données non publiées],SARL SCANNER DE LA PORTE DES FLANDRES,Radiologue,
+985ba4cc-402e-4782-8a59-6a628c0b3afe,[Données non publiées],Ville du Mans,[Données non publiées],
+985bdf22-6f4b-43c9-835c-5e7f5fe08190,[Données non publiées],SoftNext,Contrôleur financier,
+986780d6-9419-4a36-a38e-b90d204de0b4,[Données non publiées],CH de BLAIN - EPSYLAN,Infirmière [Données non publiées],
+9868a0c6-9681-4650-8f0d-4cbf5c2a7f72,[Données non publiées],lui même,journaliste Président et directeur du journal Le petit mag Lens Liévin exploitant agricole [Données non publiées],[Données non publiées]
+986eb9be-1958-41a1-b8e8-a5ba1e1e1772,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] [Données non publiées] retraite [Données non publiées]
+9891804b-e622-44a9-90c8-f0155744d3da,[Données non publiées],Hôpital [Données non publiées],Directeur Général Adjoint,
+9891804b-e622-44a9-90c8-f0155744d3da,[Données non publiées],Pharmacie [Données non publiées],Président,
+9891804b-e622-44a9-90c8-f0155744d3da,[Données non publiées],Institut Central des Hôpitaux,Membre du conseil de fondation,
+9891804b-e622-44a9-90c8-f0155744d3da,[Données non publiées],Fédération des Hôpitaux [Données non publiées],Membre du comité,
+9891804b-e622-44a9-90c8-f0155744d3da,[Données non publiées],Les Blanchisseries Générales LBG SA,Membre du conseil d'administration,
+9891804b-e622-44a9-90c8-f0155744d3da,[Données non publiées],INSTITUT EN SANTE GENESIQUE WOMEN SAFE & CHILDREN 74,Membre du conseil d'administration,
+9898bbd8-55ac-4b63-ae99-f6778f6a0f0e,[Données non publiées],VILLE [Données non publiées],REDACTRICE,
+989a6865-9edd-491e-8ba5-6543de5edfb2,[Données non publiées],libéral,infirmier,collaborateur en cabinet
+989c1612-ed9e-45bb-a5bb-0d09de9b1862,[Données non publiées],Groupe Saint-Sauveur,DAF,
+989e8834-7987-4d9b-a32e-7702576528bb,[Données non publiées],SCEA [Données non publiées],activité agricole,
+989f52b4-6486-462d-8d0b-48ab43454817,[Données non publiées],Avocat indépendant,Avocat au Barreau de Paris,
+98ad19eb-b842-424c-aefa-c6ad3796d14f,[Données non publiées],Néant,Retraitée,
+98b1f096-1d39-4a30-834a-a249e3a4b2da,[Données non publiées],EDUCATION NATIONALE,PROFESSEUR CERTIFIÉE STG BTS,[Données non publiées]
+98b702cb-02a5-4ba2-a122-bb4082ac8db3,[Données non publiées],Ministère de l'enseignement supérieur de la recherche et de l'innovation,[Données non publiées],
+98bd1d05-4353-4909-b544-d130eba2c6a9,[Données non publiées],GCSMS INTEGRATION,Pilote MAIA,
+98e9d259-6ad2-40e9-ba23-9506db1985d2,[Données non publiées],[Données non publiées],Retraité,
+98ef2cd4-1b19-478d-acb4-73a64292c892,[Données non publiées],Profession libérale,Avocate,
+98f417f0-1644-4563-8704-4b3288290143,[Données non publiées],NEANT,NEANT,[Données non publiées]
+98f79d86-3cee-47e5-b7e7-9349bd170266,[Données non publiées],Education Nationale,Professeur de Philosophie [Données non publiées],
+98fc1ec2-8de5-4c52-916b-a9561b25cd91,[Données non publiées],Unec [Données non publiées],Secretaire générale,
+98fc6f9b-4803-48f8-8c0c-3d74fcbe4d6e,[Données non publiées],cgfi,CONSEILLER FINANCIER,
+990aa0fc-52d0-4818-b698-44003b766103,[Données non publiées],CNAM,Directricedéléguée,
+9913cb55-e2c4-4beb-8929-0be9bed53265,[Données non publiées],Communauté d'Agglomération de blois: Agglopolys,Ingénieure principale,
+9920cf61-422f-49c8-ab08-30e147f688b4,[Données non publiées],SARL MAGASIN MAEVA,épicerie [Données non publiées],
+9920cf61-422f-49c8-ab08-30e147f688b4,[Données non publiées],PENSION [Données non publiées],Pension de famille,gérante et propriétaire
+9934a75c-f7a4-470d-b281-623044d4cec6,[Données non publiées],Groupe Thivolle,[Données non publiées] [Données non publiées],[Données non publiées]
+99351ffd-dd22-46e5-8c39-ae3ef360546e,[Données non publiées],Education Nationale,Professeure des écoles,
+99449348-42bf-4997-bd73-902e92be7d08,[Données non publiées],BCI BUSSIERE,Employée,
+995bb93c-3e75-4ceb-9604-811fcbccab0c,[Données non publiées],OMS Genève (Suisse),Employée,
+9960de50-48ee-4945-b9e2-4820329fc605,[Données non publiées],CNRS,Chargée de communication,
+99623141-6447-4d92-8dc9-0a4ef10ae531,[Données non publiées],Département de Loire-Atlantique,Attaché Territorial,
+9962802d-05f9-4b00-8f4b-b2e0b15ef4cc,[Données non publiées],[Données non publiées],Neurologue,
+9963ef5f-61c3-4bc7-98fb-939726fb35a2,[Données non publiées],EHPAD [Données non publiées],Adjointe aux cadres,
+9963f426-fc80-404e-b167-64a7240aa562,[Données non publiées],Retraité,néant,
+998fac3d-7fbe-4104-a1bb-b6c7a8dc5d5c,[Données non publiées],EDUCATION NATIONALE,PROFESSEUR,RETRAITEE [Données non publiées]
+999524b2-c6ca-4f12-8b53-e4490eb58c5c,[Données non publiées],néant,Retraitée,
+99ab744a-ea75-420d-8a3b-e54e49ea30c8,[Données non publiées],neant,NEANT,RETRAITE
+99b46254-7049-4ed7-8576-c58a1654bac1,[Données non publiées],MARS CHOCOLAT FRANCE,Chef de secteur expert,
+99b475ba-2ca4-4e78-9bcf-e3b4f45ccc4c,[Données non publiées],MABEO industrie,technico commercial,
+99bcf0f9-5d60-427e-9971-22214c503b99,[Données non publiées],SCEA [Données non publiées],Exploitant agricole [Données non publiées],[Données non publiées]
+99dac1a7-9cda-43a3-a812-b0ef6e7f3f23,[Données non publiées],Education Nationale,Retraitée,
+99e76e31-6136-49f2-a8b7-b0b9509a776b,[Données non publiées],Néant,Retraité,[Données non publiées]
+99f6bbf9-a44d-45c8-9c61-a62b7679476c,[Données non publiées],SCEA [Données non publiées],activité agricole,
+99fce94d-5331-40a5-a060-5d7cd7dad6a7,[Données non publiées],RETRAITE,retraité,
+9a152e3e-7b4a-4354-8a9d-640eb1d39863,[Données non publiées],Société Générale,Cadre bancaire,
+9a194255-c8ec-4066-9d19-ad75a4dab8fd,[Données non publiées],Nouvelle Région Aquitaine,[Données non publiées],
+9a1c2633-be99-4c22-8999-23511fbc9471,[Données non publiées],auto entrepreneur,"artisan, second oeuvre",
+9a2cca6f-eec5-48d2-ab94-7db864b69592,[Données non publiées],Etablissement Public Départemental de l'Enfance et de la Famille,Assistante Socio-Educative,
+9a355ffd-c786-4cd4-877c-a69fbb9cfd65,[Données non publiées],Onrangetout,Gérante [Données non publiées],
+9a45cd01-f42a-4c1f-be80-4819f9e9eb9d,[Données non publiées],aucun,néant,[Données non publiées]
+9a5d4d9f-9ebb-42d4-b593-ca0c6f42721c,[Données non publiées],SUEZ,[Données non publiées],
+9a797d11-2c91-45cf-be33-0641f0943f82,[Données non publiées],SOLARINOX,COMMERCIAL,
+9a79c3bc-0d07-47a3-b747-f51fd1f67db9,[Données non publiées],CCAS [Données non publiées],directrice de la pouponnière [Données non publiées],[Données non publiées]
+9a842974-d30c-4737-a932-288182db97c3,[Données non publiées],CENTRE HOSPITALIER [Données non publiées],Aide soignante,
+9a85d1c6-e9ee-40ec-9d23-fed6d3181481,[Données non publiées],Université [Données non publiées],Professeur Agrégé,[Données non publiées]
+9a93bd05-1dad-4fcf-8999-16c9ad6e2fe1,[Données non publiées],AXA FRANCE IARD / VIE-AFI,chargé de clientèle,[Données non publiées]
+9a95131f-07d6-43ba-9e90-5d732ee7a0ab,[Données non publiées],néant,néant,
+9a98fe38-46a3-49af-a32c-a6cb4c072382,[Données non publiées],Avocate/ Centre de Formation,AvocateEnseignante,
+9a9e5760-2ffc-47b9-af7c-83544cca200b,[Données non publiées],Néant,Maire [Données non publiées] et Vice Présidente de la communauté de communes [Données non publiées],
+9a9fe5f1-fa5f-460d-b29d-6e85e4a0cef6,[Données non publiées],Néant,Retraité,[Données non publiées]
+9aa9100b-9007-4203-9beb-35a7bb9b273c,[Données non publiées],[Données non publiées],[Données non publiées],Retraité [Données non publiées]
+9aaccffc-3fe2-4588-a1e5-e7bdfa63a6ca,[Données non publiées],BANQUE POPULAIRE DU SUD,CADRE DE BANQUE,
+9aad85c2-3d21-4d89-9151-aa38e396fec7,[Données non publiées],Profession libérale,Avocate,
+9ab4dc9f-35b0-4cfd-8483-216def85b2a4,[Données non publiées],Polynesie Française,Comptable,Fonctionnaire de la fonction publique territoriale [Données non publiées]
+9ab9c5b8-f0a4-47d2-8ede-d565837b5596,[Données non publiées],Préfecture de l'Oise,Attachée principale [Données non publiées],
+9acbd316-26fa-4042-bf4d-1bb163701443,[Données non publiées],[Données non publiées],Notaire,
+9ad7a627-a08c-4419-9c39-9a0c51d06bef,[Données non publiées],Banque Rhône Alpes,Employee de banque,
+9ad7e79a-2e11-41d8-af7a-243a899f2ff9,[Données non publiées],MAERSK FRANCE,EMPLOYE DE CONSIGNATION,
+9adaf203-7419-4e70-beb8-f7bd8e8d8da3,[Données non publiées],Retraité,[Données non publiées],
+9add188a-4c88-47f7-acef-33e0df859e3f,[Données non publiées],retraitée,[Données non publiées],
+9ae5091e-a079-4960-b105-c85899d5e229,[Données non publiées],guidewire,senior business analyst [Données non publiées],
+9ae7414d-72ed-4c49-96de-b55be133f419,[Données non publiées],Centrakor,vendeur,
+9ae9474e-04bc-4648-90d1-0573242915e9,[Données non publiées],SYNALIA,[Données non publiées],
+9af5afb8-34c8-4f3e-911a-6094232b997a,[Données non publiées],Education Nationale,enseignant,
+9afb2d74-a204-412d-b6ca-dc608772bcce,[Données non publiées],SARL PIERROT SPORTS,Responsable de magasin,
+9afb8e22-c57c-40c6-b8dd-7573f99a1e60,[Données non publiées],CNRS,Chargé de recherche puis directrice de recherche,[Données non publiées]
+9afe42ba-9657-4a0d-8806-16f01556b460,[Données non publiées],Paris ouest veto,[Données non publiées],[Données non publiées]
+9b16840c-fead-424f-87c8-284dfdbf962c,[Données non publiées],Retraite,NEANT,
+9b1af0e1-7bf7-4d8a-9771-96dd2f93c59b,[Données non publiées],Micro-entreprise,Gérante. Activité de conseil de gestion en entreprise.,
+9b23c303-333d-418b-aad9-9b055ba82241,[Données non publiées],Néant,retraité,
+9b285fc6-47b1-451d-ab0b-0580ae97afc8,[Données non publiées],Société de transport du Grand Angoulême,Responsable atelier [Données non publiées],
+9b3720b7-8372-4f77-8cce-e3969fff6561,[Données non publiées],Ville d'Evry-Courcouronnes,cabinet,
+9b376b32-078a-4067-9225-ce76134d175b,[Données non publiées],Association France Handicap APF,psychologue [Données non publiées],
+9b376b32-078a-4067-9225-ce76134d175b,[Données non publiées],auto-entrepreneur,psychologue clinicienne libérale [Données non publiées],
+9b4784ae-b341-49dc-9d25-65d02e6bb8a4,[Données non publiées],ENTREPRISE INDIVIDUELLE,Artisan menuisier,
+9b49f802-82af-4e08-8e63-73a4b51f00b6,[Données non publiées],Lafarge Ciments,[Données non publiées],"Dans les diverses fonctions et postes que mon épouse a occupés au sein de Lafarge Ciments, elle n’a jamais été en position, ni susceptible d’entretenir des relations avec le département, la commune de La Couronne, la région Nouvelle Aquitaine ou le GrandAngoulême. Ses fonctions ont été uniquement techniques au sein de l’usine de La Couronne depuis 1980, [Données non publiées] Elle n’a occupé aucun poste de commercial ou de négociations de vente la mettant en relation avec l’extérieure. Les fonctions exercées par ma conjointe ne comportaient aucune fonction de représentation ni de direction de la société Lafarge Ciments. Elle a par ailleurs détenu aucun mandat ou pouvoir de gestion, d'administration ou de direction de ladite société, en raison de ses fonctions. Outre le fait que ses fonctions relevaient du champ technique (hygiène et sécurité), elle n'était donc pas en capacité juridique d'engager la société dans ses rapports avec les tiers. Lafarge Ciments a été racheté par le groupe HOLCIM en 2015 et produit 190 millions de tonnes de ciments dans le monde essentiellement pour la construction et non pour les voiries. Le process de fabrication a été arrêté en novembre 2016 à l’usine de La Couronne. [Données non publiées] . Je n'ai pas connaissance de relations contractuelles nouées entre le Département de la Charente et la Société Lafarge Ciments Au vu de ce qui précède, il n'apparait pas nécessaire de mettre en place des mesures de déport particulière. Les collectivités quelles qu’elles soient ne sauraient entretenir des relations commerciales directes avec le cimentier Holcim-Lafarge ou précédemment avec Lafarge ciments puisqu’elles ne sont pas clientes en directes. Une collectivité n’achète pas en directe du ciment car elle n’en consomme indirectement qu’au travers ses marchés publics pour ses investissements. Les autorisations d’exploitation notamment pour les extensions de carrières (extraction du calcaire pour la fabrication du clinquer) sont délivrées par le préfet du département. La commune est seulement appelée à émettre un avis sur la demande de l’industriel. Ce fut le cas en 2010 et en tant que maire de La Couronne, je n’ai pas pris part au débat ni au vote puisque mon épouse était salariée de l’entreprise. En tant que maire de La Couronne, j’ai pris la décision de ne pas prendre aux votes concernant des délibérations ou avis sur la société Lafarge. C’est ainsi que je n’ai pas pris part au débat ni au vote sur l’avis de la commune concernant le dossier d’approfondissement de la carrière de calcaire de Lafarge à La Couronne. Le conseil municipal n’était consulté que pour avis puisque c’est le préfet qui donne son autorisation d’exploitation par arrêté."
+9b49f802-82af-4e08-8e63-73a4b51f00b6,[Données non publiées],LAFARGE HOLCIM,[Données non publiées],[Données non publiées] à la retraite depuis mars 2022
+9b49f802-82af-4e08-8e63-73a4b51f00b6,[Données non publiées],CCI Formation Charente,Formation professionnelle à destination des jeunes apprentis du campus des métiers de la Charente.,[Données non publiées]
+9b4b50cc-2c3d-4438-aefc-48d35b6d0c80,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] Société Aménagement et Territoire [Données non publiées]
+9b599c53-4e3b-41ed-8f9a-5be8fd679221,[Données non publiées],Theis Avocats,Avocat,
+9b6255fa-9929-4e60-b723-c0779bb4b459,[Données non publiées],auto entrepreneur,professeur de langues,
+9b62cefe-1593-41a8-b655-8e5b47259172,[Données non publiées],Rectorat d'académie,Enseignant,
+9b652f84-a095-4dd3-b391-f330ce844b1c,[Données non publiées],CHU,Laborantine,
+9b74bf2f-2dbe-4b12-b08c-7b317c1d38d2,[Données non publiées],HOPITAL DE MULHOUSE,[Données non publiées],
+9b76c0c8-1f7d-4340-972d-c70b2fb23848,[Données non publiées],HYGIENAZUR,RESPONSABLE D'ETABLISSEMENT,
+9b7c1e93-1e3b-4d29-8477-8898c2946328,[Données non publiées],Université [Données non publiées],enseignante,[Données non publiées]
+9b85da03-f6db-4405-a863-f795b09aea9f,[Données non publiées],CD,contractuelle ADE,
+9b8795cb-dae7-42b8-a6c5-455a6e728ef7,[Données non publiées],[Données non publiées],Pharmacien titulaire d'officine,
+9b95be17-033f-4d60-8b7a-f3d0efa79536,[Données non publiées],néant,néant,
+9b9b47ae-24ef-42ea-9302-85076265fd54,[Données non publiées],Reconquête,Fondateur et Président,
+9b9f7460-3e35-4863-82af-a9a3517b5cb4,[Données non publiées],neant,retraitée,
+9ba68683-6e6c-458e-a2ea-0dec404f55eb,[Données non publiées],Université Nice [Données non publiées],Maître de conférences des facultés de droit,
+9ba966bf-2460-46c4-9498-19a8bb487363,[Données non publiées],REGION REUNION,FONCTIONNAIRE TERRITORIAL,
+9bb8dfba-18e4-47f9-a22f-eadc068c26d9,[Données non publiées],Conseil de l'Europe,Cheffe du service [Données non publiées],
+9bbc61e2-ae34-4cf5-b380-8eae3f2f5d02,[Données non publiées],Retraitée,aucune activité,
+9bbfaf2e-91a5-4a42-8a02-dfce279d2dd3,[Données non publiées],Caisse d'Epargne [Données non publiées],conseil en gestion de patrimoine,
+9bc5466e-62f0-48cc-ac5a-07623c21f07e,[Données non publiées],TSA Elec [Données non publiées],Commercial,
+9bd446b1-e37b-47d5-b239-d3ef94470bab,[Données non publiées],SARL [Données non publiées],Gérant de la société SARL [Données non publiées],travailleur non salarié
+9bd73442-16f8-43e4-9689-0b9262ea2e4d,[Données non publiées],SNCF,Agent de voie et de manœuvre au fret,
+9bec22ff-fc1b-4a10-9275-5812103f510c,[Données non publiées],Néant,Co gérant [Données non publiées],
+9becce09-2f12-42e0-ad78-5418329dc8c4,[Données non publiées],neant,Neant,
+9bef07ad-d6b6-4343-83f6-9603d3be0718,[Données non publiées],neant,neant,
+9c00a64c-b8cf-4b5b-87d4-b55df39e1539,[Données non publiées],[Données non publiées],Administrateur Réseau,
+9c063874-da20-4a2f-88b9-2ffd1b8cb904,[Données non publiées],Education Nationale,Professeur des écoles [Données non publiées],
+9c064bc1-6819-4203-907e-72891f9ad676,[Données non publiées],[Données non publiées],[Données non publiées] - retraitée,
+9c0f65f6-eb5b-43d0-afc3-dbc941455138,[Données non publiées],Education nationale,AESH,
+9c1cf011-94ea-4adb-8835-04978ad82b40,[Données non publiées],SAS Fertiléo,[Données non publiées],
+9c2a555e-caea-47d2-9316-d98d53a75b13,[Données non publiées],STMicroelectronics Tours SAS,Ingénieur,
+9c2cae02-3300-48ab-a3f6-68118ee717e8,[Données non publiées],retraitée,aucune,[Données non publiées]
+9c2ec401-3cb5-42ac-be9c-6e18fa605ad5,[Données non publiées],[Données non publiées],responsable gestion dossier production,
+9c3ca03a-5a04-401f-8b30-13b5d2ade855,[Données non publiées],Mairie du Coteau (42120),Maire,[Données non publiées]
+9c3d6cea-e130-4595-85cc-b1285bd18381,[Données non publiées],Néant,[Données non publiées],[Données non publiées] retraité [Données non publiées]
+9c3f4ed1-df66-47da-beca-16d9e94d4a29,[Données non publiées],Neant,Neant,
+9c3f5404-dc92-47da-92da-dd2e453a46f5,[Données non publiées],néant,Néant,Retraité du BTP
+9c402dc0-9481-4f5d-b429-40e69620937f,[Données non publiées],elior,serveuse,[Données non publiées]
+9c4eb824-6ba9-4542-a704-8958b14ac718,[Données non publiées],Earl [Données non publiées],EXPLOITANTE AGRICOLE,[Données non publiées]
+9c599eda-2c68-46f4-9a7a-fea580c3b084,[Données non publiées],UGECAM Lille,[Données non publiées],
+9c5b00b0-12d2-47ce-b1a0-f9c8763cdd1d,[Données non publiées],Mission locale Bourgogne nivernaise,Conseillère en insertion professionnelle,
+9c5d562e-fff0-4228-b42f-6dfcc8c60554,[Données non publiées],Procivis Maisons Individuelles,Assistante de Direction,
+9c62c015-9534-4614-931d-ea577a2a55d9,[Données non publiées],CNRACL,[Données non publiées] Retraité sapeur-pompier militaire de Paris,
+9c74a9ce-81b5-420d-9131-659e2db337cd,[Données non publiées],néant,Néant,
+9c841da6-fe1a-4d5f-88f2-a2475ad9c150,[Données non publiées],SARL [Données non publiées],SALARIE ASSISTANTE ADMINISTRATIVE,
+9c928e68-b776-411d-8c53-e0b7db89a62b,[Données non publiées],PSA AUTOMOBILES,Agent professionnel,
+9c9e23fa-f0be-4a47-bd63-7eeee0551d37,[Données non publiées],Laboratoire Defrance - Maison de Santé du Pays Neufchâtelois - [Données non publiées],Secrétaire Médicale [Données non publiées],
+9ca36bcf-a34b-4375-8ca4-de0a755c58a9,[Données non publiées],VILLE [Données non publiées],Attaché principal,
+9ca7e853-5995-4e0d-9bbd-d44d0a3e478c,[Données non publiées],DK Propre,Agent d'entretien qualifié.,
+9ca96a78-641d-47f8-b95b-5336ce900b7f,[Données non publiées],SARL [Données non publiées],Gérante non salariée,
+9cac0f48-df28-4258-981a-4a82151eef37,[Données non publiées],néant,néant,
+9cb02427-7811-4ae4-bcd7-9fdb5251a7c3,[Données non publiées],EDF,CHEF DE GROUPE [Données non publiées],
+9cb76ac4-739a-4c02-b06f-4e4e702848e5,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] n'occupe plus cet emploi [Données non publiées]
+9cb818c1-769e-41d4-9beb-f0389ee4f5ff,[Données non publiées],Etat,Professeur des écoles,
+9cba0aba-8f0f-46ef-812a-2ec8bcdbe5e7,[Données non publiées],Centre Hospitalier de Cayenne,Directrice; de [Données non publiées],
+9cbbafc2-f78c-48f2-b365-29d3e17dba61,[Données non publiées],MMA IARD,Responsable Conseils juridiques. [Données non publiées],
+9cc7d9c8-5eba-4549-9e3a-139799a5e3d9,[Données non publiées],SARL APREV,[Données non publiées],
+9cca6f78-7489-4b6b-b74d-1b7c160bb29c,[Données non publiées],CPAM du VAL D'OISE,Technicien de maintenance informatique,
+9cd03e12-ed04-4eaf-88b3-357138f0ad82,[Données non publiées],CC de la plaine dijonnaise,Adjoint d'animation,
+9cd03e12-ed04-4eaf-88b3-357138f0ad82,[Données non publiées],[Données non publiées],Assistante maternelle,
+9ce0d4db-5e4c-4b17-b6bb-6e0a2995caf6,[Données non publiées],Education Nationale,inspecteur,
+9ce43551-7181-4135-a1d9-8d9de42e9e3e,[Données non publiées],Fondation COS Alexandre GLASBERG,Directeur d'établissement de santé privé non lucratif. [Données non publiées],
+9ced8853-0060-4557-8762-6c1fa1c15540,[Données non publiées],Conseil de l’Ordre des médecins,[Données non publiées],Retraitée active [Données non publiées]
+9d04846a-dab1-497e-891d-6e2c6692ea2d,[Données non publiées],Neant,Neant,
+9d07af70-8885-47d8-b5af-e7f10a7f9d4d,[Données non publiées],Mairie de Papeete,[Données non publiées],
+9d09646b-5adf-4e63-88e9-f957d0027dbb,[Données non publiées],GuidiGO Europe,Gérant non rémunéré,
+9d0988d1-1618-431d-9b9b-ad444d312a7b,[Données non publiées],Néant,Retraité,
+9d0df5df-d8d7-4c21-b589-f7d109c5acb2,[Données non publiées],néant,néant,Retraitée
+9d134ced-e813-4c78-bba0-50f4e902b958,[Données non publiées],Ministère de l'Education Nationale,IA-IPR [Données non publiées],
+9d1ae168-097b-47fd-8a03-cccbe8fb2f78,[Données non publiées],Safer [Données non publiées],Chef de projets,
+9d1b6f69-c9db-4b68-9926-8a07f4612faa,[Données non publiées],CAMG,[Données non publiées],
+9d1eb98d-b00e-44ba-9316-eb36945a9c2f,[Données non publiées],APHM,Cadre superieure de santé aux hopitaux publics de Marseille,
+9d23f514-2597-4945-b43f-254e3491c840,[Données non publiées],EDUCATION NATIONALE,Proviseure adjointe,
+9d24c723-a521-4cb9-9075-a5acba22c592,[Données non publiées],AFEV,Responsable [Données non publiées],
+9d2beb90-7fa7-401d-a2d2-7033905e183a,[Données non publiées],Néant,Néant,[Données non publiées]
+9d3164f7-86f3-4b8a-8313-7caffb790b7c,[Données non publiées],Etat,Retraité militaire [Données non publiées],
+9d350cbf-5fec-4adf-b0f7-aa99c410b649,[Données non publiées],[Données non publiées],[Données non publiées],
+9d37172f-d5ce-46c3-8c34-124322b68b2e,[Données non publiées],ADIL [Données non publiées],[Données non publiées],
+9d3af5d6-25a3-4591-b7f2-e2d637009699,[Données non publiées],Sans activité à la date de l'élection,Sans activité à la date de l'élection,
+9d3c15b2-e418-4607-ae09-ef8f6d616c0a,[Données non publiées],ORPAN,Chargé de mission,
+9d40b172-3c91-493b-8d00-23586e21576f,[Données non publiées],[Données non publiées],[Données non publiées],
+9d414d7a-0c91-41b7-bc32-c17ed9659bb4,[Données non publiées],Education nationale,professeur d'Histoire-Géographie,
+9d4a3fd9-a55a-4c9b-be2a-562afbfc8985,[Données non publiées],SEARL [Données non publiées],Secretaire juridique,
+9d4fcf7c-9c47-4f2b-8d12-564703b48e07,[Données non publiées],ADIL 74,Directeur de l'antenne départementale [Données non publiées],[Données non publiées]
+9d50fb4e-664b-4303-b7b9-e6dff5bb63ee,[Données non publiées],EDUCATION NATIONALE,Professeur d'Economie,
+9d5ed04f-686e-4e6a-a692-4796e114a06c,[Données non publiées],Artiste,Artiste plasticienne,
+9d5ed04f-686e-4e6a-a692-4796e114a06c,[Données non publiées],SAS HALMAHERA,Présidente,
+9d65a3bf-31a3-42ee-9c48-b27c44ee9c69,[Données non publiées],Ministère de l'Intérieur,Préfet de département,
+9d6cdc09-86a2-4d8d-9384-b9ba974214c2,[Données non publiées],VILLE D'ARRAS,ELECTRICIEN,
+9d6e01a0-4659-43b9-b7a5-3a19d0370428,[Données non publiées],Conseil Départemental de l'Isère,[Données non publiées] Fonctionnaire territoriale.,[Données non publiées]
+9d70afdf-3338-4f37-b128-1d2057304658,[Données non publiées],Centre-Sevres-Faculté-Jésuite-de-Paris,doctorat-en-théologie,[Données non publiées]
+9d7558b9-9f0f-4589-bc97-322452907e3d,[Données non publiées],MINISTERE INTERIEUR,SECRETAIRE ADMINISTRATIVE PREFECTURE VAL D OISE,
+9d79670b-db41-4fbe-bee4-e244fb3c2462,[Données non publiées],CGT,Administrative,
+9d7d37c2-92ce-441d-9610-ae9e5df50ccf,[Données non publiées],Artisan - Individuel en nom propre,Plombier-Chauffagiste,
+9d81f198-2ae7-41bf-81ce-d4de19df4832,[Données non publiées],CPAM 93,Cadre de la fonction publique,
+9d88c289-ccb9-46dc-96ff-c1e4d23385a7,[Données non publiées],Sénat,Conseillère des services du Sénat,
+9d892850-d633-4ac3-86e0-818dc1a44c17,[Données non publiées],SAS [Données non publiées],Président de cette société qui a pour activité le Conseil en Gestion de Patrimoine,
+9d957c71-16e9-42e6-ab0e-22ce7acd7484,[Données non publiées],Avermes Distribution,Employée de Commerce,
+9d98ea52-a35c-445b-a96b-ae4d1daeee48,[Données non publiées],[Données non publiées],graphiste,[Données non publiées]
+9d9bd037-6ef9-43ec-b3a0-d39a21eb186a,[Données non publiées],Assemblée Nationale,Député [Données non publiées] et Notaire,[Données non publiées]
+9d9c802c-0b3a-4d74-afce-cfbba541c8e0,[Données non publiées],Etat,Retraité de l'Education nationale [Données non publiées],
+9da17e3e-c655-4cf9-a1cf-f14602aec614,[Données non publiées],[Données non publiées],Clerc de notaire,
+9da28fdd-b0c9-493a-bd16-5c7d6c8be702,[Données non publiées],Chambre d'Agriculture des Deux-Sèvres,Conseillère agricole [Données non publiées],
+9dc24727-bdec-4195-8a34-f383d11b128f,[Données non publiées],Retraitée,Retraitée,
+9dc7b163-0fbf-4e03-b8bf-05d2841594a1,[Données non publiées],APHP [Données non publiées],médecin,
+9dde49fd-5d00-471a-89a3-e98a027c1a3b,[Données non publiées],Néant,Retraitée,
+9de3c8f9-5d4a-4d25-a740-03f313ec52e0,[Données non publiées],Ville de Saint-etienne,[Données non publiées],[Données non publiées]
+9de59c7c-4954-4325-955f-ac14242547de,[Données non publiées],[Données non publiées],Directeur général,
+9df322b6-5f92-454b-8650-487793d53154,[Données non publiées],Etude notariale de [Données non publiées],Notaire salariée,
+9df50920-b9f0-4412-a691-958cd1f5d76a,[Données non publiées],conseil départemental Aude,[Données non publiées],
+9df808a4-b389-4b7c-8719-d5d62671b7a4,[Données non publiées],Location meublés non professionnel,Chambres d'hôtes,
+9dfbfa64-0214-4873-b43c-c5be7058039f,[Données non publiées],Groupement Hospitalier [Données non publiées],Assistant de direction,
+9e035962-0f7d-4f00-9fa1-0130d86b8014,[Données non publiées],TEMM CONSEIL,Gérante,
+9e07319e-2404-4eb9-99a1-6b356090b99c,[Données non publiées],office de tourisme d'Ax les Thermes,retraitée,
+9e1d9370-3f71-4453-8a47-66241b009c00,[Données non publiées],NEANT,NEANT,RETRAITEE
+9e1d9370-3f71-4453-8a47-66241b009c00,[Données non publiées],[Données non publiées],[Données non publiées] NON-EXPLOITANTE AGRICOLE ET RETRAITEE DU REGIME GENERAL,[Données non publiées]
+9e24ddbd-9a39-4c0d-8abe-03201ef541dc,[Données non publiées],Moteur s'il vous plaît Production,Actrice réalisatrice et productrice.,
+9e2900a7-ce35-47bc-9255-7d79d2b333b3,[Données non publiées],[Données non publiées],secrétaire comptable,
+9e2aa58d-36d2-4c14-9fff-ee1d99029b34,[Données non publiées],Retraité + Auto-entrepreneur,[Données non publiées] auto-entrepreneur (ingénieur-conseil en télé-communication).,
+9e4513f2-a854-48b8-955e-83e739a95f5c,[Données non publiées],néant,retraité,
+9e4828d1-4719-44fc-9ce7-df2023777441,[Données non publiées],Gaec [Données non publiées],Co Gerant du gaec [Données non publiées],
+9e48c340-349f-47f5-85e1-68b5c6705361,[Données non publiées],Nespresso France,"Cadre commercial, responsable de secteur [Données non publiées] pour les établissements de débits de boissons, hôteliers et de restauration.",
+9e6c1a42-dac0-452b-a473-9abd40a7cda1,[Données non publiées],AHM,Dirigeant de l'entreprise [Données non publiées],
+9e76fdb7-f7d1-41b5-9ec8-fe085deedae8,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+9e76fdb7-f7d1-41b5-9ec8-fe085deedae8,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+9e80f430-aeef-4472-ba02-d4d073477efc,[Données non publiées],CEA,Physicienne,
+9e8199f4-3950-4b64-9243-e9fb054e082d,[Données non publiées],GROUPE IGS,[Données non publiées],
+9e912d7c-11a7-4c0b-b3a4-75387526a86f,[Données non publiées],Néant,Néant,[Données non publiées]
+9e9f182e-858b-466a-8f1d-0137acc18a8b,[Données non publiées],Le Point,[Données non publiées],
+9ea6d89a-9985-4791-853f-f47252d3376a,[Données non publiées],[Données non publiées],deviseuse dans une imprimerie,[Données non publiées]
+9ea6d89a-9985-4791-853f-f47252d3376a,[Données non publiées],[Données non publiées],Deviseuse en imprimerie,[Données non publiées]
+9eb2a5d8-0f48-4644-909d-921f2173567d,[Données non publiées],Néant,Retraité,
+9eb484a6-aae0-470e-983c-fbfb68b2821e,[Données non publiées],Commune de vêtre sur Anzon,[Données non publiées],
+9eca7744-ae5d-4179-a2f1-70368645c898,[Données non publiées],CONSEIL REGIONAL DES HDF,CONSEILLIERE TECHNIQUE AU CABINET DU PRESIDENT [Données non publiées],
+9ecaf15c-5c8d-41e0-b98a-4c4d195a75e3,[Données non publiées],[Données non publiées],technicienne de laboratoire,
+9ed4d5b8-d337-4713-ac42-87f2130753dc,[Données non publiées],[Données non publiées],Société d'Investissement,[Données non publiées]
+9edda008-96ac-4b5a-a8ee-6c1c56d67a9d,[Données non publiées],CLS_EVENT,COMMERCIALE,
+9ef2ceb6-0168-47be-b8aa-71e2a70ba61b,[Données non publiées],Ministère de la Culture,Conservatrice du patrimoine,
+9ef9bbd8-b7d6-444f-b0c5-20dc00c0293e,[Données non publiées],[Données non publiées],Ingénieur dans le domaine des technologies médicales,[Données non publiées]
+9efd2edf-bcd9-4749-baa7-62c5db2e694e,[Données non publiées],avocate associee,Avocate,
+9f08112c-c5c9-4cda-917e-3461729419f3,[Données non publiées],retraitée,néant,
+9f204855-472f-4f11-96d5-d857d383f5c8,[Données non publiées],Néant,Néant,
+9f2c4684-d908-46d3-a77f-07c55cd8c1fd,[Données non publiées],NEANT,NEANT,
+9f330e46-11bb-40b8-a006-3736168acb63,[Données non publiées],Education nationale,Enseignant,
+9f353ce4-6f02-4f33-91d5-e0d7d5b9fde6,[Données non publiées],[Données non publiées],agence immobiliere,
+9f38740e-a5c2-47fc-95f3-fe22c5298577,[Données non publiées],AUTO ENTREPRENEUR,NETTOYAGE BATIMENT,
+9f3a5091-00a8-496e-94cb-a95af580c892,[Données non publiées],retraité,retraité,[Données non publiées]
+9f65c2bc-0c43-433c-acad-8fc131adf2c3,[Données non publiées],Sarlat Moto Service,vendeur,"Il est également déclarer en tant que indépendant, pour activités animateur speaker sur certaines manifestations."
+9f691508-0c1a-4384-90f0-b4d7c79851d7,[Données non publiées],1001VIESHABITAT,BAILLEUR SOCIAL,
+9f69a53b-5091-4569-9461-8761b9d1f1ca,[Données non publiées],néant,néant,
+9f6d7d1d-78c2-42fa-a783-691bb0715d71,[Données non publiées],Société Générale,Cadre bancaire,
+9f70bb3d-29c7-4a9e-b8ff-c955e84a1408,[Données non publiées],NSK,DIRECTEUR COMMERCIAL EUROPE,[Données non publiées]
+9f78504c-71d2-4079-8552-5d82b45dd960,[Données non publiées],CH de [Données non publiées],Médecin gériatre - chef de service.,
+9f7b6bf9-f1fe-4e1c-a9bf-6b4d0795defb,[Données non publiées],activite liberale,Avocat [Données non publiées],
+9f7db98e-3be7-4bee-b2c6-aa474b397456,[Données non publiées],SAS SEBADIS,[Données non publiées],
+9f83eb31-befc-412b-8463-35ad11bcc266,[Données non publiées],Education Nationale,Professeur des écoles,
+9fa538f0-2759-4d39-937b-4f8019132189,[Données non publiées],Alliance distribution,[Données non publiées],
+9fc19d4e-42c3-4ad7-b797-35f1d343f09b,[Données non publiées],Groupe Austral Assistance,Manager de plateau d'assistance en télécommunication,
+9fc311e0-eeab-4fcd-a238-357f742efe0b,[Données non publiées],SWISS-LIFE Compagnie d'Assurances,[Données non publiées],
+9fcc2461-cc5e-4055-9ace-e7b63c0cc65a,[Données non publiées],Education Nationale,Professeure [Données non publiées],
+9fcd5790-42d0-4d85-8dc5-c99bebe0748c,[Données non publiées],SOCIETES [Données non publiées],Agriculteur,[Données non publiées]
+9fcdf20c-6e7e-4b5f-995a-ef779b84662b,[Données non publiées],Groupe Alternance Nancy,"Formatrice, responsable pédagogique",
+9fd46596-48d4-49e7-8ecb-aa62db3aa0bd,[Données non publiées],Gérant,SARL.Activité exercée: sécurité privée,
+9fe86cbb-5806-4803-a04c-73d30d69cf2c,[Données non publiées],Entreprise individuelle,Commerçant - Agence de Publicité,Arrêt de son activité au 31/07/2021 - [Données non publiées]
+9ff2ae77-8370-4ecd-a57d-22ad19c4fcb2,[Données non publiées],MAIRIE DE SAINT-PIERRE,DIRECTEUR [Données non publiées],
+9ff9296c-794c-4a16-aca6-bc432629d323,[Données non publiées],[Données non publiées],GERANTE D'UNE EXPLOITATION AGRICOLE,
+9ff9296c-794c-4a16-aca6-bc432629d323,[Données non publiées],FRUTICOR,RESPONSABLE DEVELOPPEMENT FRUITS SECS,
+9ffc2f8c-24d0-4ac3-8201-7b8e58b0b739,[Données non publiées],ASSOCIEE DE GAEC,AGRICULTRICE,
+a001faad-24b0-4957-aeaf-4fc97d78a02b,[Données non publiées],ARS Bretagne,Directeur-adjoint [Données non publiées],
+a002a2d1-9927-4d14-b17c-aa7ae68169f2,[Données non publiées],COVEA,MANAGER [Données non publiées],
+a012ff0e-b4ce-48f7-b7e6-867f13221254,[Données non publiées],EPDSM,Assistante de Service Social,
+a025d908-3829-4b22-9ca0-2ef6ab6bc1f6,[Données non publiées],Kaleido'scop,[Données non publiées],
+a03ce5cf-af13-4ce6-a805-7d0ddcb608b3,[Données non publiées],EDUCATION NATIONALE,PRINCIPAL D'UN COLLEGE,
+a0539b2c-d224-4155-91c9-56a2513ba33f,[Données non publiées],retraitee,fonctionnaire territorial,
+a063c2f3-ae68-4295-81c1-990968d80d2b,[Données non publiées],Entreprise individuelle,Infographiste,
+a06f6f0f-5ca3-42cf-b486-8e38b50c20eb,[Données non publiées],[Données non publiées],Technicien informatique,
+a0708973-a6ba-404e-95ee-8f870189539d,[Données non publiées],CCAS [Données non publiées],Directeur de crèche,
+a07b9484-440d-4195-8977-ecfc379240bc,[Données non publiées],FIDUCIAIRE COMPTABLE NC,[Données non publiées],
+a08b9e9f-1a5c-46ad-955e-b569c9308724,[Données non publiées],TDL Ingenierie,Secrétaire [Données non publiées],
+a0939c00-edd4-4174-b8f9-f12857b21a10,[Données non publiées],RETRAITE,RETRAITÉE DE L'AGRICULTURE,[Données non publiées]
+a09a3372-fe74-4621-a204-a1dc3b22a651,[Données non publiées],retraité,[Données non publiées] retraite au 30/03/2021,
+a09b127f-27d9-4bea-a2bc-e0b8fdc40204,[Données non publiées],Néant,Retraité,
+a0a6c927-bdf3-4e8e-87a0-a03472b32d00,[Données non publiées],[Données non publiées],Collaboratrice notariale,
+a0b648a0-4770-4189-9878-653d4b8cf980,[Données non publiées],[Données non publiées],Huissier de Justice,
+a0b80e3e-8096-4709-a1a3-4ba6b16b7a05,[Données non publiées],Néant,Néant,
+a0baeb3d-1c08-47b0-b843-458d117d092d,[Données non publiées],education,enseignante,
+a0c7a0f2-08ec-4860-bdbb-3e19264373b8,[Données non publiées],EDUCATION NATIONAL,PROFESSEUR DES ECOLE DANS LE 1ER DEGRES,[Données non publiées]
+a0da6f5f-37f9-44fb-bf2d-0b51f641a7d7,[Données non publiées],SBR,SOCIETE DE VENTE ET REPARATIONS DE GROUPES FRIGORIFIQUES,[Données non publiées]
+a0e6c815-4a5e-4116-8a52-a858b8dd71d9,[Données non publiées],Département de la Gironde,Gestionnaire ressources humaines,
+a0e72108-b51a-4d40-b21e-113a793e597a,[Données non publiées],Ministère de la Justice,[Données non publiées],
+a0ee72cc-d941-4294-83dd-eef6c74f3a5e,[Données non publiées],SIETREM,Adjointe administrative,[Données non publiées]
+a0f073e5-cca5-416c-9b19-02251d23f2c7,[Données non publiées],KTM Advance,[Données non publiées],
+a0f073e5-cca5-416c-9b19-02251d23f2c7,[Données non publiées],Holix,[Données non publiées],
+a0f7ebd8-6801-4fa1-a414-cb27d2e6c3ad,[Données non publiées],Communauté de communes du Piemont Cévenol,Directrice générale des services [Données non publiées],
+a0f883ef-0166-49a4-bcee-b67738f1e18f,[Données non publiées],Banque des Règlements Internationaux (BRI),[Données non publiées],[Données non publiées]
+a0fd40ad-8bc6-473c-b560-ba9b4c9d9a2c,[Données non publiées],education nationale,professeur des écoles,
+a103ca08-6e04-418b-bdbe-2ea32f39b154,[Données non publiées],Département du Nord,[Données non publiées],
+a10ee808-e10b-4cca-bc82-866884b7a45d,[Données non publiées],SDIS 35,[Données non publiées] Fonctionnaire territorial catégorie C,
+a114d000-0ebe-4607-9dea-52aed569c132,[Données non publiées],[Données non publiées],gestion parc immobilier,
+a11584eb-6b50-4325-be13-1dc266cba9f4,[Données non publiées],DGFIP,Contrôleur des finances publiques,
+a1198b59-252b-4ffe-8b6b-391b4f52e028,[Données non publiées],La Provence,[Données non publiées],
+a1326041-3309-4819-bc80-434191c1fc85,[Données non publiées],profession libérale,Infirmière libérale,[Données non publiées] [Données non publiées] activité d'hypnothérapeute en auto-entreprise [Données non publiées]
+a133b91c-02ee-4e6a-9ea3-3e8ef1a9f6a7,[Données non publiées],néant,néant,[Données non publiées]
+a146f2c5-6a01-4641-8024-89b220b0ff20,[Données non publiées],Retraitée,Sans,
+a154808b-7eed-42d1-a47c-b614225a86ee,[Données non publiées],Néant,Néant,
+a154b14b-e629-4a22-8b95-7bed54b3aafe,[Données non publiées],mairie,gerante,
+a15cd276-900c-4c33-bf3a-447898cf6907,[Données non publiées],Retraitée,Retraitée,
+a15e1750-6122-46e4-b754-bbad92f9c909,[Données non publiées],VILLE ANGERS,EMPLOYE,[Données non publiées]
+a161eef1-eb77-4779-99d5-3eade1e2541b,[Données non publiées],Education nationale,enseignant,
+a163b287-1e6b-4950-8370-c51ddf141ff7,[Données non publiées],NEANT,NEANT,Chômage/ POLE EMPLOI
+a163ffcd-f07e-4a90-b2e8-1b274543b0fd,[Données non publiées],DRIEAT d Île-de-France,Instructrice [Données non publiées],
+a167be53-0b58-4198-8fee-8c8607ea008a,[Données non publiées],CAF,[Données non publiées],
+a16f5be8-7b7a-49fe-a1a8-e214af5e71ed,[Données non publiées],néant,néant,
+a17357f5-45e6-4be2-94ad-9d4434725ed1,[Données non publiées],[Données non publiées],gérante de [Données non publiées] société Immobilière [Données non publiées],
+a176d6e6-2993-40dc-b281-7465508b1ea6,[Données non publiées],[Données non publiées],Enseignement à domicile,
+a1789df0-bf16-487f-98ca-ad3898af4a79,[Données non publiées],néant,néant,
+a17be403-c644-423b-870b-77ec74304cb8,[Données non publiées],Secafi,[Données non publiées],
+a181c7eb-3cae-4ea5-bfa8-0df53bb2e1c1,[Données non publiées],SAS NEGOCIM,Directeur d'agence d'aménagement foncier,
+a1a11106-bfe2-40a4-89dc-71ae7adfd7fa,[Données non publiées],[Données non publiées],psychiatre attachée en tabacologie et expert de justice [Données non publiées],en retraite [Données non publiées]
+a1a1c1df-9d20-49ff-a2ae-e2689bc308a7,[Données non publiées],MUTUALITE RETRAITE,Femme de service en EHPAD,
+a1a49311-be4c-4f98-bdaa-c79109e78f70,[Données non publiées],Groupe CISN,Responsable [Données non publiées],[Données non publiées]
+a1a8f609-6796-4d12-a6f0-924ade1521a3,[Données non publiées],CNAV,RESPONSABLE PROJETS [Données non publiées],
+a1b1afad-2df7-42ad-8499-e80bf6dea5f7,[Données non publiées],[Données non publiées],mandataire judiciaire à la protection des majeurs [Données non publiées],
+a1baf1a4-8ba7-42ad-a055-e65a9f808698,[Données non publiées],[Données non publiées],responsable qualité,
+a1c4d914-1194-4e78-969d-c2267cb0e6d9,[Données non publiées],OGEC [Données non publiées],directeur d'établissement scolaire [Données non publiées],
+a1c9f9ce-5b85-42f0-a6c1-2281d7778f4a,[Données non publiées],Ville de Paris,Communication et relations presse,
+a1cd82c4-398e-4421-8f25-f8879920f7d7,[Données non publiées],EDUCATION NATIONALE,AGENT ADMINISTRAIF,
+a1cfb37e-322d-40e6-8778-8bd7d2dfedc4,[Données non publiées],SESU,Employé de maison avec plusieurs particuliers,
+a1d4fcb1-1b79-446e-be25-91ecc086bbf0,[Données non publiées],CHU de Pointe à pitre,Adjoint administratif [Données non publiées],
+a1d5fd87-9084-4526-9d31-d8a0ceec6043,[Données non publiées],Caisse Primaire d'Assurance Maladie,Manager [Données non publiées],
+a1d7c248-af3e-4ff8-b50a-ff5aabd2eba4,[Données non publiées],Avocat -,Avocat,
+a1da7a71-5b95-49e6-a298-b2c6c15acd09,[Données non publiées],Fonction Publique Hopsitalière,Retraitée,
+a1df9ca1-3b17-4302-a977-5f59b8b8260b,[Données non publiées],EARL [Données non publiées],co gérant de société,
+a1df9ca1-3b17-4302-a977-5f59b8b8260b,[Données non publiées],[Données non publiées],Entreprise de Travaux agricoles,
+a1e108e7-2113-4016-ae48-42791c9cd682,[Données non publiées],NEANT,NEANT,
+a1e637dd-049a-4374-ad70-5d4ab8b46c3f,[Données non publiées],GAEC [Données non publiées],Agriculteur céréalier,
+a1f0df4f-ffb4-4848-ac8d-d6904424b34b,[Données non publiées],PLR,Secrétariat,
+a1f55e7c-1295-4cad-a016-09f4c2a845b4,[Données non publiées],OTIS,RESPONSABLE CENTRE DE SERVICES,
+a1fc3f8f-a0e1-4b77-9a9f-ecfb3341dd5c,[Données non publiées],CCIR pays de la loire,[Données non publiées] accueil,
+a205a916-6132-4229-9f9a-d292d3f7eeb2,[Données non publiées],Néant,Néant,
+a20bfd8a-1fae-42fb-947a-d54228c223e3,[Données non publiées],maison Hanras,fleuriste,
+a2129fe5-0afe-4ba5-94aa-c162a147e872,[Données non publiées],AUTO ENTREPRENEUR,NETTOYAGE BATIMENT,
+a216ad77-d38a-4e28-b1af-8cba955ecee1,[Données non publiées],Travailleur indépendant,conseil en communication scientifique et journaliste,
+a21ce73a-b77b-4db8-924e-4bf9df41c299,[Données non publiées],[Données non publiées],[Données non publiées] A la retraite [Données non publiées],
+a220479f-3a30-4593-95d5-0cae1d1002ac,[Données non publiées],Conseil départemental,[Données non publiées],
+a2217ddb-dc26-4efd-b9a1-048d62eac94f,[Données non publiées],Grand Poitiers Communauté urbaine,Chef de mission [Données non publiées],
+a2225105-10a6-4235-a719-52474ea3ba81,[Données non publiées],profession libérale,médecin,
+a242c58e-3a5d-4fbe-a56f-276f337cf64c,[Données non publiées],APHM & Aix Marseille Université,Maître de Conférence et Praticien Hospitalier [Données non publiées],
+a24dc800-f4a0-4cbf-b2d1-35d1ce18a111,[Données non publiées],RATP,[Données non publiées],
+a251a913-2986-466d-9503-bd8d3c9003f6,[Données non publiées],CONSEIL DEPARTEMENTAL,ADJOINTE ADMINISTRATIVE,[Données non publiées]
+a2634c55-af24-4613-a43f-d29a76f95938,[Données non publiées],Lycée Général et Technologique et Lycée Professionnel [Données non publiées],Professeur d’Education Physique et Sportive. [Données non publiées],[Données non publiées] [Données non publiées]
+a2685adf-771b-4525-ab4d-0d2bf2a4b396,[Données non publiées],SCP NIQUE SEGALEN PICHON,Bureautique et comptabilité,
+a2768343-5551-490d-9531-1ff2935ba2f9,[Données non publiées],Education nationale,AESH [Données non publiées],
+a280b92f-2480-40d4-8a24-179e79f17e9e,[Données non publiées],Cap Coreli SARL,[Données non publiées],[Données non publiées]
+a288ad79-6c2d-4fa3-832b-961ea7a863b5,[Données non publiées],[Données non publiées] entreprise individuelle,"Artisan/commer_çant son, lumière et vidéo",En retraite
+a288ad79-6c2d-4fa3-832b-961ea7a863b5,[Données non publiées],gérant de société,SARL [Données non publiées] : location d'écrans plein jour,
+a288ad79-6c2d-4fa3-832b-961ea7a863b5,[Données non publiées],co-gérant de société,SCI [Données non publiées] : locations de locaux commerciaux,
+a29026ff-e370-4c3a-8696-43a4e6dd3677,[Données non publiées],Centre hospitalier [Données non publiées],praticien hospitalier,
+a2906da8-0b2e-4871-aca7-76ba0a4b1521,[Données non publiées],L'OREAL,Directeur Zone Europe [Données non publiées] [Données non publiées],
+a299ac69-383a-478d-9e31-5e0cf431cfa6,[Données non publiées],Département de la Moselle,Employée administrative,
+a2a15437-ad3e-4014-8aa5-108fd8e82b30,[Données non publiées],fiducial consulting,salariée comptable,[Données non publiées]
+a2ad2d8b-a70f-4e7b-9129-25f073cc6b9e,[Données non publiées],profession libérale,Sage-femme libérale,
+a2b0d26c-bbe0-4346-8cbe-8f7c2f6688bd,[Données non publiées],Education Nationale,Professeur de Physique Chimie [Données non publiées],[Données non publiées]
+a2ba67e6-5051-4ca6-bc7b-93a578b9040a,[Données non publiées],CH Genevieve de Gaulle Antonioz,SAGE FEMME [Données non publiées],
+a2c610f3-1d16-4d53-8f04-663e57a7349b,[Données non publiées],Néant,Néant,[Données non publiées]
+a2cecc1c-ad5e-4dd3-a1b5-1810c784ac77,[Données non publiées],néant,néant,
+a2d23af7-4510-4892-9725-94ea6da644af,[Données non publiées],ARTISAN,Coiffure à domicile,[Données non publiées]
+a2d40e67-cfa1-482d-8f86-74b580b3d065,[Données non publiées],[Données non publiées],[Données non publiées] entreprise COTRAL,
+a2d7a50c-f6ad-4387-9a1d-787af3e88997,[Données non publiées],[Données non publiées] HOTEL,Gérant,
+a2e17888-d070-4c89-b8d8-8eabf35ea267,[Données non publiées],RATP DEV,[Données non publiées],
+a2e2d8d4-62f4-4ba4-9aee-09aa55021d45,[Données non publiées],Education nationale,Professeur du secondaire,
+a2e32dd1-9293-44cf-a67d-aa1d3d310088,[Données non publiées],GENDARMERIE,Gendarme,
+a2e4ec97-5741-494e-94d1-4823de46826b,[Données non publiées],Mairie de Besançon,Directrice adjointe [Données non publiées],
+a2e7b79a-b2ef-4a87-b64f-d2ad5c266818,[Données non publiées],[Données non publiées],[Données non publiées],Retraitée [Données non publiées]
+a2f64a46-1c17-486a-a073-e7657e87e104,[Données non publiées],Conseil Départemental,[Données non publiées] muséum d'histoire naturelle,
+a30241cf-692c-4dcb-b195-a34a765480a9,[Données non publiées],Crédit Agricole,Chargée de clientèle professionnelle,
+a3143a64-e9c6-4b41-a56b-390c3d9ee6ae,[Données non publiées],STAG - Villers Bretonneux,Assistante administrative,
+a31b4a2e-2362-4e42-9f61-59b765bb60f6,[Données non publiées],néant,néant,
+a31e25cd-bf9a-424a-9a49-94b39995526b,[Données non publiées],néant,néant,[Données non publiées]
+a33e28be-8711-4813-af2e-c5ce82a17803,[Données non publiées],INSEE,[Données non publiées],
+a3441198-675a-4370-a1a7-817530a18ab2,[Données non publiées],Retraitée [Données non publiées] de la fonction publique hospitalière.,Hôpital public.,
+a347c233-67cb-44c4-9214-1a795dec9128,[Données non publiées],DSDEN [Données non publiées],[Données non publiées],[Données non publiées]
+a349c399-f6ca-4f67-bd70-68bb6d076ce7,[Données non publiées],cosy home france [Données non publiées],[Données non publiées],gérant [Données non publiées]
+a361d4c2-d591-4f52-b06a-31b4f14570a7,[Données non publiées],SCP Ciavaldini,Notaire,
+a371a444-fa9a-4994-8d38-615aad3a5c68,[Données non publiées],Education Nationale,Gestionnaire Comptable du Lycée [Données non publiées],[Données non publiées]
+a37577aa-ed45-424e-a8d0-631cd2a4ea12,[Données non publiées],Retraitée,Néant,
+a3847296-7c1d-431d-8fd1-e13b26a9217e,[Données non publiées],Caisse d allocations familiales de l'Aude,chargé de conseil et de développement . Coordinatrice Petite Enfance,
+a38a1750-1112-4b9c-9d72-6fd625e30720,[Données non publiées],Indépendant,Avocat,
+a38adab8-dd45-4c63-977a-355f4e6f2786,[Données non publiées],/,/,Retraitée (Médecin Territorial)
+a3ab774f-f52c-4bdb-88ca-9cb98135c168,[Données non publiées],Compagnie Océane,Maître d'équipage [Données non publiées],
+a3aebb2e-2ce8-4680-ba17-0ae3e040e951,[Données non publiées],Education Nationale,Professeur des écoles,
+a3b1d582-5208-4f9d-a244-69c1dab7baa7,[Données non publiées],Haut Bugey Agglomération,éducateur sportif,
+a3be5291-20df-4f52-b262-d1842f736539,[Données non publiées],Néant,Néant,
+a3c78b87-0331-4251-bb66-b86438d227cd,[Données non publiées],Libéral,Masseur Kinésithérapeuyr,
+a3d0e123-1cd6-4249-bef9-a0b50a2f02a7,[Données non publiées],[Données non publiées],[Données non publiées],En retraite [Données non publiées]
+a3dba70b-7c62-4011-9e72-11adda880b43,[Données non publiées],Conseil Regional,Secretaire Générale adjointe [Données non publiées],
+a3e2c3d6-f0ec-4d49-90a3-75568ecec8ed,[Données non publiées],Retraitée [Données non publiées] [Données non publiées],[Données non publiées],
+a3e8bd60-fa86-4eb5-ad15-3f3bba1777e7,[Données non publiées],seac,logistique,[Données non publiées]
+a3fb484d-c1a1-4004-8fb6-fe84d0aecfd8,[Données non publiées],[Données non publiées],RETRAITEE,
+a3fff8c3-3f16-442b-86cb-2f1c327f9db2,[Données non publiées],[Données non publiées],ESTHÉTICIENNE A DOMICILE,[Données non publiées]
+a4098378-e179-4724-a2f3-0c56eba34438,[Données non publiées],Clinique du Souffle le Pontet [Données non publiées],directeur d'établissement [Données non publiées],
+a409d506-b8ae-49ab-bea9-73eee824d20a,[Données non publiées],TAHITI RAVAAI [Données non publiées],Marin pêcheur,
+a416dddd-272b-4771-87b5-5c7e111a7ad5,[Données non publiées],eplefpa [Données non publiées],formatrice,
+a41d3c8b-1a3e-4306-bba6-7fd99831d67c,[Données non publiées],[Données non publiées],Releveur de compteurs,
+a41dc30e-b2f3-488e-8bd0-fb18d30b9bcb,[Données non publiées],Artisan,Coiffeuse,
+a43f7f08-2d0e-44e0-94be-768d60e8ce0b,[Données non publiées],GHEF,Pédopsychiatre praticien hospitalier,
+a4463fc3-0443-4a8a-a0d9-400083d97e5c,[Données non publiées],Néant,retraité,[Données non publiées]
+a449070c-de78-4530-89f6-5ff63971eb27,[Données non publiées],SOCIETE RHODANIENNE DES CARS GINHOUX,[Données non publiées],
+a45488bd-429a-4465-bc70-7b3cd3f0e338,[Données non publiées],Apple Retail,Manager commercial,
+a454d05a-9109-4d78-a17d-694e2a873120,[Données non publiées],france telecom,retraitée,
+a4563286-1a2c-4ff4-80a1-0eec9f04d615,[Données non publiées],Centre Hospitalier Moulins Yzeure,Infirmière [Données non publiées] à 80% (a été à 100% durant la période de crise sanitaire),
+a45a8a56-375c-41ac-b4fa-c70d1cef8e49,[Données non publiées],neant,neant,
+a463f71a-1764-49f6-81bf-442c67b18a3f,[Données non publiées],NEANT,NEANT,SANS ACTIVITE
+a47344d7-8ed3-4c47-8123-9fbce2ef0dbd,[Données non publiées],néant,commerçant fruits et légumessous le régime d'exploitant individuel.,cessation d'activité au 31 décembre 2018
+a47680aa-b8e0-47cb-9a01-6122c4fa4fd6,[Données non publiées],Rectorat Orleans-Tours,Professeure Documentaliste,
+a47826ad-4f89-4938-8480-27c6e201af7b,[Données non publiées],retraité,neant,
+a4a08acd-1dbb-473a-8980-05970cf21e47,[Données non publiées],Metropole européenne de Lille,Ingénieur hydraulicien,
+a4ae6b4e-ed21-4570-9854-66f59bfbb716,[Données non publiées],LEXCAP,[Données non publiées],
+a4b40182-68a5-488d-8973-4d6104849289,[Données non publiées],WILL&CIE,Evénementiel professionnel Accompagnement en stratégie de communication Formation en relations publiques,cessation d'activité au 30 juin 2021/ [Données non publiées]
+a4b40182-68a5-488d-8973-4d6104849289,[Données non publiées],Dialogues et Solutions,salariée depuis le 1er avril 2021,
+a4b921a4-059c-43ac-adea-c9d4593d2bc4,[Données non publiées],Commissariat à l'Energie Atomique,Directrice [Données non publiées],
+a4ceb177-6d98-4095-ab53-230e1e9cf38b,[Données non publiées],BNC,psychologue,
+a4d706d3-b137-4fd0-b55c-fb7b05998938,[Données non publiées],Worldline,Ingénieur informatique [Données non publiées],
+a4e0984e-335c-4df8-9df9-bd2abac7beab,[Données non publiées],Sénateur PIEDNOIR,[Données non publiées] collaboratrice parlementaire,
+a4e2f067-9d89-452e-adae-7a1f7e49930a,[Données non publiées],Prof de tennis,Cours de tennis adultes et enfants,
+a4ed625b-cb16-49a9-90c2-9e827d77db93,[Données non publiées],profession libérale à son compte,Pharmacienne libérale,
+a4f4bcb4-eae9-4595-be53-0e38cd96540b,[Données non publiées],THÉÉTÈTE CONCEPT SASU,Enseignement et formation [Données non publiées],
+a50bdc47-911a-4a7a-8b08-4c3ae00f57bc,[Données non publiées],[Données non publiées],Conseil en Gestion de Patrimoine [Données non publiées],SARL
+a50df33e-e129-4610-8618-01a74a4fc2fc,[Données non publiées],Néant,[Données non publiées],Retraité
+a514f800-1a97-4aa4-9cff-eddffb6e048c,[Données non publiées],sans,"Artiste, sculpteur",
+a523a718-c58e-4513-bea4-2e6ec110aa49,[Données non publiées],EPDSM,Assistante de Service Social,
+a52e716e-1451-4720-8bc4-484add07215b,[Données non publiées],MDPH 976,Responsable [Données non publiées],
+a53038f7-4c7a-41d0-b391-6a437b904f68,[Données non publiées],néant,étudiante,
+a532ecb2-0a7c-494f-a238-a01bb9c43d7c,[Données non publiées],Association ABCM zweischprachigkeit [Données non publiées],Professeur des écoles et Directrice maternelle,
+a53312dc-1668-4d46-a0a4-307032a2c15d,[Données non publiées],Groupe ETAM,[Données non publiées],[Données non publiées]
+a538871a-f47d-4b1d-866a-30b4ab490e56,[Données non publiées],CIC,gestionnaire privé,
+a53b25e4-bcff-4f9f-8efa-f0531d0273e5,[Données non publiées],ETUDE NOTARIALE [Données non publiées],CLERC DE NOTAIRE,
+a53d0f96-eac7-444e-b92e-4705f1ecbe0c,[Données non publiées],CourdesComptes,conseillèremaitre,
+a53ff3bb-68b2-4118-8f6b-559c18939b79,[Données non publiées],HYQUAL SERVICES,ASSISTANTE TECHNIQUE ET ADMINISTRATIVE À MI-TEMPS,
+a54027c6-7aa0-4529-a8d8-12e5e13a779d,[Données non publiées],TOURING CLUB SUISSE,[Données non publiées] [Données non publiées],
+a549aebf-c9f7-4531-8733-4c815f8487be,[Données non publiées],retraitée,Néant,
+a54da107-eece-42d5-bcd6-3cb9830b8de9,[Données non publiées],Assistance Publique Hôpitaux de Marseille,Chirurgien [Données non publiées],
+a55dba7a-7d48-4293-9781-0b357e0de19b,[Données non publiées],Le Point,[Données non publiées],
+a568a506-1025-44cf-86e4-c7d1f63583e4,[Données non publiées],COMUTITRES,Responsable Achats,[Données non publiées]
+a56bb2ed-5432-4170-9ef9-1d293603998f,[Données non publiées],GAGARAGE LITTORAL AUTOMOBILE,[Données non publiées],
+a56c5c87-6c29-4c50-9408-080221b56c09,[Données non publiées],Education nationale,Professeur [Données non publiées] de sciences économiques et sociales [Données non publiées],
+a56f799e-bb2e-42bc-b7a6-377b442ba3a0,[Données non publiées],Néant,Agricultrice retraitée,
+a5799a44-70d0-4c52-b188-b3e9db241690,[Données non publiées],Ministère de l'Education nationale,Professeure des écoles,
+a57a1aad-393f-47ba-8947-5eb0e174d477,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+a58832f3-61e1-4541-a409-9c3d4206a8d3,[Données non publiées],Néant,Néant,
+a59079f6-9061-4cac-bf98-94d90137ffaf,[Données non publiées],Vénétis - Groupement d'Employeurs,Directrice générale,
+a59cb0f9-4a44-438a-9929-0a4b41bc85ed,[Données non publiées],[Données non publiées],[Données non publiées],
+a5a8f41b-d60d-4f58-a76b-cf12415903a7,[Données non publiées],SARL VENDEE FLEURS,fleuriste,
+a5b5a7c6-e8bb-42df-8f77-ad9208186484,[Données non publiées],[Données non publiées],RESTAURATION,
+a5bc141e-1c2a-426a-8729-1f119f90b6cd,[Données non publiées],MARTINEAU Éric,agriculture,[Données non publiées]
+a5c2c06f-2e7e-40ca-aae1-4a91f95c744e,[Données non publiées],[Données non publiées],retraitée,
+a5c84f44-dc9f-449c-a3d7-800651f3fa2d,[Données non publiées],CG 49,Assistante sociale,
+a5df7f8c-ffcd-432c-9606-b9005c2a186a,[Données non publiées],Aucun,Pas d'activité professionnelle,Gérante de la SCI [Données non publiées]
+a5e29ecb-adf4-4491-a3d5-32bafc3de2dc,[Données non publiées],NB Stratégie,Société de conseil [Données non publiées],
+a5ee792c-dbd6-45f4-921e-9886866052f9,[Données non publiées],Librairie des Thés,Vendeuse en librairie,
+a608a3da-cd41-4572-aa4f-35874c014994,[Données non publiées],Réseau ecoles montessori [Données non publiées],Directeur du développement et Président [Données non publiées],[Données non publiées]
+a60a0c18-1085-44f2-85d8-a2b22ff90447,[Données non publiées],Département du Doubs,[Données non publiées],
+a6144f3f-c0be-4988-8430-b255d360eae6,[Données non publiées],Retraité,Retraite,
+a62424e7-797b-4158-8165-36ed4a2ced41,[Données non publiées],Agricultrice,Chef exploitation,
+a625c05a-ee85-4379-83cb-eb26a4f182bf,[Données non publiées],Education Nationale,Professeure des Ecoles,
+a62765d5-c206-4980-ada1-7840bf0e9a40,[Données non publiées],RecycLivre,Responsable commercial [Données non publiées],
+a6294436-b6de-4aed-9a18-8c9336492248,[Données non publiées],ASTBTP,Secrétaire Médicale,
+a62a7c96-cf5a-4b4d-b659-6ec2e222ef8c,[Données non publiées],VILLE DE CHOLET,[Données non publiées],
+a6586c98-3bca-4a46-abba-e7159a5defc3,[Données non publiées],KTM Advance,[Données non publiées],
+a6586c98-3bca-4a46-abba-e7159a5defc3,[Données non publiées],Holix,[Données non publiées],
+a65992de-0e16-4f62-bd6f-882d38979f6e,[Données non publiées],Néant,Néant,
+a6640093-2f72-4f07-a528-db97a991fbe4,[Données non publiées],Néant,Néant,Sans activité
+a6694ac3-70a5-4ac3-83e6-9b7169201240,[Données non publiées],Cour de cassation,Conseiller-doyen [Données non publiées],
+a6799094-b15e-448f-bf17-b4b80c890bb5,[Données non publiées],Communauté de communes du Piemont Cévenol,Directrice générale des services [Données non publiées],
+a689237e-7e09-4bdb-ad44-0791c1d900da,[Données non publiées],CH [Données non publiées] + activité liberale,Chirurgien,PH temps partiel
+a689e463-de3e-467a-83c2-ba82e31393b8,[Données non publiées],Auto-entrepreneure,Coach sportive,
+a68a8e73-341f-4522-916d-4f1f69e7d442,[Données non publiées],General Electric,Responsable qualité,
+a68c5033-0c68-444e-a8fa-06385106a3d9,[Données non publiées],SANS,SANS,
+a69d9d97-eac3-45c5-9fd1-1f89e02a5e62,[Données non publiées],néant,néant,[Données non publiées]
+a6ac199d-f9ba-4b6b-8300-40d1be470956,[Données non publiées],Rectorat enseignement privé [Données non publiées],Enseignant,
+a6b1e96b-a4fd-422e-a455-daa26d18a91a,[Données non publiées],Néant,Retraitée,
+a6b90981-ec0c-4d8e-b5b4-9f443081d5dd,[Données non publiées],SYNALIA,[Données non publiées],
+a6baa084-8065-4d5e-be47-3937129a0884,[Données non publiées],Mairie de Canéjan,Collaboratrice de cabinet,
+a6c0a957-9934-49d4-baa8-b1fc4812d4a3,[Données non publiées],lui même,journaliste Président et directeur du journal Le petit mag Lens Liévin exploitant agricole [Données non publiées],[Données non publiées]
+a6c490ea-7e63-404d-8e25-42d66c28e4b1,[Données non publiées],retraité,retraité,
+a6c58255-72af-4c2c-8d7b-54887547f266,[Données non publiées],OMS Genève (Suisse),Employée,
+a6ca7b2b-4c95-45a7-81d1-c7270f5c58c0,[Données non publiées],retraitée,[Données non publiées],
+a6ced1e4-85e0-432d-be39-a9dca96601f0,[Données non publiées],avocate,profession liberale,
+a6d02c0a-c58f-47ed-a8de-6bcf66916b6a,[Données non publiées],AVSEA,[Données non publiées],
+a6d389bd-6b79-4f5e-a102-f67721369843,[Données non publiées],Hopital [Données non publiées],Aide soignante,sans objet
+a6e5b628-3477-4594-bc9f-172961ef4213,[Données non publiées],COMMUNE SAINT MAURICE LES CHATEAUNEUFS,[Données non publiées],[Données non publiées]
+a6ed5d63-7458-44e3-9dd1-ac0d648abc5e,[Données non publiées],Alliance Healthcare,Chargé de mission [Données non publiées],[Données non publiées]
+a6f4e3ac-513e-4a32-bbe4-06fde54e495b,[Données non publiées],mairie de Wimereux,[Données non publiées],
+a6f551c9-688c-4b9c-a288-7921721f5c95,[Données non publiées],[Données non publiées],entrepreneur de travaux agricoles,[Données non publiées]
+a6fa4e47-2ce0-4597-9a24-e7077ec60491,[Données non publiées],retraitée,[Données non publiées],
+a710d3f2-7364-4171-8ff6-fbc42622a6cb,[Données non publiées],néant,aucune,
+a71631af-257b-4e3c-825b-6f99a27875d7,[Données non publiées],avocat,avocat,
+a716b855-7fe0-4f36-9f21-331d25dc08a0,[Données non publiées],néant,[Données non publiées],
+a72f27b4-c682-4d15-b6a8-cb5fde57badb,[Données non publiées],[Données non publiées],Médecin radiologue,
+a72f90f5-8498-4799-b1f0-439ce63e74bc,[Données non publiées],Mairie [Données non publiées],Secrétaire,Retraitée [Données non publiées]
+a7339260-0fa3-4488-a910-4c475630ad81,[Données non publiées],Architecte libéral,[Données non publiées],
+a7370c9b-7944-4fe8-ab5c-694dbcb09ee0,[Données non publiées],Retraité,Retraité de l'Education Nationale.,
+a73b747b-db50-460b-98d7-e501cdc1520e,[Données non publiées],DAUNAT [Données non publiées],Assistante R H,
+a73e908a-e057-4ef3-adfa-14ac842dce9b,[Données non publiées],CMD,Ingénieur,
+a749429f-2cd7-4917-aa92-02cce5c5cdd7,[Données non publiées],sans,Néant,[Données non publiées]
+a74d8da1-5c5e-4094-9a42-424416a41cc3,[Données non publiées],Direction des Services Départementaux de l'Education Nationale du Cantal,AESH [Données non publiées] [Données non publiées],
+a75335dd-7462-41d2-8a33-f2e6dbcf0e96,[Données non publiées],[Données non publiées],GERANT,AGENCE DE VOYAGES
+a7584a3b-7e02-4103-845d-85c43276b2a1,[Données non publiées],éducation nationale,enseignante,
+a75edf23-418d-47a2-806e-0f3236bb09ec,[Données non publiées],Groupe Austral Assistance,Manager de plateau d'assistance en télécommunication,
+a762dab6-52c6-42bc-9ba9-626f4b9f914f,[Données non publiées],Ministère de la santé et des solidarités,[Données non publiées],[Données non publiées]
+a7661773-9892-41da-81ef-4b767a086fb0,[Données non publiées],Assemblée nationale,Député,
+a76c788c-383d-4c56-8994-86c2b5bf0354,[Données non publiées],Sénat,Sénateur,
+a787ddbc-9c7a-42ac-81bd-a0107c383488,[Données non publiées],Conseil Départemental de Haute-Garonne,Chef de service [Données non publiées],
+a788d848-c808-4f3e-95a4-8b6bf06135a0,[Données non publiées],conservatoire de musique et de danse du tarn,agent comptable,
+a7988228-44a5-4dcf-a230-63de1881936d,[Données non publiées],Education nationale,Professeure certifiée de lettres modernes,
+a79e8d09-27d0-4719-8170-e2b730257add,[Données non publiées],[Données non publiées],conseillère de vente en librairie,
+a7b0d803-1de4-4699-8156-bc0e356a955f,[Données non publiées],profession libérale,Medecin pneumologue,
+a7b73961-9ea0-48e7-918a-f4c08488c487,[Données non publiées],Néant,Retraité [Données non publiées],
+a7b75084-2e8b-4eac-a9d1-f0a9bd9389d9,[Données non publiées],Artiste,Peinture murale et décorative,
+a7bb7af5-3b44-4fab-a4d5-add678f82378,[Données non publiées],OMS Genève (Suisse),Employée,
+a7cb352c-b232-4666-8896-4c2c3f6fd24b,[Données non publiées],Université Paris 3,PRAG,
+a7cb6d2d-0b11-4eb1-9a06-0f367df0e4f0,[Données non publiées],néant,retraité sans activité,
+a7cfd45a-bdb1-43e9-8132-61406d2a47c0,[Données non publiées],NEANT,NEANT,
+a7e9439c-a325-4efc-b2cd-023b17cb97da,[Données non publiées],Mission locale Bourgogne nivernaise,Conseillère en insertion professionnelle,
+a7ed0877-3f2f-4995-97a8-7cac804d12e3,[Données non publiées],Procter et Gamble,infirmière en santé au travail,[Données non publiées]
+a7f733fa-1eba-4eec-9e17-682b3c64402c,[Données non publiées],Droit d'auteur et pigiste,Photographe Documentariste,
+a7fe0afd-65ab-482a-ad7a-11d2d636d14a,[Données non publiées],Ville de Strasbourg,[Données non publiées],
+a8115871-2525-457d-882e-ba5a23de1582,[Données non publiées],Profession libérale,enseignement musical,
+a8119973-f69d-450e-8a61-b653247e6db7,[Données non publiées],[Données non publiées],[Données non publiées],Retraite
+a8241cdf-70e3-4f5e-81ca-1a4f7afb49a7,[Données non publiées],SA De Giorgi,[Données non publiées],
+a82629aa-c886-454d-8b60-22e11c86492f,[Données non publiées],CNRS [Données non publiées],Directeur de Recherche,
+a8290aef-0def-45fa-8674-55f5f9005c52,[Données non publiées],3C2A,Dirigeant [Données non publiées],
+a832cde1-4f53-4f31-9379-38d353f1b691,[Données non publiées],earl [Données non publiées],associée exploitante sur earl [Données non publiées],pas de rémunération
+a8366b85-a8ad-4860-a410-9afa4234c26b,[Données non publiées],ELIOR Services,[Données non publiées],
+a83823d4-a5b9-4e1d-b167-c1687ab332f0,[Données non publiées],néant,néant,
+a83f3b0c-393a-4b2d-9551-2fe564119ff3,[Données non publiées],Ville [Données non publiées],Directrice Générale des Services,
+a841ac3d-5589-4d97-8770-3881ef5e765a,[Données non publiées],Decathlon,Employé,
+a8555b96-5c19-4831-a397-0f4f39fcd674,[Données non publiées],[Données non publiées],gerant de la société,
+a8575d39-0b77-4f04-9dee-853db001c6bf,[Données non publiées],BDO Avocat,avocat associé,[Données non publiées]
+a8596218-a1da-44b2-ae1e-13c042a94d51,[Données non publiées],diocese le havre,[Données non publiées],
+a85c4d01-8912-40c0-b609-47f086b358e2,[Données non publiées],Sans,Sans,
+a866b6d0-e2bd-48dd-8157-361eb1c0b56c,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] En retraite [Données non publiées]
+a8670f04-763d-4c83-811a-d060a0d21a38,[Données non publiées],retraitée,néant,[Données non publiées]
+a86d59f0-8398-4832-9beb-83b4aa9ec663,[Données non publiées],Pharmacie [Données non publiées],Préparatrice en pharmacie,
+a86dfcde-adf2-4238-a5de-cd47fc4503bd,[Données non publiées],Ville de Val de Reuil,Néant,"[Données non publiées] directrice ""sports, culture et vie associative"" à la mairie de Val de Reuil."
+a86dfcde-adf2-4238-a5de-cd47fc4503bd,[Données non publiées],Ville de Canteleu,Maire,"Il ne s'agit pas d'une activité professionnelle mais d'un mandat électif rémunéré, [Données non publiées]"
+a86dfcde-adf2-4238-a5de-cd47fc4503bd,[Données non publiées],Région Normandie,Conseillère régionale,[Données non publiées]
+a86dfcde-adf2-4238-a5de-cd47fc4503bd,[Données non publiées],Métropole Rouen Normandie,Conseillère métropolitaine,"Il ne s'agit pas d'une activité professionnelle mais d'un mandat électif rémunéré, [Données non publiées] [Données non publiées]"
+a86dfcde-adf2-4238-a5de-cd47fc4503bd,[Données non publiées],LOGEAL,Membre du conseil d'administration,Il ne s'agit pas d'une activité professionnelle mais d'un mandat d'administrateur (non rémunéré).
+a86dfcde-adf2-4238-a5de-cd47fc4503bd,[Données non publiées],HABITAT 76,Membre du conseil d'administration,Il ne s'agit pas d'une activité professionnelle mais d'un mandat d'administrateur (non rémunéré).
+a86dfcde-adf2-4238-a5de-cd47fc4503bd,[Données non publiées],CCAS de Canteleu,Présidente du Conseil d'administration,Il ne s'agit pas d'une activité professionnelle mais d'un mandat d'administrateur (non rémunéré).
+a86dfcde-adf2-4238-a5de-cd47fc4503bd,[Données non publiées],Centre de Gestion de la Fonction Publique Territoriale,Membre du conseil d'administration,Il ne s'agit pas d'une activité professionnelle mais d'un mandat d'administrateur (non rémunéré).
+a8787d79-c10d-4f35-9cc2-82258559268e,[Données non publiées],Fidesco,[Données non publiées],Fidesco est une ONG qui envoie des volontaires à l'étranger.
+a88f1db0-3ec1-4e81-aec2-4747d40f8a22,[Données non publiées],Ministère de l'Education Nationale,Professeur des écoles,
+a88f7d72-6ca3-4328-a2b2-2547721710b7,[Données non publiées],néant,néant,Néant
+a89810da-41d3-477e-bbf8-95f6a6f5e80b,[Données non publiées],Retraité,retraité,
+a89e60dc-2a0b-4d9e-b7e3-0e1e0a25f60e,[Données non publiées],[Données non publiées],assistante maternelle à domicile,[Données non publiées]
+a8b23101-0098-4fc1-ae93-3568e2d15585,[Données non publiées],néant,néant,[Données non publiées]
+a8b55e15-1d59-416d-b473-d602c81b39b1,[Données non publiées],LABELIFE EVENTS S.A.S,Assistante de production,
+a8cb34c1-e0d8-4632-ab3f-c0e79072a70b,[Données non publiées],CEREP,Arthérapeute,[Données non publiées]
+a8d558b2-d201-4387-ab24-d1391d41a6c9,[Données non publiées],Veolia,Directrice de [Données non publiées],
+a8e05d72-886c-4e31-b9ff-7804c06b3caf,[Données non publiées],retraité,neant,
+a8e0d23f-9700-4192-b2d0-060810f159d1,[Données non publiées],CONSEIL DEPARTEMENTAL,[Données non publiées],[Données non publiées]
+a8e34697-eb5b-4add-a13a-edec05f42501,[Données non publiées],Retraité [Données non publiées],Précédemment Agriculteur exploitant,
+a8e8a8f1-2c03-4f06-8243-671a8b4e7970,[Données non publiées],Etat,contrôleur du trésor public,
+a8ea35fa-c6b5-4d41-9fd3-0fbe1d0cb744,[Données non publiées],-,-,-
+a8ed8569-1262-473c-8a5c-436ce63e1540,[Données non publiées],Gérante sarl,Administration de biens,
+a8f01278-da22-4e87-93fe-7f00d604b284,[Données non publiées],BOULANGERIE PATISSERIE [Données non publiées],VENDEUSE MAGASIN BOULANGERIE PATISSERIE,
+a8f06f29-9b79-4cc5-be34-80b0178358fd,[Données non publiées],Mairie du Lamentin,[Données non publiées],
+a8f5b37e-6171-43b1-9338-a23e0a2ed1b0,[Données non publiées],Sans emploi,Aucune,[Données non publiées]
+a8f5b37e-6171-43b1-9338-a23e0a2ed1b0,[Données non publiées],Aucun,Aucune,
+a8f5b37e-6171-43b1-9338-a23e0a2ed1b0,[Données non publiées],Sans,Aucune,
+a8f6e4eb-636f-42e2-98a9-ea96b0bf1c30,[Données non publiées],CENTRE HOSPITALIER [Données non publiées],AUXILIAIRE PERICULTRICE,
+a900efcf-18a9-4b07-9aa9-57a6e976b562,[Données non publiées],Education nationale,Directrice [Données non publiées] de l'Université [Données non publiées],[Données non publiées]
+a90487a2-99fc-42bc-8c45-2070ec068848,[Données non publiées],Neant,néant,[Données non publiées]
+a904fb9b-fc31-48fc-9178-6673708fd5a8,[Données non publiées],Sécurité sociale retraité,enquêtrice,
+a9085500-8d66-4c12-a1a1-be55525df7b5,[Données non publiées],[Données non publiées],vente de vins,[Données non publiées]
+a912fd9a-c8b8-4d7e-b431-c4392e3f6ba0,[Données non publiées],EIFFAGE,Conducteur de travaux,
+a9171738-d58e-48a9-9e0b-6692d0bcd07d,[Données non publiées],La Fab,[Données non publiées],
+a918c7f6-4b0e-4d95-ad45-bdc34d86b1df,[Données non publiées],Conseil départemental,Adjoint administratif,
+a91f8d68-bc84-4e8a-a35b-58590c06d1b6,[Données non publiées],Kabestan,Responsable immobilier [Données non publiées],
+a9223fab-6ada-414f-b992-3dad86e4263a,[Données non publiées],Education Nationale,Professeur,
+a92b7a3b-85db-4413-b5d3-8d602e40ba2b,[Données non publiées],Chef d'entreprise,Gérant,
+a92cb2de-ef1f-4418-b539-5e6a79b256fe,[Données non publiées],CREAPT,Sociologue,
+a93bcf41-eadc-4d21-a2ce-9451de605a4b,[Données non publiées],Etude [Données non publiées],Clerc de commissaire priseur,
+a93db3a6-de8e-41f3-b8c2-0287d68e29b9,[Données non publiées],TENTE SA,Responsable [Données non publiées] - cadre,
+a94992ac-7fe5-4ff4-b17b-82acc896fc64,[Données non publiées],[Données non publiées],[Données non publiées],
+a967744f-4d35-4971-b8c1-87a606d22c20,[Données non publiées],[Données non publiées],ARTISTE PEINTRE,[Données non publiées]
+a9699a85-f61a-4316-aa00-dbbc922be454,[Données non publiées],Musée des Arts Déco - Ecole Camondo,[Données non publiées],fin de contrat en janvier 2021
+a9699a85-f61a-4316-aa00-dbbc922be454,[Données non publiées],Stone Holding,[Données non publiées],embauche le 18 janvier 2021
+a96c3e5e-731d-490d-9e08-32c2f4f971dd,[Données non publiées],Gérant,SARL. Activité exercée: sécurité privée,
+a9726a55-3cae-4128-b479-9be2fd095957,[Données non publiées],Ministère de l'Education Nationale,Enseignant,
+a9729d7e-674b-401c-95cf-80264df5caa9,[Données non publiées],Laboratoire [Données non publiées],Prothésiste dentaire,
+a97b9fde-01e5-429e-a043-c4c37c2a2873,[Données non publiées],retraite,néant,[Données non publiées]
+a981a3fb-f5a8-431c-9a1a-d942cde6dfb4,[Données non publiées],CCAS [Données non publiées],Aide soignant,
+a98c83e9-de18-4f4c-9875-ce589f5bd21a,[Données non publiées],Lycée St François d'Assise [Données non publiées],[Données non publiées],
+a9954d48-954b-4575-99bd-a014eed01805,[Données non publiées],néant,retraité,
+a99993bf-7ae9-4d52-8a49-de973de45486,[Données non publiées],Cigair Distribution,directeur général,
+a9a41616-da3e-4a20-abab-30fdac676bef,[Données non publiées],Agence Limite,Directeur général délégué,
+a9abfc50-f61e-4fa4-9158-c05e744da92b,[Données non publiées],Néant,Néant,
+a9b40aec-4389-4eab-8acb-c579ea34c04e,[Données non publiées],gérante de société [Données non publiées],conseil,
+a9b55f72-8776-4f89-a92b-f4c84fee23be,[Données non publiées],ESMPI [Données non publiées],Infirmière psychiatrique,
+a9b968ca-cb15-4790-bfad-e87346c42919,[Données non publiées],Conseil régional Nouvelle Aquitaine,Secrétaire Générale du pôle [Données non publiées],[Données non publiées]
+a9bb6de1-fd3b-47de-b4b2-6e0079728697,[Données non publiées],FAUN environnement,soudeur,
+a9c9ea79-9af0-47d5-a1f9-18d2551bc1f9,[Données non publiées],NEANT,NEANT,
+a9d12daa-0b41-4c2f-926b-34aaf4b50dbe,[Données non publiées],Bénénova,Chargée de développement [Données non publiées],
+a9e3267a-3083-4baf-8c27-689b39490423,[Données non publiées],retraitee,fonctionnaire territorial,
+a9e34ebe-d7ca-4599-8fa7-c2f967296271,[Données non publiées],RETRAITEE,Néant,
+a9eb327c-07f9-46ed-bd45-de4ab9bf3dc2,[Données non publiées],AUCUN,RETRAITEE,
+a9f6ee6c-c297-4efe-8f7c-5cedd3d3f7da,[Données non publiées],neant,néant,[Données non publiées]
+aa03cbd1-ce5a-47a0-b58e-8b942fa6942d,[Données non publiées],Caisse d'Allocations Familiales,Assistante Sociale,
+aa05189d-b160-4515-8f64-6643ee8af2b7,[Données non publiées],EDUCATION NATIONALE,Adjoint administratif,
+aa07971a-f355-4f6b-a9a5-951ac1a28c56,[Données non publiées],Conseil départemental de La Loire,gestionnaire de dossiers [Données non publiées],[Données non publiées]
+aa1455cb-402e-4188-ba9f-1a4afcc3b6a4,[Données non publiées],Pharmacie de BEAUREGARD,docteur en Pharmacie,[Données non publiées]
+aa1e596d-e47e-40bd-b48f-5567e4251a83,[Données non publiées],Autoentrepreneur,Tapissière,[Données non publiées]
+aa33f757-31f8-4f97-b43c-efc177c0c99f,[Données non publiées],OGC SAINT ANDRE,INTERVENANTE [Données non publiées],
+aa33f757-31f8-4f97-b43c-efc177c0c99f,[Données non publiées],CRECHE KOKIRI,INTRVENANTE [Données non publiées],
+aa352f9f-2cdc-4b80-bb27-e76e2d397272,[Données non publiées],SELARL Pharmacie Centrale [Données non publiées],Gérante Pharmacie officine,
+aa3ab958-e898-45c5-aa4e-64db37a5f14c,[Données non publiées],Education Nationale,Professeur des écoles,
+aa4067c7-753f-476e-bdc8-ac9ad8975534,[Données non publiées],Ville de Val de Reuil,Néant,"Depuis décembre 2022 [Données non publiées] directrice ""sports, culture et vie associative"" à la mairie de Val de Reuil."
+aa4067c7-753f-476e-bdc8-ac9ad8975534,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] conseillère municipale de Canteleu.
+aa4067c7-753f-476e-bdc8-ac9ad8975534,[Données non publiées],Région Normandie,Conseillère régionale,[Données non publiées] elle a démissionné de cette fonction le 20 février 2024.
+aa4067c7-753f-476e-bdc8-ac9ad8975534,[Données non publiées],Métropole Rouen Normandie,Conseillère métropolitaine,[Données non publiées]
+aa4067c7-753f-476e-bdc8-ac9ad8975534,[Données non publiées],LOGEAL,Membre du conseil d'administration,[Données non publiées]
+aa4067c7-753f-476e-bdc8-ac9ad8975534,[Données non publiées],HABITAT 76,Membre du conseil d'administration,[Données non publiées]
+aa4067c7-753f-476e-bdc8-ac9ad8975534,[Données non publiées],CCAS de Canteleu,Présidente du Conseil d'administration,[Données non publiées] a démissionné de cette fonction le 20 février 2024.
+aa4067c7-753f-476e-bdc8-ac9ad8975534,[Données non publiées],Centre de Gestion de la Fonction Publique Territoriale,Membre du conseil d'administration,[Données non publiées]
+aa46c67a-a8c1-4970-a1fc-7ecce5ca1a13,[Données non publiées],neant,neant,
+aa5c37d5-d265-4648-b268-bfaa42c1efab,[Données non publiées],France Télévision,Journaliste,
+aa654963-e13c-4cbc-8639-43c363a78b67,[Données non publiées],Radiologie [Données non publiées],secrétaire administrative et comptable,
+aa6acbbc-b134-45f3-8a0b-df9e91016081,[Données non publiées],Ministère des collectivités territoriales,Administratrice civile,
+aa7294d0-2045-46a6-adbf-4ca152a5bdc2,[Données non publiées],néant,néant,
+aa85cb01-8e1f-4f80-97d6-fc766e9ee218,[Données non publiées],Amiens métropole,Cheffe de service,
+aa888ce0-7aac-4363-9f96-db2cdf8c4033,[Données non publiées],SASU [Données non publiées],"Président, participation aux activités de conseil en management",
+aa8b1fc4-de67-4b85-8a13-d99faf058f56,[Données non publiées],Mairie de Beauchamp,Assistante de direction,[Données non publiées]
+aa8cb2d3-1cb1-45eb-a9b2-905ad0073699,[Données non publiées],Agence départementale du Tourisme,[Données non publiées],
+aab40836-c76b-4316-b995-1b22338c6ea0,[Données non publiées],Centre Départemental de Gestion de la Fonction Publique Territoriale du Gard,Cadre de la fonction publique territoriale.,
+aad119ad-4594-4d50-b789-c5760ad5ccca,[Données non publiées],Ministère de l'agriculture et de l'alimentation,[Données non publiées],
+aadb0b20-3f0b-4096-8d9f-e71820184d5b,[Données non publiées],centre hospitalier [Données non publiées],conseillère [Données non publiées],
+aae0bb61-60ef-475f-87ad-4c830814f0d7,[Données non publiées],DB Conseil,[Données non publiées],
+aae23a37-f13d-4996-a3f8-b2f394ec73f5,[Données non publiées],Mairie [Données non publiées],Assistante Administrative [Données non publiées],[Données non publiées]
+aae4d16e-2b9d-466a-8897-cf5d41268fc6,[Données non publiées],Mairie de Portet sur garonne,Agent administratif,
+aae78137-fb21-4e6a-9125-ac40df66a6c3,[Données non publiées],Profession libérale,Psychologue,[Données non publiées]
+aaeea504-32b5-4109-b35c-c0a1b0b83be2,[Données non publiées],[Données non publiées],Architecte libérale,
+aaef3886-efef-4482-8c8e-e5ae14faf3ba,[Données non publiées],PACQUAM,"Directrice de l'association PACQUAM depuis 1997, en charge de l'aide à la scolarité [Données non publiées]",
+ab03634c-2446-4d0f-b47e-14eb55c430a2,[Données non publiées],Néant,Néant,En retraite
+ab0e3c7f-f37c-4a16-b4b4-99d73bbc3a30,[Données non publiées],Art Escale,Galiériste,
+ab1171c5-0adf-439a-8e7e-4ba45a9aaba0,[Données non publiées],Micro-Entrepreneur,Agent Commercial dans l'immobilier.,
+ab1dd27e-b1cd-4330-a6dd-a7e8b7cb6f53,[Données non publiées],Mairie [Données non publiées],Adjoint administratif,
+ab1e3f5d-0f67-4ede-b124-50f67c409926,[Données non publiées],ECOTEC,Assistante commerciale,[Données non publiées]
+ab2039de-2175-4fcb-864b-7e0374a11cf6,[Données non publiées],LABELIFE EVENTS S.A.S,Assistante de production,
+ab268ac9-d208-4ca3-95f2-849939684e28,[Données non publiées],France Travail,Chargée de mission conseil,
+ab2cc0ac-1bb8-4cae-b778-7fc3f41f75cb,[Données non publiées],CINEBOOK Ltd,Editeur de bande dessinée,[Données non publiées]
+ab349614-9e60-4dfd-9bab-dc0085d324f2,[Données non publiées],Néant,Néant,Retraitée
+ab4d88dd-6d21-48cb-b4ce-af64b7638247,[Données non publiées],chu [Données non publiées],[Données non publiées] [Données non publiées] technicien superieur hospitalier [Données non publiées],
+ab522318-7f85-44dd-9a4e-a7789bd8d6de,[Données non publiées],CNFPT,Enseignante vacataire,
+ab5851b2-d890-492a-9c4b-9c7b5f1777e8,[Données non publiées],EDUCATION NATIONALE,Professeure des Ecoles,
+ab5eea6e-bcf1-4ee5-b2aa-e146a6f25999,[Données non publiées],[Données non publiées],Urbaniste-Chargée d'études principale,
+ab64e085-1352-4033-9a42-f52700a0b6ac,[Données non publiées],néant,néant,
+ab6b4557-b744-4286-8e92-9c1233f22d3f,[Données non publiées],néant,retraité,
+ab78132d-e972-4242-9bb5-47665fae870a,[Données non publiées],CLOTURES MOIZARD,RESPONSABLE ADMINISTRATIF ET FINANCIER D'UNE ENTREPRISE DE CLOTURES DE MOINS DE 10 SALARIES,[Données non publiées]
+ab7ce72e-b30f-4268-9e77-6fe3d9c9ec5f,[Données non publiées],Retraitée [Données non publiées],Infirmière à la retraite,
+ab822270-87e6-4cc2-88f0-0df49f21c89f,[Données non publiées],neant,retraitée,[Données non publiées]
+ab87d138-c5d8-4cfa-8473-2130028a582e,[Données non publiées],Crédit Mutuel,[Données non publiées],
+ab87e4fe-aed3-40c2-ba17-8e59cfdbdbfa,[Données non publiées],PRADO BOURGOGNE,DIRECTEUR DE POLE,
+ab9badc6-b6bc-4537-9f50-84b02bd272ec,[Données non publiées],Ministère de l'Education Nationale,Enseignante spécialisée,
+aba52d69-aa42-44e7-9a56-e2b0922acbf9,[Données non publiées],Néant,retraité,
+abad14c7-d4dc-4495-814a-a51caee5d9f6,[Données non publiées],retraité,[Données non publiées],
+abae2dff-852e-4a4e-97a4-6ec4f76f152d,[Données non publiées],profession libérale,Kinésithérapeute,[Données non publiées]
+abaf70ed-cff2-4215-81a5-edb7cabc1e21,[Données non publiées],RUPTURES,DÉLÉGUÉ GÉNÉRAL,
+abaf70ed-cff2-4215-81a5-edb7cabc1e21,[Données non publiées],MTKK,PDG de cette SAS [Données non publiées],
+abaf70ed-cff2-4215-81a5-edb7cabc1e21,[Données non publiées],OMNI-TO,"Président de cette SASU, [Données non publiées]",
+abb97de6-3789-4539-a721-42530c29238f,[Données non publiées],[Données non publiées],Assistante sociale,
+abc2d64b-dff2-4985-8284-0c9556dfb6c8,[Données non publiées],Centre Hospitalier [Données non publiées],[Données non publiées] praticien hospitalier.,
+abce97f4-38fd-496b-ad29-bac6d6f64cb0,[Données non publiées],néant,néant,
+abd11cac-35b5-4ef3-a0c5-314855bfc090,[Données non publiées],CREDIT MUTUEL,CONSEILLERE CLIENTELE,
+abd2bc36-8728-45ec-b95a-b4ed06729249,[Données non publiées],Divers,Intermittente du spectacle.,
+abd50c30-4ba8-4ee8-a076-c8ed0a27a3b7,[Données non publiées],hopital [Données non publiées],secraitaire médicale,
+abd93aaa-2cd6-43ae-a3c3-26d22965c245,[Données non publiées],Lycée [Données non publiées],enseignante,
+abdd02e7-683d-4c63-bda6-373e9dbfec1e,[Données non publiées],OGEC ECOLE [Données non publiées] [Données non publiées],[Données non publiées],
+abe53411-2dec-40ec-8d2b-0c3d517683a7,[Données non publiées],néant,retraité de la Société Taxis Cousin,"Au 27 août 2021, gérant de la SCI [Données non publiées] (terrains et bâtiments)"
+abe5b536-15b2-42b6-a879-3a98d602d70b,[Données non publiées],néant,aucune,
+abe82cfd-e16e-468c-b768-5ddced4fffe9,[Données non publiées],Néant [Données non publiées],Néant,
+abf63c41-4e65-44b9-b9c4-10895988c98d,[Données non publiées],cabinet [Données non publiées],expert comptable,
+ac002a1a-5665-4e87-b66d-8aeef2e9e1d6,[Données non publiées],[Données non publiées],secrétaire,n'est plus en activité [Données non publiées]
+ac0e133c-6d12-4d91-b129-8a5fcd626dcc,[Données non publiées],ville de toulouse,agent administratif [Données non publiées],
+ac1fc426-8a09-4787-9e06-b74e911e6c77,[Données non publiées],Néant,néant,[Données non publiées]
+ac22372b-a745-45cb-b264-1fe19cc1f214,[Données non publiées],néant,néant,
+ac370183-0181-4ec6-82e0-41ca944ae6cc,[Données non publiées],[Données non publiées],Auto entrepreneur : prestations d'animation de réseau,
+ac49e382-9ea3-4ae0-8d0d-f32e8b013c24,[Données non publiées],Sarl [Données non publiées],salon de coiffure,
+ac4a4d13-cbb7-43ab-844f-2b434943bdbe,[Données non publiées],Mairie de FAUCON [Données non publiées],Secrétaire générale,[Données non publiées]
+ac4d2d25-5b4c-461a-ae70-8eca389eab5d,[Données non publiées],SARL [Données non publiées],"ACTIVITE : INGENIERIE , conception de salles d'affinage de fromages [Données non publiées]",
+ac4d2d25-5b4c-461a-ae70-8eca389eab5d,[Données non publiées],[Données non publiées],[Données non publiées],
+ac5725c8-bd0a-474f-b69e-4fc11d61289d,[Données non publiées],Centre Hospitalier [Données non publiées],Médecin spécialiste en imagerie médicale,
+ac5e25f9-7d70-42f8-b617-a9613710c41d,[Données non publiées],Profession libérale,Consultant,
+ac62c6aa-f51a-4101-9eae-6b7617a637a6,[Données non publiées],Profession libérale,Chirurgien ORL,
+ac683e40-69d0-4c2f-89aa-559684015219,[Données non publiées],Association OPTIMISM,responsable de la branche [Données non publiées],
+ac693815-1521-4a79-a314-6bd830de8988,[Données non publiées],Néant,Néant,[Données non publiées]
+ac6bba59-20e1-45af-9d36-d586c2abe8ba,[Données non publiées],Néant,Néant,
+ac7e440e-7263-4ea6-a8f4-470da7590ab6,[Données non publiées],Hop,[Données non publiées],
+ac80688d-4c7d-4e30-bba1-a185cd0163ea,[Données non publiées],NEANT,NEANT,[Données non publiées]
+ac897e84-c9c1-4fea-8e0f-a55fff8eab81,[Données non publiées],AVOCAT,AVOCAT,
+ac8ed7c8-03bb-4ee8-a6b3-5141d5775c2f,[Données non publiées],travailleur non salarié,[Données non publiées] Agent immobilier. [Données non publiées],
+aca38b42-0648-4484-a13b-6a4fb2cf82ea,[Données non publiées],conseil départemental,assistante sociale,
+aca71e62-3f6d-430c-b521-4cc3bfa6625b,[Données non publiées],Firmenich SA,Assurance qualité manager,[Données non publiées]
+acaf47d4-bd80-48e6-ae4f-e4d5043f667c,[Données non publiées],retraitee,neant,
+acb302a1-872b-4b19-9d9d-c9c3cbbe1ce2,[Données non publiées],BNPPARIBAS,[Données non publiées],
+acbb3d3e-9de0-499a-93b3-59ee38d048a3,[Données non publiées],communauté de commune de chateaulin,agent auprès des enfants [Données non publiées],
+acbb76b0-7c3d-4f20-95d0-47f3d784ce5b,[Données non publiées],Centre Psychothérapique de l'Orne,Assistante Sociale [Données non publiées],
+accb65b9-5342-42aa-bbc7-b4342a6b4ff2,[Données non publiées],retraitée,néant,
+acd5684c-6291-4641-89c6-8df221e4d8b8,[Données non publiées],La Poste,Conseillère aux particuliers,
+acd5684c-6291-4641-89c6-8df221e4d8b8,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] retraitée
+acdda324-5ddb-4023-935f-cb25b7ad65d5,[Données non publiées],Néant,Néant,
+acdea20f-787b-446b-8ffd-069854f5b0bb,[Données non publiées],Hachette éditions,auteur,parascolaire
+acdea20f-787b-446b-8ffd-069854f5b0bb,[Données non publiées],Nathan,auteur,manuel
+ace2aa86-ab71-4173-89b4-e8af031aacee,[Données non publiées],Ville de St Denis,[Données non publiées],
+ace2f574-95e0-4bc6-bf12-9c1f019f4165,[Données non publiées],CHIVA,Médecin [Données non publiées],
+acfbd757-09df-4bc0-bc3b-0cdea4c54f2c,[Données non publiées],Néant,Retraitée [Données non publiées],
+ad18d016-c444-4763-aece-dbcc5a3ef2d6,[Données non publiées],néant,retraitée,
+ad25d54f-57d3-4cc2-a0cd-2128c630983c,[Données non publiées],Castanea Spectacle et les objets perdus,Diffusion de spectacles - Intermittente du spectacle,
+ad25fb18-5646-4899-af53-047ccb9a6a08,[Données non publiées],SARL VEGA,EMPLOYE [Données non publiées],
+ad25fb18-5646-4899-af53-047ccb9a6a08,[Données non publiées],EIRL BARREAU,ELECTRICITE PLOMBERIE,
+ad28a31e-78d2-4a52-90c3-6b2a7c2a146e,[Données non publiées],CONSEIL DEPTAL DES HAUTS DE SEINE,[Données non publiées],
+ad2a0abc-a17b-4568-9b11-dd9c9b60dc25,[Données non publiées],parti communiste français,[Données non publiées],
+ad33024b-f9fb-43b7-bd10-ed974b70e93d,[Données non publiées],AUTOVISTA,Conseiller commercial [Données non publiées],
+ad34bdd7-9b9a-4905-8f10-264bbda02397,[Données non publiées],Education Nationale,Professeur des écoles stagiaire,
+ad40b286-e304-41a1-a1e4-1ffd2c7c6d1f,[Données non publiées],ALLIANZ,Conseiller en assurance et commercial [Données non publiées],
+ad410016-c5b5-4442-84b1-407f1d10d0bc,[Données non publiées],[Données non publiées] [Données non publiées],Retraité [Données non publiées],Plus aucune profession salarié depuis la retraite.
+ad41b9d9-3ce7-47c4-a5ba-3f6205a7976f,[Données non publiées],néant,retraité de la Société Taxis Cousin,"Au 27 août 2021, gérant de la SCI la [Données non publiées] (terrains et bâtiments)"
+ad456363-af81-4b1a-83b7-5a56f9584296,[Données non publiées],retraité,[Données non publiées],[Données non publiées]
+ad4ff817-d708-4737-8c3d-8dc2ce825c13,[Données non publiées],MAIRIE DE SALLAUMINES,[Données non publiées],
+ad5d7fa4-6667-4f3f-8072-a6284d827de1,[Données non publiées],Education Nationale,Professeur d'Arts plastiques,
+ad61d793-013b-4e9d-8b96-18952167b610,[Données non publiées],NEANT,NEANT,[Données non publiées]
+ad63c0c8-e8c6-4f40-a1a1-5b883e7dcc3d,[Données non publiées],retraitée,[Données non publiées],[Données non publiées] Médecin vacataire PMI pour le compte du conseil Départemental
+ad6587cb-5c02-4f3b-89b1-5350800f5bec,[Données non publiées],CPAM,Cadre Coordonnateur,
+ad821bbf-29ad-45c3-b1f7-0a6b5eb0425a,[Données non publiées],Ministère de l'Intérieur,Préfet de département,
+ad91ac5f-c0be-4f3d-9b9f-23d814dcf479,[Données non publiées],BPM,DIRECTEUR GENERAL,
+ada2fe81-9d7c-4b9b-bbb8-f4b3cf6bbfbf,[Données non publiées],Education nationale,Professeure des écoles,
+ada38c4a-2696-4730-87b7-3896d0fc3dbb,[Données non publiées],ACVPA,[Données non publiées],départ en retraite [Données non publiées]
+adaae169-87d4-45d6-852c-06fa9d28d5c6,[Données non publiées],Education nationale,Professeur des écoles,
+adb1bfcb-85a6-428a-b3a9-f7a4b79546d5,[Données non publiées],CNFPT,Rédacteur principal [Données non publiées],[Données non publiées]
+add554da-072f-4f8f-b7aa-2fdf03a272c2,[Données non publiées],[Données non publiées],Enseignant de Mathématiques,
+add554da-072f-4f8f-b7aa-2fdf03a272c2,[Données non publiées],SCEA [Données non publiées],Paysan,
+ade6a169-ec56-442e-9dc4-6ceb10ff2391,[Données non publiées],PHARMACIE [Données non publiées],PREPARATRICE EN PHARMACIE,
+adeed4f3-8cf6-4954-b165-b5b2d583cfa1,[Données non publiées],chef d'entreprise [Données non publiées],patronne et écrivain,[Données non publiées]
+ae036eaf-b10f-4d2b-9871-67e38378e243,[Données non publiées],Retraitée,Retraitée,[Données non publiées]
+ae124d7e-ad5d-408d-aa92-240887f4d4ea,[Données non publiées],retraité,néant,[Données non publiées]
+ae133a46-f5e2-4868-b476-9d46f33489b5,[Données non publiées],Conseil départemental de Loir et Cher,[Données non publiées],[Données non publiées]
+ae15dbfc-954d-4453-b6da-d355c754aff0,[Données non publiées],ville [Données non publiées],conseillere socio-éducative,
+ae1c6a92-d07d-4ac3-99a3-cbad0e574f7b,[Données non publiées],Kabaret,[Données non publiées],
+ae1fe4a9-3f4d-43f4-828d-5275ec91b1fb,[Données non publiées],CCAS ville de Boulogne sur mer,responsable du service [Données non publiées],
+ae325072-23df-4c9d-816a-5bc3e5109e75,[Données non publiées],Notaire associé,Notaire associé Etude : [Données non publiées],
+ae34f61f-243d-4408-a49f-e0ddffb90dbc,[Données non publiées],Éducation Nationale,Professeur des écoles,
+ae39c1ab-7092-47f0-a4ce-59ec723cee81,[Données non publiées],[Données non publiées] [Données non publiées],Dr Vétérinaire,RAS
+ae44eade-d867-44a8-bd95-ed4c5690788a,[Données non publiées],Groupama,Conseillère commerciale [Données non publiées] [Données non publiées],
+ae682bdd-2b88-4748-97ea-e45c5803191e,[Données non publiées],NEANT,Absence d'activités professionnelles,
+ae6e7695-dd57-4c9b-b6ca-7847d5992130,[Données non publiées],Groupe VYV,Président,
+ae6fd2c9-1130-4548-843e-928fc7598476,[Données non publiées],SAS SLTS,[Données non publiées],[Données non publiées]
+ae716ebf-0638-48e5-b2e6-35512071dab5,[Données non publiées],[Données non publiées],[Données non publiées],Gérant non salarié de l'EURL Le culturel [Données non publiées]
+ae830131-44d7-4a8b-a2c1-8fcc4a9d9476,[Données non publiées],NEANT,NEANT,
+ae8ba1b3-e6fe-47f4-901b-4994c5748481,[Données non publiées],[Données non publiées],Orthophoniste en structure d'accueil pour enfants handicapés,
+ae8fabb7-4606-4dd0-b873-bb0082024dd8,[Données non publiées],Assistance Publique - Hôpitaux de Paris,Interne [Données non publiées],
+ae93f8a7-d9bd-4a05-a0d0-f6d70b51dd8d,[Données non publiées],NEANT,NEANT,[Données non publiées]
+ae9e4097-bcbd-487f-bf84-821a680b1e01,[Données non publiées],[Données non publiées],Assistante maternelle,
+ae9e4b96-35f2-42e1-8377-e2d2cde1f80a,[Données non publiées],retraitée,retraitée,Activité antérieureDirection générale de la santé.
+aeaaf37a-a51e-4a1a-81b7-f33103bfb9bf,[Données non publiées],Agriculteur,Eleveur,
+aeb4a518-2b7f-4207-9774-61d01d40f172,[Données non publiées],Ville de Val de Reuil,Néant,"Depuis décembre 2022, mon épouse est directrice ""sports, culture et vie associative"" à la mairie de Val de Reuil."
+aeb4a518-2b7f-4207-9774-61d01d40f172,[Données non publiées],Ville de Canteleu,Maire,[Données non publiées]
+aeb4a518-2b7f-4207-9774-61d01d40f172,[Données non publiées],Région Normandie,Conseillère régionale,Il ne s'agit pas d'une activité professionnelle mais d'un mandat électif rémunéré [Données non publiées]
+aeb4a518-2b7f-4207-9774-61d01d40f172,[Données non publiées],Métropole Rouen Normandie,Conseillère métropolitaine,"Il ne s'agit pas d'une activité professionnelle mais d'un mandat électif rémunéré, [Données non publiées]"
+aeb4a518-2b7f-4207-9774-61d01d40f172,[Données non publiées],LOGEAL,Membre du conseil d'administration,Il ne s'agit pas d'une activité professionnelle mais d'un mandat d'administrateur (non rémunéré).
+aeb4a518-2b7f-4207-9774-61d01d40f172,[Données non publiées],HABITAT 76,Membre du conseil d'administration,Il ne s'agit pas d'une activité professionnelle mais d'un mandat d'administrateur (non rémunéré).
+aeb4a518-2b7f-4207-9774-61d01d40f172,[Données non publiées],CCAS de Canteleu,Présidente du Conseil d'administration,Il ne s'agit pas d'une activité professionnelle mais d'un mandat d'administrateur (non rémunéré).
+aeb4a518-2b7f-4207-9774-61d01d40f172,[Données non publiées],Centre de Gestion de la Fonction Publique Territoriale,Membre du conseil d'administration,Il ne s'agit pas d'une activité professionnelle mais d'un mandat d'administrateur (non rémunéré).
+aeb84735-4ced-4e55-948e-1046f92083a6,[Données non publiées],[Données non publiées],Avocat,
+aebe314b-6e8c-447d-80a8-a6052fc4af49,[Données non publiées],Education nationale,Enseignant Bac Pro et BTS Pro,
+aebe3370-cc2a-4c41-8d20-dbbae0e4b18d,[Données non publiées],RECTORAT GUYANE,ENSEIGNANTE SECOND CYCLE,[Données non publiées]
+aebfc448-16f4-4447-ae8c-8e680194a6cb,[Données non publiées],autoentrepreneur,psychologue,
+aec77213-577a-4d11-bced-a180933c47e0,[Données non publiées],[Données non publiées],Retraité,
+aeccba5a-064e-41ac-90ef-e98f3bb69e7a,[Données non publiées],aucun,gérant SARL CMEP [Données non publiées],[Données non publiées]
+aed40a3b-7cd7-4b75-9eee-517dbb45806f,[Données non publiées],[Données non publiées],Médecin libéral spécialiste [Données non publiées],
+aedcc53d-af21-48dd-857b-f29ea02efce3,[Données non publiées],néant,néant,Retraitée de la fonction publique territoriale
+aef1e487-42ac-4c8f-95e4-cd2c5aa87a60,[Données non publiées],PHI SAS,[Données non publiées],
+aef4e813-22ea-467d-af1e-6e1539a88c2b,[Données non publiées],Association Villevieille,Chef du service [Données non publiées],
+aef70812-1b43-4b41-8e8c-37c66dcb6d6e,[Données non publiées],Parlement européen,[Données non publiées],[Données non publiées]
+af00c10f-744d-41c9-b944-c09ad126deff,[Données non publiées],Société Les Petits Poulbots,[Données non publiées] vendeuse [Données non publiées],
+af04fead-c11b-4bb4-9685-4ef3446729ad,[Données non publiées],RETRAITE,RETRAITEE,NEANTRETRAITEE
+af0639bd-4365-4fac-b8cb-56defc67d228,[Données non publiées],CPAM de l'Eure,[Données non publiées],
+af22aff4-ee9c-48da-a8cf-b06f68e53652,[Données non publiées],[Données non publiées],[Données non publiées],En retraite [Données non publiées]
+af38255f-6bb2-4e8d-853c-b5d32aa249fa,[Données non publiées],Néant,Néant,
+af3e8878-43e1-45d7-b862-1f82204fe2ca,[Données non publiées],AFLD Paris,[Données non publiées],Infirmier [Données non publiées]
+af3f0f2c-c25e-4b4f-8d70-19d7f5e670e6,[Données non publiées],communauté de communes de Gémozac,[Données non publiées],
+af44a077-f19c-4265-865a-028f1a95e5f2,[Données non publiées],AUTOENTREPRENEUR,DIVERS TRAVAUX DE RENOVATION PETITE MACONNERIE,
+af490d23-cc62-4a68-ae5a-24d0dfe9c770,[Données non publiées],[Données non publiées],Ingenieur,RETRAITE [Données non publiées]
+af4feba4-49d2-4914-b8b4-d2401399fcde,[Données non publiées],[Données non publiées],[Données non publiées] Retraité de l'éducation nationale.,[Données non publiées]
+af68de96-cab1-4161-8511-b22a23ea5cfe,[Données non publiées],néant,néant,
+af6d99ad-7f50-4e12-aeae-ec67ba1445ff,[Données non publiées],Mairie de Gennevilliers,Professeur d'enseignement artistique [Données non publiées],
+af70f1c4-003e-4a04-84b5-7ff6de805f9b,[Données non publiées],CPAM 93,Cadre de la fonction publique,
+af75aa4c-bbc7-4be3-9b60-9dfa6f8fd965,[Données non publiées],néant,néant,[Données non publiées]
+af85d193-8354-46d7-a77b-68dbb0086b92,[Données non publiées],Mutualité sociale agricole,[Données non publiées],
+af85f530-8493-4249-9cad-6b16bab965b1,[Données non publiées],PARIS AEROPORT,[Données non publiées],
+af88888c-d377-489a-86cf-be232280ece6,[Données non publiées],NESTENN,AGENCE IMMOBILIERE,
+af88888c-d377-489a-86cf-be232280ece6,[Données non publiées],ARTHUR IMMO,agent immobilier,
+af9d78db-f81f-4ec6-85fa-494b1668475a,[Données non publiées],sncf,agent polyvalent,
+af9dcaa2-e070-4ea6-a9d9-96f0e6e83c16,[Données non publiées],Decathlon,Employé,
+afa376c8-1cf1-4787-8460-3951c7394448,[Données non publiées],A COMM,Cabinet d'Expertise comptable,
+afaff5af-f3ef-44a6-aaef-a25b4fe320c8,[Données non publiées],Education nationale,Professeur vacataire,
+afbc2c77-bbdb-44d7-b685-be014477ffbd,[Données non publiées],néant,néant,[Données non publiées]
+afe0f5e0-88a3-4eb2-bd62-cc9e58883ae2,[Données non publiées],néant,néant,[Données non publiées]
+afe1c0ee-cc69-4423-9312-55bf6c5f6d0f,[Données non publiées],scp infirmieres,infirmiere liberale,
+afe2b757-9c16-463f-a487-b092309405f2,[Données non publiées],Education Ntionale,Professeur de français en collège,[Données non publiées]
+afe303a6-ca05-4e05-8161-d03809d0734d,[Données non publiées],CAF GUYANE,Technicien conseil [Données non publiées],
+afe64dc9-b7be-4907-8fbe-8d1d4baf1918,[Données non publiées],néant,retraitée,
+afe680a6-5613-4bd0-9ff4-58b7e2534c46,[Données non publiées],[Données non publiées],assistante Maternelle,
+aff12332-9992-4491-b294-5e2bb6ff2225,[Données non publiées],EDUCATION NATIONALE,professeur des écoles (Directrice d'école),
+aff2a4de-7c2b-462b-8db6-88b5cd0dcc13,[Données non publiées],AUTO ENTREPRENEUR,CONSULTANT EN COMMUNICATION,
+aff69e01-8e00-4202-96ab-965bf11d078e,[Données non publiées],Neant,sans profession,[Données non publiées]
+aff69e01-8e00-4202-96ab-965bf11d078e,[Données non publiées],NEANT,NEANT,
+b001ae24-bc2a-4d2a-97da-f63c4a670379,[Données non publiées],Ministère chargée de l'égalité entre les femmes et les hommes,Attachée principale d'administration [Données non publiées],
+b0062374-3798-4161-b289-451e9d4945ee,[Données non publiées],Association ABCM zweischprachigkeit [Données non publiées],Professeur des écoles et Directrice maternelle,
+b00caf9b-4aab-4615-8aa9-09d583420988,[Données non publiées],NEANT,NEANT,
+b01974da-ae94-437a-958e-323cd2eeca5f,[Données non publiées],Néant,Gestion de son parc immobilier et de son patrimoine financier,[Données non publiées]
+b024d55b-044e-4a3b-b224-8c8aec3bc143,[Données non publiées],[Données non publiées],saariée d'une activité de tourisme,[Données non publiées]
+b0268727-af55-4a2a-98fb-6bf6b88cd82b,[Données non publiées],ORANGE,Employé de bureau,
+b03cff75-a970-4428-9231-a2448b3e0979,[Données non publiées],Éducation Nationale,Principale-Adjointe [Données non publiées],
+b0438795-136a-4ade-a1cb-e4bcecf06562,[Données non publiées],SAS MITJAVILA,Employée de bureau,
+b050753c-9ded-4d83-9f97-9cffa6114496,[Données non publiées],RETRAITE,[Données non publiées],NEANT
+b0535e6b-a3a8-4598-9b82-12c0f3a7fcb8,[Données non publiées],"TOTAL Energie,",néant,Cessation d'activité anticipée
+b054c1ba-405c-4773-8950-89824d522c66,[Données non publiées],GAEC [Données non publiées],Agriculteur,
+b05d882e-8a3d-4ead-a40d-e34140b90e01,[Données non publiées],Eriks SAS,Responsable approvisionnement et stocks,
+b069d627-5b45-40d5-9474-7dcc6d5aee36,[Données non publiées],[Données non publiées],Exploitant agricole,
+b076bab1-97a5-48fe-822e-9e3144ed0531,[Données non publiées],MEDECIN,MEDECIN DU SPORT [Données non publiées],
+b07cd99e-0909-4471-b2d2-f166d0af9734,[Données non publiées],Apple Retail,Manager commercial,
+b07f37a7-99a3-40aa-8b8c-91eb0ed684ca,[Données non publiées],néant,néant,retraité
+b087bb77-8efd-4d30-87aa-6e2ea8e8cf82,[Données non publiées],EDF,QSE /Chargé d'affaires,
+b09345f3-f456-4e79-8745-718d48e579dc,[Données non publiées],néant,néant,
+b0a61e97-cc0b-4e40-a544-6e65563ddc10,[Données non publiées],Fonction publique,Magistrat administratif,
+b0ad8436-aca4-4544-afb0-af5d2634c640,[Données non publiées],EXPLOITANT AGRICOLE,[Données non publiées],
+b0b296c6-c1ca-4eac-8c57-6a9fd52a3d63,[Données non publiées],exercee a titre individuel,auteur compositeur interprete,
+b0b734db-146e-442c-bdbe-b7b39b343332,[Données non publiées],Ministère de la Culture,Conservatrice du patrimoine,
+b0b73f5b-813d-44cf-9234-90fd6c538c50,[Données non publiées],[Données non publiées] Chirurgien dentiste [Données non publiées],Assistante dentaire,
+b0bbeace-f504-4e21-811d-467327ae6270,[Données non publiées],Mairie Essarts en Bocage,[Données non publiées],
+b0bd9132-a647-43f6-9b59-72647d7ba510,[Données non publiées],Conservatoire de musique [Données non publiées],enseignement musical,
+b0bffaf7-8ab9-40cf-a6d6-ff3c71aa881f,[Données non publiées],Sas Fd Arnaud,[Données non publiées],
+b0c73f57-ff21-4ea5-91f2-d32a88f0a214,[Données non publiées],CREDITAGRICOLE [Données non publiées],[Données non publiées],
+b0c7aa54-18a3-4c72-bfeb-e2e6c5517511,[Données non publiées],Coopérative Maritime,Employé de commerce,
+b0c7d376-4031-4db2-8a22-3cfa8849bb91,[Données non publiées],ETABLISSEMENT FRANCAIS DU SANG,LOGISTIQUE,[Données non publiées]
+b0d296e5-2871-415d-9645-b6b7799a3b7c,[Données non publiées],neant,néant,
+b0db2c4b-6ef6-463a-a305-f3076fe2f0f2,[Données non publiées],Retraité,Ancien exploitant agricole,
+b0e42bff-538d-47bb-bd6a-ef9053b8292c,[Données non publiées],profession libérale,Vétérinaire,
+b0f14784-8e50-46ee-9c79-a16855c3d77c,[Données non publiées],lui même,journaliste Président et directeur du journal Le petit mag Lens Liévin exploitant agricole [Données non publiées],[Données non publiées]
+b0f8f920-f001-4bbc-bb72-4edd561eb95b,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] retraite [Données non publiées]
+b102f3b8-0ec2-410d-8ebb-30cf76288f95,[Données non publiées],Conseil départemental des Landes,[Données non publiées],[Données non publiées]
+b105d77e-b0a0-4c8a-8b04-bbd25c64d492,[Données non publiées],Education Nationale,Enseignante,
+b1086ab6-b772-4de4-abb5-b6b4e24a3654,[Données non publiées],SPSTI [Données non publiées],Directrice générale,
+b10a7b69-9494-4077-8f4f-0fbaf9c304dd,[Données non publiées],Lycée Professionnel [Données non publiées],Formateur / enseignement agricole privé sous contrat,
+b10c0772-1d1a-469c-9410-dd602bfc12db,[Données non publiées],"ESSEC, GEM, SKEMA, ESA",Enseignant vacataire en grandes écoles.,
+b1205267-eb09-4d72-a5bc-4bf2aa3dedba,[Données non publiées],Université de Strasbourg et Hopitaux Universitaires de Strasbourg,Professeur des Universités - Praticien Hospitalier,
+b1205ef9-ff1c-4bb2-ba41-ee87463f5197,[Données non publiées],Sté [Données non publiées],Transport,
+b120e41b-2952-451c-b151-70c2f6d31ece,[Données non publiées],Retraitée Renault,néant,
+b12a4eb0-b0fa-421d-bb3f-76d9657fe196,[Données non publiées],néant,Retraité,
+b13250e7-8171-437f-aa3b-13e4e669c4d8,[Données non publiées],OMEGREEN SARL,Gérante Stratégie commerciale,[Données non publiées]
+b135a587-31ac-4783-91cc-d8a68839f60d,[Données non publiées],CEPAC,employée de banque,
+b136d440-7ff8-46e2-a89f-2c93a1b9eb6d,[Données non publiées],Médecin spécialiste libéral [Données non publiées],Spécialiste en endocrinologie installée en libéral et hospitalière,[Données non publiées]
+b136ece7-8cd6-402e-9f4d-f12d368be9f0,[Données non publiées],air france,chef de cabine,
+b148ef02-bcb7-4ef8-908d-a760a4c5f0a7,[Données non publiées],AHM,Dirigeant de l'entreprise [Données non publiées],
+b1493a66-bd8d-4af7-be3f-fd23d8ab8258,[Données non publiées],Néant,Néant,Néant
+b14cfa52-8c36-4b1c-ad33-42700c25e8be,[Données non publiées],NEANT,NEANT,
+b1553814-6546-47de-8d04-04b17174708d,[Données non publiées],auto-entrepreneur,Psychologue,
+b15587b5-bb01-4333-94ca-5d6c7e18922e,[Données non publiées],[Données non publiées],[Données non publiées],Arrêt [Données non publiées]
+b155e4ec-cb2a-4249-8349-3f6e396e2989,[Données non publiées],[Données non publiées],entreprise &gro alimentaire Directeur technique,[Données non publiées]
+b1643da3-062c-434a-9737-8a3e2731bc35,[Données non publiées],néant,retraitée,
+b16806b3-ba3a-46c6-9647-8f4d1e0ed9ac,[Données non publiées],Ville de Montreuil,[Données non publiées],
+b16a5d49-4126-4a0f-80fe-651b128b59df,[Données non publiées],RMP CARAIBES,AGENT TRANSPORT MARITIME ----------------------- [Données non publiées],
+b1767446-f037-4cf2-86c6-86492b675aa5,[Données non publiées],retraité,[Données non publiées],[Données non publiées]
+b17d14d0-3a54-46a0-89da-ce29817e4712,[Données non publiées],Retraité,retraité,
+b17d803c-dc7c-4bbc-b7c4-a64e6e659439,[Données non publiées],ADP Salarié,Délégué aux affaires territoriales [Données non publiées],
+b1831947-5133-49ca-9d11-f3d08c10e7dd,[Données non publiées],Pays de Montbéliard Agglomération,Fonctionnaire territorial,
+b18c07ba-f4d8-4aac-934b-f3170ed7729d,[Données non publiées],conseil départemental 35,Chargée de missions [Données non publiées],
+b18f851e-53b3-4e35-9042-cc6d23ef7456,[Données non publiées],[Données non publiées],Dirigeante de la société (SASU),
+b195f9cb-5fdb-4da6-91b4-7ef846d2fc91,[Données non publiées],ContentArmor,[Données non publiées] [Données non publiées],
+b196e92f-0c22-4920-8cc9-844f3c1c4a02,[Données non publiées],[Données non publiées],[Données non publiées],
+b1a513e0-0782-4cfe-af01-cf55da624771,[Données non publiées],ABL EMPLOI,cabinet de recrutement,
+b1a83c1d-9973-4798-abb8-8f6be1d0c202,[Données non publiées],NEANT,NEANT,
+b1abb7ee-d357-4d39-a231-b1e6b19b2fa8,[Données non publiées],MULTIPLES EMPLOYEURS (INTERMITTENTE DU SPECTACLE),CHARGEE DE PRODUCTION,
+b1b559f3-c8e9-4c64-9bf2-b332d850112e,[Données non publiées],Education nationale,Professeur [Données non publiées] de sciences économiques et sociales [Données non publiées],
+b1c6d206-76ff-43cc-922d-5c649dec01db,[Données non publiées],UCLY,Enseignant-Chercheur Biologie,
+b1ca5f5b-a506-4cd2-95f4-cfbd7f6e5486,[Données non publiées],CENT ET PLUS Sarl,CONSEIL EN GESTION,[Données non publiées]
+b1cda593-79a4-4e69-afa3-38f249866a3c,[Données non publiées],Conseil Régional d'Ile de France,[Données non publiées],
+b1cffdde-dd0c-4294-bbe3-683ac2b79eee,[Données non publiées],NEANT,NEANT,[Données non publiées]
+b1d60ae8-0f4a-4729-9d44-448e85c8c9d1,[Données non publiées],PLR,Secrétariat,
+b1f5bde3-36a2-4a71-8fd0-34227f1e83c0,[Données non publiées],Accelonix SAS Evreux,Directeur du Développement,[Données non publiées]
+b2012d4c-be70-4b1b-9cca-6c7fa2479882,[Données non publiées],Néant,Néant,
+b20f8aba-eb2f-4287-b194-32827e29aa44,[Données non publiées],Hauts de France Innovation Dé veloppement,"Responsable du service Réseaux et Développement, cadre",
+b2103eda-0daf-4267-84e2-0a0b2d820857,[Données non publiées],GFA [Données non publiées],GERANT,
+b21313d7-61c9-41dc-ad3e-d02cd218e9aa,[Données non publiées],CAISSE REGIONALE DU CREDIT AGRICOLE MUTUEL DE LA REUNION,[Données non publiées],
+b215dd34-44cb-4a52-ab3e-70f96df1a056,[Données non publiées],Néant,Consultante - formatrice,
+b2167876-047a-480e-8b23-0c60a1340f0e,[Données non publiées],CSAPA Verdun,Infirmière sociale,
+b23a0b88-8323-4e3a-ae0b-9513f658748a,[Données non publiées],Hopitaux [Données non publiées],Interne en médecine,
+b23f74f6-ad95-4a79-896f-a5b06a972af0,[Données non publiées],DGFIP,Contrôleur des Finances publiques (Fonctionnaire),
+b23f8c61-2dfc-4720-bd95-2cd40378cda4,[Données non publiées],LIBERAL,MEDECIN GENERALISTE,
+b240c76f-7993-46bc-986a-8bc63d2fb7af,[Données non publiées],Association Francaise des Pôles de Compétitivité (AFPC),Déléguée générale,
+b2553ec4-76e6-4a0b-9622-a558c78d013f,[Données non publiées],Agence départementale du Tourisme,[Données non publiées],
+b25a3c2c-80ab-44cf-82bf-1ac3e7668cd3,[Données non publiées],Independante,Formatrice,
+b25aedb4-dfb6-4405-bcab-ac902de5bf86,[Données non publiées],[Données non publiées],Retraité,
+b265732c-c944-4453-96c6-adf9b7eaa2ce,[Données non publiées],Commune de Brétigny-sur-Orge,Rédactrice territoriale [Données non publiées],
+b269dff4-ff00-4d50-b6f3-c36d138928e8,[Données non publiées],CCVS,Agent d'animation périscolaire,
+b2700463-9706-4123-bb93-92a1e4204224,[Données non publiées],Education national,Professeur de lycée professionnel,
+b2a86fe2-1fef-4f83-b241-8e7b4f003b66,[Données non publiées],[Données non publiées] AGENT SWISSLIFE,[Données non publiées],
+b2b0a45c-a373-4d2d-963f-f4c17c1a29e9,[Données non publiées],Activité libérale,Architecte,
+b2bdccaf-4edf-4a45-b46f-e110694d87be,[Données non publiées],conseil,Médecin,
+b2cb68cc-b46a-477e-b0a9-0c61b7262bc2,[Données non publiées],NEANT,[Données non publiées],
+b2d1f21f-0005-430b-986b-401c4f6b8bd8,[Données non publiées],[Données non publiées],Directrice Générale,[Données non publiées]
+b2d42c09-1374-4763-aa39-a3b158bf0dd3,[Données non publiées],DGAC,[Données non publiées],
+b2d49a15-6c40-40d4-8030-0678ee457589,[Données non publiées],retraité,retraité [Données non publiées],
+b2ef37c9-4607-4f73-9652-051a9dc0e9f4,[Données non publiées],ALSTOM,Ingénieur,
+b2fc43da-7955-41da-96b2-f09064fcef30,[Données non publiées],néant,néant,
+b30cebc2-86a7-4d6f-a47e-938ebe0c0206,[Données non publiées],EDUCATION NATIONALE,Professeur d'allemand [Données non publiées],[Données non publiées]
+b31808f8-a4dd-45a3-9d30-9f6839bedc0a,[Données non publiées],SCI [Données non publiées],[Données non publiées],[Données non publiées]
+b3362e19-a917-4a00-a1a2-0f7aebe5abfc,[Données non publiées],[Données non publiées],Mandatairejudiciaire,
+b339e6f0-0dac-49e2-bafe-2a7d9daacf13,[Données non publiées],sagess,AMP/AES= accompagnant éducatif et sociale,Maison de retraite [Données non publiées]
+b34d25e0-1f20-4de2-9895-c589700e9d63,[Données non publiées],[Données non publiées],retraitée,
+b34f4052-c7c3-4c3e-8131-c1230ab79bed,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] retraitée [Données non publiées]
+b34fcb50-86e5-4525-904b-34e0f6fe50fb,[Données non publiées],Retraitée,retraitée,
+b358017f-5d14-4dc6-812c-2fc3bb81b68d,[Données non publiées],megagence,[Données non publiées],
+b358017f-5d14-4dc6-812c-2fc3bb81b68d,[Données non publiées],valorège,société d'investissements et de participations,
+b35c3a69-1cfe-47b8-914d-61497f9c2b4c,[Données non publiées],Agriculteur,Exploitant Agricole,associé dans le GAEC [Données non publiées]
+b35d2a08-165b-4013-817b-35d1c82316e5,[Données non publiées],retraité,néant,[Données non publiées]
+b35e4b4f-e35b-43a8-b1fb-3233d2f20493,[Données non publiées],Education nationale,Professeur de physique chimie,
+b3796a8b-4e53-46a5-8bb7-b694cdf92ac0,[Données non publiées],Auto boulevard,Mécanicien automobile,
+b38ca0fa-f8da-4ee6-80a1-e0b98881ca88,[Données non publiées],NEANT,NEANT,
+b3924f4a-8c06-4885-bac2-a776b28826b7,[Données non publiées],CLEMESSY,CHEF DE PROJET,
+b3985d83-6756-4ad0-aa62-07ad10e94641,[Données non publiées],Centre Hospitalier [Données non publiées],Assistante spécialiste des Hôpitaux,
+b39c40a4-2444-456e-a423-61acd38a47d4,[Données non publiées],Viticulteur ( son propre employeur),Viticulteur,
+b39d8ffc-fa68-4c0f-b3a5-a1edbb2aca60,[Données non publiées],PHARMACIE [Données non publiées],PHARMACIENNE,[Données non publiées]
+b3a3e8c8-5101-4d77-942a-6321c31915a5,[Données non publiées],Education national,Professeur de lycée professionnel,
+b3a76dfa-925f-4f5a-81d1-e9b357c21423,[Données non publiées],[Données non publiées],Dirigeant de société groupe automobiles [Données non publiées],[Données non publiées]
+b3a94dc4-e00b-47d5-8463-1f3f05f47b69,[Données non publiées],EDUCATION NATIONALE,Retraite,
+b3b462ea-77a4-4144-89bb-5d507180f3e5,[Données non publiées],[Données non publiées],[Données non publiées],cessation d'activité [Données non publiées]
+b3b462ea-77a4-4144-89bb-5d507180f3e5,[Données non publiées],Dialogues et Solutions,salariée [Données non publiées],
+b3b4d768-da83-4a1c-9d7d-34dce76fb595,[Données non publiées],Mairie Loroux Bottereau,Agent Maitrise [Données non publiées],
+b3b60042-3b2b-4934-83fa-7d42bd5521a1,[Données non publiées],CEPAC,employée de banque,
+b3b8f68f-979e-4621-97d4-4ee0bfa26454,[Données non publiées],Secrétaire médicale,Assistante d'un chef de service à l'Hôpital [Données non publiées],
+b3c2b89d-88cc-4c44-86f8-7fcbcc89bb8f,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+b3c2b89d-88cc-4c44-86f8-7fcbcc89bb8f,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+b3c2b89d-88cc-4c44-86f8-7fcbcc89bb8f,[Données non publiées],INSIGHT,ingénieur commercial,[Données non publiées]
+b3cc4796-a0a6-4d8c-a8ed-894c8d80977b,[Données non publiées],indépendante,galeriste [Données non publiées],
+b3e78003-46bb-46ea-b409-2154f89a4857,[Données non publiées],Mairie d'Aix en Provence,[Données non publiées],
+b3ee10d5-f40a-40c3-ae85-906b77039b06,[Données non publiées],Communauté d'agglomération d'Alès,Attachée de Conservation Culture,
+b3ef1b24-d8ee-4da9-828d-cd3dfa9eddd8,[Données non publiées],retraité,retraité,
+b3f604e1-e2cb-43a1-a5e7-4bbb311173df,[Données non publiées],IME [Données non publiées],secrétaire de direction,
+b4063547-a114-42f5-90dc-818bd615f8ab,[Données non publiées],Retraitée,Néant,[Données non publiées]
+b40688ac-e38f-4718-8083-71fb07285e84,[Données non publiées],Ministère de l'Intérieur,Retraité,
+b43b01b7-0849-48cc-9d98-6875fc6765c7,[Données non publiées],[Données non publiées],sans emploi [Données non publiées],
+b43c59ed-05b0-4e1f-8b0d-75fba7af928b,[Données non publiées],SDIS de l'Ardèche,Chef de service [Données non publiées],[Données non publiées]
+b443d00b-b6d0-4a29-b9c4-fc2d4ff6f7a2,[Données non publiées],Néant,Néant,Retraitée [Données non publiées]
+b45fb87a-dadc-47b3-9b3e-2617a2dad44e,[Données non publiées],[Données non publiées],Cadre territoriale,
+b46b2117-7a3b-4778-b4d6-85690acf23b8,[Données non publiées],RETRAITEE DE L'ARS,ASSISTANTE DE DIRECTION,RETRAITEE [Données non publiées]
+b475fb98-01a5-4969-8377-b529dacb434b,[Données non publiées],SMTP (LINGENHELD),DIRECTEUR D'AGENCE cadre dirigeant,[Données non publiées]
+b479914b-c459-43df-9771-04826a82e1c7,[Données non publiées],La Fab,[Données non publiées],
+b487f05f-955b-4976-b8b4-d0ab641dad9a,[Données non publiées],indépendant,ingénieur du son et DJ,[Données non publiées]
+b4944093-3f51-40c3-b6a7-7811c68083db,[Données non publiées],Lycée [Données non publiées],Comptable,
+b49aa787-9f88-46fe-8504-6e544771fbaf,[Données non publiées],Education Nationale,Inspectrice de l'Education Nationale,
+b49aba3d-1154-49b8-91e2-d7a0852c57bd,[Données non publiées],diocèse de Luçon,[Données non publiées],
+b4b65896-b088-44b5-ab12-5683b2155619,[Données non publiées],Inspection académique d'Ille-et-Vilaine,Professeure des écoles,
+b4c04f7b-3ca7-4033-9221-160bccb2b7ed,[Données non publiées],auto entrepreneur,professeur libéral de yoga,
+b4c75a46-e7cb-4cdc-883d-63427aa16ad4,[Données non publiées],néant,[Données non publiées],néant
+b4cab925-6f29-4956-99b7-be2682f7b66b,[Données non publiées],[Données non publiées],néant,
+b4ceb16a-8ab8-490a-949b-1ebe883f51b0,[Données non publiées],CCAS Ville de Paris,Attachée territoriale - Direction de la solidarité,
+b4d0b1ad-a3d5-4487-b6cd-b3f4268ddc9b,[Données non publiées],CAMG,[Données non publiées],
+b4d4829d-1c7f-420e-bf19-26a5b2514c19,[Données non publiées],[Données non publiées],Enseignant de Mathématiques,
+b4da597f-b97c-42b8-ace9-5192582f43e9,[Données non publiées],[Données non publiées],[Données non publiées],Retraitée [Données non publiées]
+b4e75411-9418-41e4-b5d8-398016f29071,[Données non publiées],EPEFIP,[Données non publiées] Coordonnateur Général,
+b4ed7986-77a7-47bf-afd6-c9064955d0cf,[Données non publiées],Retraité,Retraité,
+b4fa4c7b-2ae9-4b9a-ae06-abc99852d5fb,[Données non publiées],MMA IARD,Responsable Conseils juridiques. [Données non publiées],
+b4fa96b5-8492-41e7-aba7-b415d5dc6fe4,[Données non publiées],UNCROP,Dirigeante [Données non publiées],
+b4ff0e91-24fb-4bee-b46d-5e65355f1faa,[Données non publiées],GAEC [Données non publiées],Conjoint d'exploitant agricole,Activité non rémunérée
+b5036522-6e7e-4ab1-b82f-5c225696793a,[Données non publiées],néant,Retraité,
+b505e5b7-d534-4e67-a51e-b9c37346c76a,[Données non publiées],Drees&Sommer,Project Manager,
+b5093997-0cf0-44b7-875f-9891b8b0cd14,[Données non publiées],Digital district,Superviseur VFX,
+b515d74d-08a7-47dc-afa0-8b8c16ca3dde,[Données non publiées],néant,Retraitée [Données non publiées],[Données non publiées]
+b51e6d44-ecbb-4e2f-b75c-bcbc5a5d4353,[Données non publiées],[Données non publiées],gestion parc immobilier,
+b52051df-7757-4413-ae1d-c01053489bba,[Données non publiées],EMC2 elevage,responsable administrative,[Données non publiées]
+b537792f-0e23-4a57-b81f-ef4b936bda7c,[Données non publiées],NEANT,[Données non publiées],
+b537ec6b-940c-414b-afaf-937d562e9b95,[Données non publiées],Ville de Marseille,Ingénieur,
+b5391063-43e8-49b4-ad4c-0e27ca0640eb,[Données non publiées],SYSCO FRANCE,assitante de direction,
+b544c30c-d36a-4363-835b-4bd4dd203b71,[Données non publiées],Nexans Power Accessories France,Product Line Manager [Données non publiées],
+b5495ef9-4b71-44e7-9b9c-7a7d5bf56f20,[Données non publiées],APHM,Cadre superieure de santé aux hopitaux publics de Marseille,
+b549b94a-ab3c-4793-807c-f2c958ef81b7,[Données non publiées],Entrepreneur individuel.,prestations culturelles et associatives,[Données non publiées]
+b54c7eb9-8fac-4b33-8c17-e5fcc22fb9c8,[Données non publiées],elle,viticultrice,
+b554eb9a-9dcc-469b-8e0d-ab7d10d0b83a,[Données non publiées],NEANT,NEANT,N EXERCE PAS D'ACTIVITE
+b55957b1-5eda-42af-aa31-8e4b91146e31,[Données non publiées],Conseil départemental de la Haute-Loire,Médecin [Données non publiées],
+b55a5abe-c8ae-4c85-8a17-70a4eaba8f13,[Données non publiées],néant,néant,
+b565aa5e-44de-46a8-9916-556a5429bd15,[Données non publiées],retraitée,Néant,
+b56ae595-a5df-4f13-8f37-90ba94da363b,[Données non publiées],Greta de l'Aisne,Formateur en formation continue,
+b56c74ec-a29f-4f07-8aa3-d9973b93d1f3,[Données non publiées],Groupama Méditerranée,[Données non publiées],[Données non publiées] retraite [Données non publiées]
+b5812b1d-9ff0-42e2-b8bf-157b9beaa5e4,[Données non publiées],SDEA,Technicien [Données non publiées],
+b586bc49-2d23-4db2-a656-9ffb3b099f45,[Données non publiées],Groupama Méditerranée,[Données non publiées],[Données non publiées] retraite [Données non publiées]
+b58d4b30-6975-4dc1-bb01-bd3fe024f38f,[Données non publiées],SFS,Infimière,
+b58eee3c-e076-4a12-bb61-c1df71e63465,[Données non publiées],Ville de Saint-etienne,[Données non publiées],[Données non publiées]
+b590b9e5-3e48-4641-a182-1b0a1c48e388,[Données non publiées],Profession libérale,Médecin angiologue,
+b59f2cd4-254b-4e98-984e-3796fd0266d8,[Données non publiées],JC Decaux,Attachée commerciale,
+b5ac2768-de55-4476-9f01-9a070df18f0f,[Données non publiées],MINISTERE DE LA JUSTICE,SURVEILLANT PENITENTIAIRE,
+b5ae291d-8739-412a-89b7-287e570dbe77,[Données non publiées],exploitant agricole,[Données non publiées],
+b5b14318-a38e-4f8f-b273-3b35733dd810,[Données non publiées],[Données non publiées],PRESIDENT DU CENTRE SCIENTIFIQUE [Données non publiées],
+b5bde2b5-7dff-4cb9-8209-c61a84e98a00,[Données non publiées],Ville de Hautmont,Directrice Générale des Services,[Données non publiées]
+b5c2f5d8-5c61-4566-a9b9-0e1ce179e300,[Données non publiées],Centre hospitalier [Données non publiées],praticien hospitalier,
+b5c82e37-8770-473b-a399-6c5a6163960d,[Données non publiées],Retraité,Néantretraité,
+b5d9def0-f81a-416b-99c9-09500a4db704,[Données non publiées],ville de Vendin les Vieil,[Données non publiées],
+b5fc2ab9-087f-4320-abd9-6c0591dd83c7,[Données non publiées],Groupe EVALIS,DGA [Données non publiées],
+b60c663f-14c8-4fd5-adfd-180c9d4325ef,[Données non publiées],LM,Location de biens mobiliers et immobiliers,
+b61211cb-e35c-43b1-ac17-1ceb409cc7ab,[Données non publiées],Retraitée [Données non publiées] [Données non publiées],[Données non publiées],
+b6202cac-7141-4e4b-8dbc-f6023cfe2e8c,[Données non publiées],[Données non publiées],Néant,[Données non publiées]
+b62225ee-d848-4c96-9094-bd9aaef90179,[Données non publiées],Ville de Marseille,Retraité,
+b627f0c9-6c7c-4fec-9cc2-e3a279c25174,[Données non publiées],[Données non publiées],chirurgien dentiste,
+b6284711-bea2-4afb-835c-cdfa4ad71d81,[Données non publiées],Neant,Néant,[Données non publiées]
+b62df46c-bea8-4171-8ea4-03cd43981218,[Données non publiées],Retraitée,[Données non publiées],
+b6331ea2-8e66-4c12-bfb0-449642776855,[Données non publiées],Education Nationale,Personnel de direction,
+b6363c5a-b52f-41b0-b30c-ef4a3cc12b95,[Données non publiées],Manufacture Française des pneumatiques Michelin,[Données non publiées],
+b639f9a9-d4bc-44a6-9cbc-2f46d1899744,[Données non publiées],AUTO ENTREPRENEUR,NETTOYAGE BATIMENT,
+b6492e25-8bde-4ba4-bc9a-f95028c3fdb9,[Données non publiées],ETABLISSEMENT FRANCAIS DU SANG,LOGISTIQUE,
+b6570b14-32bf-4993-ba16-f764d27ab90e,[Données non publiées],Association Entraide Le Relais à Strasbourg,[Données non publiées],
+b65da140-2be8-45cc-9d37-1930d03133ad,[Données non publiées],Rectorat de Grenoble,Professeur de lettres modernes,
+b6600e08-dc13-4354-af32-a5017facb019,[Données non publiées],Vergers de la tesserie,Arboriculteur salarié,[Données non publiées]
+b66586fc-c125-4b10-b6f3-237b405fa1b5,[Données non publiées],[Données non publiées],CHIRURGIEN ORTHOPEDISTE,
+b666800a-e5bc-48e2-b094-792d6cfa920e,[Données non publiées],SARL Montagnani,[Données non publiées],néant
+b666800a-e5bc-48e2-b094-792d6cfa920e,[Données non publiées],sarl montagnani,[Données non publiées],
+b668bb43-1262-4e31-b128-6aed91531c82,[Données non publiées],[Données non publiées],AIDESOIGNANT,
+b671fa7e-20ea-4720-b011-e1e781bf4e5e,[Données non publiées],Education nationale,Enseignant,
+b67bde8d-5535-4e58-a643-c003324bd9e5,[Données non publiées],OPHLM du Gers,Fonctionnaire territoriale,
+b67e3573-88a2-4e59-9088-849ec7308383,[Données non publiées],STE MECAFORM,CADRE ADMINISTRATIF,[Données non publiées]
+b681961a-c582-4980-9c09-8ce36739c533,[Données non publiées],SARL BOUCHET,[Données non publiées],
+b68386f4-6f75-4c86-919e-46f56ccd5ca3,[Données non publiées],Grand Poitiers Communauté urbaine,Chef de mission [Données non publiées],
+b68fcbfd-b770-4a96-9d32-3c6ac3239abe,[Données non publiées],CCI [Données non publiées],Formatrice [Données non publiées],
+b6a927b2-b7f5-4541-bd66-031c2e8ff04f,[Données non publiées],Néant,Agriculteur-Eleveur retraité,[Données non publiées]
+b6b950ae-9bb6-4780-a528-663086591e96,[Données non publiées],Indigo Publication,Journaliste,
+b6c4bd56-01f4-4b71-819e-56851c53026d,[Données non publiées],BanquedeFrance,Agent d'atelier,
+b6e358e8-c73c-43fa-a120-cb307e4680ce,[Données non publiées],néant,"élue à la ville de Libourne, à la Communauté d'Agglomération du Libournais",[Données non publiées]
+b6e9e43c-f2f5-48bf-bf31-dd954263dea6,[Données non publiées],hopital [Données non publiées],médecin du travail,
+b6fd42c8-8eb5-4ce7-bc5b-1dd452352919,[Données non publiées],auto-entrepreneur,Psychologue,
+b702d83a-6df0-4703-92e6-0ee38b94de10,[Données non publiées],Métropole de Lyon,Responsable du service [Données non publiées],
+b70868e1-272e-422b-9c29-273371e11ad4,[Données non publiées],Artic 42,Pharmacien [Données non publiées],[Données non publiées]
+b70b45f1-d32c-45d5-aa65-f730485b6db3,[Données non publiées],neant,exploitante agricole,
+b70b45f1-d32c-45d5-aa65-f730485b6db3,[Données non publiées],neant,exploitante agricole,
+b719066e-addc-4449-9622-023a696abb36,[Données non publiées],SARL Le chaudron d'or,Assistante de direction,
+b719066e-addc-4449-9622-023a696abb36,[Données non publiées],GIE inter nougat,Vice-Présidente du GIE,[Données non publiées]
+b71b8ad0-6574-4ad1-bcaf-00e3ddeaca0f,[Données non publiées],Travailleur indépendant,conseil en communication scientifique et journaliste,
+b72125d4-87c9-407d-a65c-3c385db80014,[Données non publiées],Animation 94- Centre de formation,Directrice [Données non publiées],
+b724d1e6-9ca6-471b-9886-8f80a77423f9,[Données non publiées],CHEF D'ENTREPRISE INDIVIDUELLE,"Entreprise individuelle de travaux de construction, démolition et terrassement",
+b72cc1b9-3b49-4c3a-9027-ee432a04838b,[Données non publiées],[Données non publiées],[Données non publiées],Sans emploi [Données non publiées]
+b731c17a-653b-4609-a47b-36287ef669d5,[Données non publiées],Agriculteur,Responsable d'exploitation agricole,
+b733f036-2389-4175-9f94-3900e986af77,[Données non publiées],snc pharmacie valois,preparatrice commandes,
+b73687c6-531e-4418-b342-f579c653dddf,[Données non publiées],[Données non publiées],[Données non publiées],Retraitée
+b737565a-41c5-4152-9b53-ebe95c4bb380,[Données non publiées],autoentrepreneur,gestionnaire de biens locatifs,
+b73b1b41-dccb-4ee1-9c96-7beb2e2f4e08,[Données non publiées],Lafarge Ciments,[Données non publiées],
+b745c9eb-7791-4005-a76c-b8ef50263e6d,[Données non publiées],transport divers services,"Transport de marchandise de plus de 3,5 t",
+b75aa85f-6305-4b23-b117-d87f22c87351,[Données non publiées],Profession libérale,Masseur Kinésithérapeute,
+b762829c-d1ec-4121-9ead-5242f12e90d5,[Données non publiées],Castanea Spectacle et les objets perdus,Diffusion de spectacles - Intermittente du spectacle,
+b7660719-41d5-43dd-93e3-dfa23c774469,[Données non publiées],Sciences Po Paris (enseignante) / Conseil régional Auvergne-Rhône-Alpes (Conseillère régionale) / Université [Données non publiées] de Marrakech (Professeure affiliée) / Raisons sociales (Cabinet de consultants Présidente fondatrice),[Données non publiées],
+b7676032-621b-42bb-a7ed-24893134ec6e,[Données non publiées],agriculteur exploitant,AGRICULTURE BIOLOGIQUE,[Données non publiées]
+b7687c19-6210-4d64-8401-62f035341078,[Données non publiées],EPCI DIJON METROPOLE,[Données non publiées],
+b7755bd5-d023-4f61-a96a-2536ec213e30,[Données non publiées],sans,"Artiste, sculpteur",
+b78ad381-6071-4f30-bee3-ce1c5be96cee,[Données non publiées],APHP [Données non publiées],médecin,
+b78f67ce-0394-4576-89d2-f1e4b1087d25,[Données non publiées],CNFPT [Données non publiées],Formatrice,
+b78f67ce-0394-4576-89d2-f1e4b1087d25,[Données non publiées],Institit d'Études Politiques [Données non publiées],Formatrice,
+b796c974-12d3-4d45-bc2b-d558b6506d4e,[Données non publiées],SCEA [Données non publiées],gerant exploitation agricole,gerant
+b796c974-12d3-4d45-bc2b-d558b6506d4e,[Données non publiées],SNC Vaucourt travaux agricoles,gerant d'une societé de prestations de travaux agricoles,
+b796c974-12d3-4d45-bc2b-d558b6506d4e,[Données non publiées],SAS Theuvy Biogaz,President societé Production de biogaz,
+b79b152b-8172-482e-b81a-de020fc779c6,[Données non publiées],Laboratoire Defrance - Maison de Santé du Pays Neufchâtelois - [Données non publiées],Secrétaire Médicale [Données non publiées],
+b7a211aa-675f-41d0-a662-1c2fc4003288,[Données non publiées],Mairie de Rieumes,[Données non publiées],
+b7b0c0a4-8d9f-46a4-a5cb-e0712f3282d5,[Données non publiées],gérant de société,SARL [Données non publiées] : location d'écrans plein jour,
+b7b0c0a4-8d9f-46a4-a5cb-e0712f3282d5,[Données non publiées],co-gérant de société,SCI [Données non publiées] : locations de locaux commerciaux,
+b7b8a0fe-11e6-458f-ae1b-7061e4c05090,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] retraite [Données non publiées]
+b7c9c547-68c2-4961-b8cf-1f266502dfb7,[Données non publiées],3C2A,Dirigeant [Données non publiées],
+b7d2b45c-2993-43b1-b95d-d6e54bdcafa7,[Données non publiées],Auto-entrepreneur,Psychologue - Psychothérapeute,
+b7e24302-35d6-4473-b68e-27d07820973c,[Données non publiées],retraité,neant,
+b7e5118a-5006-4bc1-a2f6-8ec914be6cb3,[Données non publiées],Mairie du Pontet,Agent Territorial,
+b7e6a174-be4d-4c3f-b5b0-ab850795eebe,[Données non publiées],Cistude Nature,Responsable administratif et financier,
+b7ec0f13-ba48-49d8-98a6-b16a9701b40b,[Données non publiées],Nouméa Discovery,Assistante Direction Tour opérateur,[Données non publiées]
+b7f54202-6db4-411c-b397-39a9f9006d09,[Données non publiées],CONSEIL DEPARTEMENTAL,ADJOINTE ADMINISTRATIVE,[Données non publiées]
+b7f54440-1bae-4396-8bfd-1dec92e95a55,[Données non publiées],BNP,CHARGEE D AFFAIRE PROFESSIONNEL,
+b7f59856-debc-43a4-8da5-b6d9bc70adc2,[Données non publiées],clinique [Données non publiées],Infirmiere,[Données non publiées]
+b7fb4185-9e0d-4e3a-b506-a5c5cbc2c2ce,[Données non publiées],CREDIT MUTUEL,DIRECTRICE D AGENCE BANCAIRE,
+b8030686-0dd9-438a-8829-d18c8c9b6450,[Données non publiées],Intermittent du spectacle,Compositeur de Musique,
+b80cc12e-b19b-4656-99f9-4bafa13f96b5,[Données non publiées],[Données non publiées],[Données non publiées] [Données non publiées],[Données non publiées]
+b81047c6-fbe6-40ce-8c1c-14ee09d61558,[Données non publiées],SLEA,Travailleur social,
+b815fbc3-68ea-42d0-b6a0-a33a41d8a3ff,[Données non publiées],Néant,Retraité,
+b81c88db-b09e-4256-ae12-dd33147a025d,[Données non publiées],Neant,Neant,
+b81dcadb-3888-43e6-9fb0-87650cc698d6,[Données non publiées],nantes metropole,retraité,[Données non publiées]
+b81f317b-981f-4cc5-8399-06cbcaf134f3,[Données non publiées],CRF TE TIARE,Président Directeur Général,
+b81f317b-981f-4cc5-8399-06cbcaf134f3,[Données non publiées],AIR TAHITI NUI,[Données non publiées],MEMBRE DU CONSEIL D'ADMINISTRATION [Données non publiées]
+b81f317b-981f-4cc5-8399-06cbcaf134f3,[Données non publiées],AEROPORT DE TAHITI,[Données non publiées],MEMBRE DU CONSEIL D'ADMINISTRATION [Données non publiées]
+b82be201-da96-4672-b607-8d77950a860c,[Données non publiées],EARL [Données non publiées],SECRETAIRE,[Données non publiées]
+b83777ed-c5c9-4422-bedf-0b8c265079dd,[Données non publiées],Ets Médical de la TEPPE,Aide Soignante,
+b8477c53-d555-4804-aa0f-dd42077f6954,[Données non publiées],Association [Données non publiées],Animatrice sociale,
+b84a2133-003d-404b-84c3-373605e1fb9a,[Données non publiées],Retraitée,Néant,
+b84fc26d-9e06-4a75-a673-3ecf2621b9cb,[Données non publiées],Ville de Marseille,[Données non publiées],
+b85e1bd0-7988-4960-ad32-569aae5ef363,[Données non publiées],Laboratoire Pierre Fabre,Directrice Congrès,
+b8605a34-533c-4fe9-94ea-f6f9e1d36f0f,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] [Données non publiées] retraite [Données non publiées]
+b867295f-a310-41b5-bb87-bb4aa28daa9b,[Données non publiées],Intermittent du spectacle,Musicien et régisseur technique,Employeurs multiples.
+b86974d9-7ac4-44ce-a0a4-3d1c5829c4c2,[Données non publiées],Commune de BAIE-MAHAULT,[Données non publiées],
+b86ba542-f4fe-4198-b077-bb08d3db9e1a,[Données non publiées],"Msa,sécurité-sociale,arcoo,agir",néant,
+b87c3914-ddda-4854-a08c-3dd1139ca811,[Données non publiées],NEANT,NEANT,
+b880c2a9-93ea-4605-9bcb-479c13fd88cf,[Données non publiées],DEPARTEMENT [Données non publiées],ADJOINT TECHNIQUE,
+b89095d0-cb52-456c-ac48-a9b10a5bd4c1,[Données non publiées],Wallis Label,sondage minier,
+b8941487-adc2-458b-bf60-36e3d7b48b32,[Données non publiées],VITAGRI,commercial,[Données non publiées]
+b895f069-0b95-448f-b3d5-2b329a5618da,[Données non publiées],AIR FRANCE,agent,agent
+b8a167d1-c359-4104-b4d2-5dd5f7a7bf7d,[Données non publiées],Mairie de Noisy le Sec,[Données non publiées],
+b8b10553-3589-49fe-9674-66d9d9d22c5f,[Données non publiées],[Données non publiées],gérant,
+b8b9a4bd-332d-4520-9c16-eacada1c00b3,[Données non publiées],Groupe Thivolle,[Données non publiées] [Données non publiées],[Données non publiées]
+b8bac857-756d-4de0-a7ef-6e177ada0d18,[Données non publiées],Education Nationale,Accompagnant d'Elève en situation de Handicap [Données non publiées],[Données non publiées]
+b8c71e2f-aea8-4898-9d5e-0ede30848e4c,[Données non publiées],Hôpital [Données non publiées],[Données non publiées],Fin d'activité le 30 juin 2018
+b8dd8b42-5fc9-49f6-9df3-d0513d408f07,[Données non publiées],[Données non publiées],journaliste sportive,
+b8deb9dd-c1cc-4b98-804c-ddc6a1d1d390,[Données non publiées],Académie de La Réunion,Professeur [Données non publiées],
+b8e298a7-4e6d-44b8-935b-5714171c1ab8,[Données non publiées],Retraité [Données non publiées],[Données non publiées],
+b8e4c2fe-75fa-4b0b-aef6-578bcb27bc90,[Données non publiées],SCP [Données non publiées],AVOCAT,DROIT DE LA FAMILLE
+b8e70e3c-c7a6-45b7-b4a5-b8a4640d20f2,[Données non publiées],Parties prenantes,Directrice Conseil [Données non publiées],
+b8fbe9e2-44db-42a6-8fb1-fa5bc45bfc7b,[Données non publiées],CONSEIL DEPARTEMENTAL,ASSISTANTE PERSONNE AGEE,
+b8fe0faf-f275-49b8-b5b9-ecdb7392f092,[Données non publiées],[Données non publiées],néant,Plus d'activité professionnelle à ce jour.
+b8ff7421-dcf9-4d06-9be9-4087a5210ff1,[Données non publiées],sté TACTIS,[Données non publiées] exerce au sein de Tactis des fonctions de responsable du contrôle de gestion.,[Données non publiées]
+b9065f98-5310-4ab7-8c0e-7ab373020c0e,[Données non publiées],leader_sys,[Données non publiées],
+b9124b42-dc12-4694-95d2-b93c0f4c0eba,[Données non publiées],DCC,Conseil en ressources humaines. [Données non publiées],
+b93eafdc-7fb2-4964-b2a0-dbbcc8496200,[Données non publiées],hopital de St-Lô,orthophoniste [Données non publiées],
+b9507c17-c2a4-4096-bdf3-c4eac1f1c42e,[Données non publiées],Université Nice Sophia Antipolis,Responsable [Données non publiées],
+b9507c17-c2a4-4096-bdf3-c4eac1f1c42e,[Données non publiées],Ville de Nice,Conseillère Municipale et Métropolitaine de Nice,
+b950aabd-e888-47ef-b13e-35efce108d2d,[Données non publiées],Docteur [Données non publiées],Secrétaire médicale,
+b9581f65-ee59-4e52-bc43-79d76d65e142,[Données non publiées],aucun,pas d'activité,
+b9596a06-f23e-4218-8949-5a5d2bfc2ebf,[Données non publiées],Centre Hospitalier des Pyrénées,Aide Médicale en Psychologie,
+b9664cac-7c4f-430f-ae23-2beddbda705a,[Données non publiées],EURL [Données non publiées],gérant majoritaire d'une société de lavages automobiles,
+b9664cac-7c4f-430f-ae23-2beddbda705a,[Données non publiées],SASU NB IMMOBILIER,Conseiller en immobilier,
+b96700a0-b3bb-47d6-b6b3-06d586f0a411,[Données non publiées],SAS [Données non publiées],SOCIETE DETENANT DEUX OFFICES NOTARIAUX,[Données non publiées] Notaire dirigeant de cette société [Données non publiées]
+b968e99b-09e3-43e1-9c88-32591749af4b,[Données non publiées],retraité,[Données non publiées],
+b96da977-bce0-42c8-bedf-f40593b9f937,[Données non publiées],commerçante,Esthéticienne,
+b971d8df-c602-434e-8940-6f780a4ec3cb,[Données non publiées],INSPECTION ACADEMIQUE [Données non publiées],CONSEILLERE PEDAGOGIQUE,
+b9791aa7-77d7-4156-b267-c601ce001c59,[Données non publiées],Ministère de l'Agriculture,Chef du service [Données non publiées],[Données non publiées]
+b97a804d-6d77-4139-b3bd-5ae863f118bc,[Données non publiées],Dalkia,surveillance et maintenance chaudière,[Données non publiées]
+b97cb78d-295d-4fc9-b98e-cbe7e7438b88,[Données non publiées],INSPECTION ACADEMIQUE [Données non publiées],CONSEILLERE PEDAGOGIQUE,
+b97d3a95-0129-431b-b784-e152189d63e6,[Données non publiées],La Poste SA,Directeur juridique,
+b98152de-9704-4230-ab69-0dda149080d2,[Données non publiées],Néant,Retraitée,Retraitée [Données non publiées]
+b98956a4-7fa8-4d85-828b-2cfcf4392ef6,[Données non publiées],Agent de voyages et salariée agence d'assurances,[Données non publiées],
+b98ff68d-c174-433d-b93d-ba3d6b86459e,[Données non publiées],Education Nationale,Professeur d'histoire-géographie en lycée,
+b9922ecc-e16b-4d00-9b25-20d4f286f9cb,[Données non publiées],CHU [Données non publiées],AMA,
+b999eaeb-0225-489e-991c-e871ca7fe5a9,[Données non publiées],FranceTV,[Données non publiées],
+b99d3ec4-b546-4caf-a3c5-9259a1164867,[Données non publiées],MAIRIE DE PERPIGNAN,[Données non publiées],
+b99da2fb-999d-4f41-9993-6ce4a481cd49,[Données non publiées],CDC DE SABLE SUR SARTHE,[Données non publiées],
+b9a295db-3616-4938-80c8-853bd00327ef,[Données non publiées],SNCF,CADRE DIRIGEANT [Données non publiées],
+b9bd915f-e399-4035-bc7a-50829ef1d0cd,[Données non publiées],Mairie de DENAIN,[Données non publiées],
+b9beec82-ab79-4edc-8bf0-2f48bc155fa9,[Données non publiées],néant,néant,
+b9bfa627-dce7-4090-9a4e-2c5f69763f32,[Données non publiées],education nationale,enseignante,
+b9c37b0f-ed4f-4b49-ae44-4a34b53a7c37,[Données non publiées],LEGRAND,Business développeur,
+b9cd9ee6-e9d3-4472-903f-7389d22f430f,[Données non publiées],Profession libérale,Avocate,
+b9dd2e3a-b074-4dfb-bdb0-bc2f1607f808,[Données non publiées],NEANT,NEANT,
+b9dffed4-24c5-4fe5-86a1-887184c8187c,[Données non publiées],CEPAC,employée de banque,
+b9e829d1-9bdb-4699-863a-f91e3a36a572,[Données non publiées],Amiens avenir jeunes,"Association liée à l'insertion, la formation. [Données non publiées]",[Données non publiées]
+b9ee967a-4a9c-4cfb-8f48-13d83421f691,[Données non publiées],Conseil départemental du Val de Marne,Cheffe de projet [Données non publiées],[Données non publiées]
+b9f6483b-cc2d-498c-9aa8-87e024826e71,[Données non publiées],ANS Prodia +,Employé polyvalent [Données non publiées],
+b9fa2f33-560f-4a66-b0f0-bf7dce9f4318,[Données non publiées],Education nationale,Professeure des écoles,
+b9fbf66b-bf3d-41fd-b3c1-72b4166b650b,[Données non publiées],Retraité,néant,
+ba02ab59-fcbb-4d87-aab0-8b0ca0836225,[Données non publiées],Indépendant,agent immobilier,
+ba135a73-4724-4120-8dfb-992ee8c528ba,[Données non publiées],[Données non publiées],Assistant parlementaire,[Données non publiées]
+ba135a73-4724-4120-8dfb-992ee8c528ba,[Données non publiées],SNC ITE,Directrice [Données non publiées],[Données non publiées]
+ba1a1ad2-a90d-4b33-baa3-2144b6d110a5,[Données non publiées],KEEP COOL,cadre [Données non publiées],
+ba1a4c1b-a4ed-41cf-89d7-90c50e980355,[Données non publiées],Autorité Nationale des Jeux,Responsable des agréments,
+ba1ac098-c3ac-49c1-a230-d1cc42744bf8,[Données non publiées],[Données non publiées],Directrice du Service des Transports,[Données non publiées] Des mesures préconisées [Données non publiées] avaient été prises pour éviter une situation de conflit d'intérêt entre l'activité professionnelle [Données non publiées] et mon mandat de Président de l'agglomération. Ces mesures ont été reproduites pour Vienne Condrieu Agglomération
+ba1c9998-eb1a-45dc-a5a8-fa7e32ac50f8,[Données non publiées],SARL SOLUTEC,[Données non publiées],
+ba1c9998-eb1a-45dc-a5a8-fa7e32ac50f8,[Données non publiées],GMO,[Données non publiées],
+ba2e2548-8b8d-4516-a026-a76991b4cd26,[Données non publiées],[Données non publiées],Exploitante agricole,
+ba3d2493-55f1-4d04-b2ca-5937cea8c4de,[Données non publiées],néant,néant,
+ba4cfd08-5393-4a3c-891c-c66457c8e50c,[Données non publiées],SAS LISIEUX DISTRIBUTION,DIRECTEUR HYPERMARCHE,
+ba587a40-cb66-4349-8549-0101891f207e,[Données non publiées],Ministère de l'Intérieur et des Outre-mer,Chargée de mission [Données non publiées],
+ba5cfe84-1c72-491e-8b3a-f697e50b6e26,[Données non publiées],RATP,Directeur d'unité opérationnelle,
+ba5cfe84-1c72-491e-8b3a-f697e50b6e26,[Données non publiées],Pantin Habitat,Membre du CA,
+ba72a917-f54b-4b4d-9e16-6089d43e46a5,[Données non publiées],Ostéopathe et Professeur vacataire au [Données non publiées],Installé en libéral pour son activité d’osteopathe et professeur dans une école formant des étudiants à l’osteopathie,
+ba748af9-0baa-40a7-9ec7-c6e87a6c8c87,[Données non publiées],LPCR,Directrice de crèche,
+ba814652-0ac9-4081-83f8-805e44e09310,[Données non publiées],Conseil départemental de la Dordogne,Collaborateur de cabinet,
+ba814f9b-e77f-4442-b15d-c6b3916f26fd,[Données non publiées],Centre Hospitalier des Pyrénées,Aide Médicale en Psychologie,
+ba81c256-bfe4-4507-95d4-3e7c9c9658d5,[Données non publiées],SAS Fertiléo,[Données non publiées],
+ba91a798-3e63-40fe-8abe-9368cd09129a,[Données non publiées],NEANT,NEANT,
+ba9a75ea-4431-4212-91f2-946dc4f8c8b1,[Données non publiées],DIRECTION DU CONTROLE FISCAL [Données non publiées],VERIFICATION DE SITUATION FISCALE PERSONNELLE,
+ba9e9a47-dfe5-4f56-811e-2d6e5a772fa8,[Données non publiées],Conseil départemental [Données non publiées] 44,conseillère socio-éducative,
+baa05540-203e-452f-9533-328761fb922d,[Données non publiées],neant,neant,retraitee
+baa7f720-dc3b-4b93-b537-c0aa70417491,[Données non publiées],Education Nationale,Directrice d'école,Retraitée
+baaad608-f712-477e-8bcf-43db4279c961,[Données non publiées],Ministère Education Nationale,Institutrice,
+baba8778-d472-4df8-8229-7024cd62881e,[Données non publiées],Education Nationale,Enseignante,
+bac73b2c-9bb1-49a0-8b52-617a4279d8af,[Données non publiées],Particuliers,Aide à domicile,
+bacac641-d766-4a96-8da4-6d253389f500,[Données non publiées],LA CAVE DE SOMBERNON,[Données non publiées],
+bacc2f7a-a971-4211-94e1-50bbde427cd9,[Données non publiées],neant,néant,
+bad090eb-a7f6-4a98-97c8-fff778938406,[Données non publiées],CCAS EDF,[Données non publiées],
+bad4544e-f476-49e2-a464-e5a4dd34045a,[Données non publiées],AUCUN,AUCUNE,
+bae491f1-c448-4cdb-b0af-0fc5536295de,[Données non publiées],Hôpital de Psychiatrie d'Auch,Infirmière,[Données non publiées]
+baeed056-bf0b-4dd0-8448-6847668404a2,[Données non publiées],Néant,Néant,
+baf440ba-1165-4490-aac2-0cf3b75ed946,[Données non publiées],msa ircantec,retraite,[Données non publiées]
+baf71788-bb02-46b8-a3b3-0f40cd7ec3e7,[Données non publiées],indépendant,Producteur,
+baf9b608-bb14-4d63-b996-f503f8591319,[Données non publiées],néant,néant,
+bafba660-e676-419f-8ce1-fd8c4ca0544c,[Données non publiées],Éducation nationale,Professeur,[Données non publiées]
+bafca99f-8f18-4846-9919-b11fdd95bffd,[Données non publiées],[Données non publiées],GERANT,AGENCE DE VOYAGES Cessation d'activité fin 2020
+bb1133b8-f033-4520-bd62-b0dcd512fd04,[Données non publiées],Office de Tourisme,Responsable Administrative,
+bb241454-a1e8-47d8-ab5c-af18a117cf6c,[Données non publiées],PSA Peugeot Citroen,[Données non publiées] Cadre,
+bb2a169a-ac5f-4487-9759-873faaf7b7bd,[Données non publiées],régie networks,[Données non publiées],
+bb33108f-06bf-4bb4-ab63-fd1931242ca3,[Données non publiées],[Données non publiées] Agglomération,Responsable pôle habitat,
+bb33d187-e5db-488c-88b4-d6f8d9761e17,[Données non publiées],Education,professeur,
+bb3475c0-bd6d-4768-91a5-0c95420fcd70,[Données non publiées],Néant,Retraitée,Retraitée [Données non publiées]
+bb362a06-a69f-49e6-a1f3-5a27574f551b,[Données non publiées],collège des Ormeaux Le Havre,[Données non publiées],
+bb3f8c0e-61e5-40c8-a295-fa13526af415,[Données non publiées],ADSEAM,Psychologue,
+bb4fe824-69f0-4e89-8390-56f252727a35,[Données non publiées],Néant,Néant,
+bb50935b-8718-4bb2-8c8e-4b3b173752b7,[Données non publiées],sans,[Données non publiées],[Données non publiées]
+bb587584-52e5-48ad-b23b-09df16a42d20,[Données non publiées],Voisins et soins,Accompagnement à domicile des personnes en fin de vie.,[Données non publiées]
+bb63f6aa-0211-4151-9bb1-462ea939b4f6,[Données non publiées],[Données non publiées],[Données non publiées] EXPLOITATION AGRICOLE EN CAPRIN LAIT,[Données non publiées]
+bb799a80-90b8-4cb2-ab70-7d3dad12eee0,[Données non publiées],Education Nationale,Professeur des écoles - Conseillère pédagogique départementale,
+bb870194-180a-4a8d-bcfe-91f260d0ed54,[Données non publiées],EducationNationale,ProfesseurCertifié,
+bb87942f-9ba7-40ba-bac4-a8600aae6639,[Données non publiées],ARTISAN,Artisan,
+bb967aa1-2778-4e55-baf8-5e000bc90667,[Données non publiées],NEANT,RETRAITEE,
+bb97f157-ed19-4d78-b024-007d1f9b8dcb,[Données non publiées],[Données non publiées],Architecte,
+bbac25f4-8c73-4bbb-82c9-dd3fd263705d,[Données non publiées],DSDEN PYRENEES ATLANTIQUES,PROFESSEUR DES ECOLES,
+bbaede48-8508-4caf-8f5b-4086ca627ad2,[Données non publiées],Ministère de l'Education nationale - Collège [Données non publiées],Professeur des écoles,
+bbb17af9-076d-4cb0-b8de-107a6597c5e6,[Données non publiées],Rectorat de l'Académie [Données non publiées],Professeure certifié,
+bbc17049-0a80-4f0f-aea0-dbbbec5562e3,[Données non publiées],[Données non publiées],ENTREPRISE DE SERRURERIE METALLERIE,
+bbc7b90f-d75e-44a0-b25e-2f00def1a759,[Données non publiées],Région Grand Est,Chargée de mission,[Données non publiées]
+bbcc79d1-5836-48c2-94fb-451194a9eac5,[Données non publiées],SARL SPORTIMMO,[Données non publiées],
+bbcd072f-0343-4f3f-abbe-b8f46712ff59,[Données non publiées],[Données non publiées],Coiffeuse à domicile.,
+bbcd83d6-7c53-4f15-a36f-f8d62e656f84,[Données non publiées],La Table du RÉCHO,Présidente et Directrice Générale [Données non publiées],[Données non publiées]
+bbdd7184-5523-4081-b74c-71a7c3314e60,[Données non publiées],Mairie de Gennevilliers,Professeur d'enseignement artistique [Données non publiées],
+bbe83c3f-6874-4379-818d-0d0edcea0e19,[Données non publiées],CINEBOOK Ltd,Editeur de bande dessinée,[Données non publiées]
+bbf7285c-a41d-467a-9b6c-ba168934ac79,[Données non publiées],néant,néant,
+bc0a4f61-a689-4ac0-b167-23691c62c11b,[Données non publiées],RATP DEV,"Transport en commun, responsable d'unité.",
+bc0ac533-89ac-4a6b-b0ea-3690dc6e4a54,[Données non publiées],Communauté Urbaine du Grand Reims,Directrice de la communication [Données non publiées],
+bc0eae99-356e-4fdb-a40b-4dcd46b772ed,[Données non publiées],néant,néant,
+bc0fa9ae-813f-48fe-90c8-c6558910e058,[Données non publiées],Cristal Habitat,[Données non publiées],
+bc186e9e-7fd8-40ed-b12e-ada310bf0b20,[Données non publiées],EDUCATION NATIONALE,PROFESSEUR [Données non publiées],
+bc22eac5-9727-4cd5-ae10-6a23005048e1,[Données non publiées],communes de Jainvillotte et Tilleux,[Données non publiées],
+bc22eac5-9727-4cd5-ae10-6a23005048e1,[Données non publiées],SNC Château de Roncourt,[Données non publiées],[Données non publiées]
+bc27646d-85ae-4c88-bee2-635a1f5ee1cf,[Données non publiées],[Données non publiées],Conseillère-Financière,
+bc2df6cf-0093-4188-b946-e13191db1b7a,[Données non publiées],Pharming,[Données non publiées],
+bc325e81-c826-49d5-91a6-303222068778,[Données non publiées],Neant,Neant,
+bc35080e-6284-434c-abf4-a61de6abdc4c,[Données non publiées],SASU [Données non publiées],Secrétariat comptabilité à temps partiel,
+bc373285-5a55-4e6a-ad70-9373a225e887,[Données non publiées],OPHLM du Gers,Fonctionnaire territoriale,
+bc3966c0-e496-4716-afcd-8a169c611e32,[Données non publiées],Centre Hospitalier Alès,Orthophoniste,[Données non publiées]
+bc3f3196-4e23-4680-b827-ec34aa007ab2,[Données non publiées],Rectorat Orleans-Tours,Professeure Documentaliste,
+bc3f7e2c-17db-4b1d-9f3f-982b4008ef2e,[Données non publiées],ENGIE - [Données non publiées],employé administrative - comptabilité,[Données non publiées] Retraité [Données non publiées]
+bc4132e5-41a1-4265-bdb1-1802f5f37566,[Données non publiées],HDPM Productions,Intermittente du spectacle [Données non publiées],[Données non publiées]
+bc420e32-d121-45c2-afc8-821deeaecf7d,[Données non publiées],[Données non publiées],Architecte libérale,
+bc52b1c2-db7b-4d0d-bdb2-6e38b2c92f28,[Données non publiées],Hopital Foch [Données non publiées],Masseur-Kinésithérapeute salariée,
+bc5350ad-5833-4188-8cfe-f0573e6d6ebd,[Données non publiées],profession libérale,Kinésithérapeute,[Données non publiées]
+bc62c6b4-378f-41ec-872d-f374f1ae0659,[Données non publiées],[Données non publiées],Gérant,
+bc64b39f-6a13-4023-a968-72c227085103,[Données non publiées],Pôle emploi,Conseillère pour l'emploi,
+bc682f82-d707-4d55-87b2-fc5ec1d746c4,[Données non publiées],néant,néant,
+bc69bd78-8147-4943-9e7b-37521629ff28,[Données non publiées],Communauté de Communes du Saulnois en Moselle (57),[Données non publiées],
+bc6dc517-8bf1-41e9-9c0e-082c135d6d89,[Données non publiées],INSEE,[Données non publiées],
+bc6dc517-8bf1-41e9-9c0e-082c135d6d89,[Données non publiées],Ecole des Ponts,[Données non publiées],
+bc6f4dc1-fcba-4e21-8b42-11c6643251f5,[Données non publiées],RATP DEV,CONDUCTEUR RECEVEUR,
+bc797d88-0c35-41a4-b206-66da194d8427,[Données non publiées],MARTIN ASSOCIES,Avocate,
+bca0217b-e4fb-4549-aa9b-c61ab3ebfc3a,[Données non publiées],PCM TEARI,[Données non publiées],
+bca35928-74a1-4339-9c7b-8def1ba6a519,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+bca35928-74a1-4339-9c7b-8def1ba6a519,[Données non publiées],SASU ACITI,Présidente [Données non publiées],[Données non publiées]
+bca6d101-10f5-4fce-b351-739e71079f05,[Données non publiées],CONSEIL REGIONAL DES HDF,CONSEILLIERE TECHNIQUE AU CABINET DU PRESIDENT [Données non publiées],
+bca87576-971b-4165-8e70-2aa7b5a22e34,[Données non publiées],Profession libérale,Médecin dermatologue,
+bcaa63a7-d502-4d1f-976d-b91108771436,[Données non publiées],Viticulteur ( son propre employeur),Viticulteur,
+bcb1b5aa-db97-4890-9e02-76e191dae02c,[Données non publiées],Multiples,Intermittent du spectacle : musicien et décorateur dans l’événementiel,Multiples employeurs pour son intermittence
+bcb1b5aa-db97-4890-9e02-76e191dae02c,[Données non publiées],Micro-entreprise,Fabrication d'articles personnalisé en cuir,Développement de cette activité en parallèle de l'intermittence
+bcb1e9ab-45e4-4fd5-adfc-b3b0b21776c0,[Données non publiées],NEANT,NEANT,
+bcc04a9b-d967-4061-963b-0fd052fede8b,[Données non publiées],CASDEN,[Données non publiées],
+bcc1c618-1efe-4a5d-99d7-6b4026b6f87e,[Données non publiées],Mairie de Brie,[Données non publiées],
+bcc49da3-a5f8-421b-939b-336e6f019130,[Données non publiées],néant,néant,[Données non publiées] retraité [Données non publiées]
+bcc4ef40-2e9a-4440-ad99-5cae592a0f6d,[Données non publiées],[Données non publiées],[Données non publiées],RETRAITEE [Données non publiées]
+bcd53ca6-495d-465f-884d-5036cf9370da,[Données non publiées],néant,néant,Retraitée [Données non publiées]
+bcd5feb1-2a80-4581-8c24-b5b2cb934c70,[Données non publiées],néant,néant,
+bcdb5042-b75d-4f06-b453-47f132917b71,[Données non publiées],Association [Données non publiées],Directeur,
+bcdef82b-d202-4d98-a526-7a54e93abd48,[Données non publiées],Commune de Grenay,Chargé de communication,
+bce6453d-2b77-4aca-8676-e5b18af02ca1,[Données non publiées],Mairie de Montreuil,[Données non publiées],
+bcf09c7f-35d6-44a2-934f-3218f9511c2c,[Données non publiées],Montaz,Conseiller technique vente magasin de sport,
+bd096585-50f7-4e37-bd63-a390144f2d77,[Données non publiées],POLE EMPLOI,Manager d'équipe,
+bd09e636-993c-4487-a789-75f989f12d5e,[Données non publiées],Université de la Réunion,enseignant [Données non publiées],
+bd140afd-7973-40f0-a704-1ba76c73ef90,[Données non publiées],HOTEL LE GUANAHANI,[Données non publiées] CONCIERGE,
+bd1459da-239a-4d31-844c-1ed028fc900c,[Données non publiées],Education Nationale,Assistante Vie Scolaire,
+bd14d048-6f11-447e-9d97-871b445ab75c,[Données non publiées],Néant,Néant,Conjoint retraité
+bd2a2e62-1622-4e03-95ed-d3bf2dc0c8af,[Données non publiées],Néant,Retraitée,
+bd32dc01-cd87-41d8-81dd-f38e5379feaa,[Données non publiées],Néant,Directeur juridique retraité,
+bd6464e8-d93c-4b5f-8737-cdf6cf7a3b6e,[Données non publiées],Secafi,[Données non publiées],
+bd667e3c-25ef-4a22-8165-95a2de3b861f,[Données non publiées],NEXITY [Données non publiées],Responsable technique,[Données non publiées]
+bd667ed5-838c-4bf4-b524-01df3b4328a9,[Données non publiées],Autoentrepreneur,Agent commercial,
+bd6841bf-9e5f-4237-82f1-ffa7d999b84d,[Données non publiées],MARINE NATIONALE,OFFICIER DE MARINE,
+bd696c94-b965-419b-ad48-13a581d75dc8,[Données non publiées],CGSCOP,Directeur [Données non publiées],
+bd6d4396-06aa-46ed-b8b1-f3c6ef37362c,[Données non publiées],Commune de BAIE-MAHAULT,[Données non publiées],[Données non publiées]
+bd732f64-3148-4997-9fe7-4d44322d6618,[Données non publiées],[Données non publiées],AIDE A LA PERSONNE,
+bd75d490-c9b8-4c50-97df-8e505170766d,[Données non publiées],Retraitée EN,Néant,
+bd7b2e23-5324-486f-ac6d-5dfc6eaec367,[Données non publiées],Auto-entrepreneur,Consultante en affaires de gestion,[Données non publiées]
+bd7b7b0e-a573-41a4-96f7-68c8e236eebd,[Données non publiées],NEANT,NEANT,
+bd7d612e-2c23-4211-bf13-1b35df146c4c,[Données non publiées],Rectorat de Poitiers,Professeure,
+bd85752b-9e95-4cf7-bce4-764ba469013f,[Données non publiées],BOLUDA LA REUNION,Officier [Données non publiées],
+bd8ec5ee-69b8-458a-bee1-e666aab23529,[Données non publiées],NEANT,RETRAITE,
+bd8fa427-d4a2-4633-ac55-63fcc0fc1120,[Données non publiées],[Données non publiées],Logement social,
+bd95ad20-fe2d-4be0-8259-97126a5f1d26,[Données non publiées],[Données non publiées],Coiffeuse,
+bd99c351-450a-43b9-8253-e0ab8b4fd14c,[Données non publiées],Blue enerfreeze,[Données non publiées],
+bd9cade0-0b8b-4e45-bf13-185ae5070c74,[Données non publiées],Education Nationale,Professeur de Sport,
+bda2f074-70d6-4dae-beb2-0c11dc13c69e,[Données non publiées],Conseil Départemental des Cotes-d'Armor,[Données non publiées],
+bda2fb58-805e-41c6-a8fc-1cf351df90ab,[Données non publiées],[Données non publiées],Senior manager affaires institutionnelles [Données non publiées],
+bda70874-6798-4ee4-9d80-f60c3d5a874f,[Données non publiées],Kim Executive,Présidente,
+bda717ca-9b59-431a-8eb0-a8268c68a105,[Données non publiées],ministère de l'intérieur,Policière territoriale,[Données non publiées]
+bda717ca-9b59-431a-8eb0-a8268c68a105,[Données non publiées],Ministere de l'intérieur,Police aux frontières,
+bdc19856-7e6c-4844-be6a-1d53ac17fe1f,[Données non publiées],SA CHAMBON LA FRIDIERE [Données non publiées],Chauffeur poids-lourds et conducteur d'engins TP,
+bdcb5b0b-ea72-4f5e-91f2-4dfd1308a8bd,[Données non publiées],Indépendant,Avocat à la Cour,
+bdcc20aa-a84c-44c8-b0f8-02541b540122,[Données non publiées],Région Nouvelle-Aquitaine,Chargé de mission [Données non publiées],
+bdd7e7a6-fab6-4088-8081-be81c3ff1749,[Données non publiées],IFEAP,Formatrice,
+bddd4d94-1f2e-4c51-99e3-a0440717ae20,[Données non publiées],Kabestan,Responsable immobilier [Données non publiées],
+bde4798f-ea48-45ac-948f-3635dce1180a,[Données non publiées],SARL VENDEE FLEURS,fleuriste,
+bdf03cb3-562e-43e7-9354-a1eb2aec96ae,[Données non publiées],[Données non publiées],[Données non publiées],Retraitée [Données non publiées]
+bdf48a2b-02de-4175-b5e5-1d84400ff290,[Données non publiées],néant,retraitée,
+bdff151a-af40-4ea0-98b7-cca32021f1aa,[Données non publiées],Moteur s'il vous plaît Production,Actrice réalisatrice et productrice.,
+be09e37a-9443-4f03-ae35-fce5f5b3fc92,[Données non publiées],Macocco Ouest,Assistante commerciale,
+be143cab-372d-433e-bbcf-51aae477cd6e,[Données non publiées],AP-HP,Interne en médecine,
+be1f56b1-dcb8-4636-8b57-0b690844ca94,[Données non publiées],CPAM,Responsable de Centre,
+be273fc6-9ac8-4947-a11a-f5c403a82a78,[Données non publiées],Vergers de la tesserie,Arboriculteur salarié,[Données non publiées]
+be2a9810-acae-4ab1-8179-eeb438890d14,[Données non publiées],Education nationale,Professeur des écoles,
+be31988f-5039-479f-9f1a-53a9aa7555b7,[Données non publiées],Indigo Publication,Journaliste,
+be3318ea-7c58-4ee9-b659-efbb1b19b89d,[Données non publiées],Indépendant,Commerçant Cafetier,
+be438848-898e-46b6-adf4-21adbd076028,[Données non publiées],Centre des Monuments Nationaux,Directrice des Ressources humaines,
+be4eff54-a4c4-44d7-99d6-50ba50bc56da,[Données non publiées],L'arche,educatrice spécialisée,
+be53134d-4b99-4cd0-b673-620b79765887,[Données non publiées],néant,néant,
+be6d6fd6-5dde-4277-baf0-0975996f4128,[Données non publiées],[Données non publiées],ARCHITECTE,
+be6f1bd0-8275-4f6d-8ad2-4747541f0fbe,[Données non publiées],ASSEMBLEE NATIONALE,Député,
+be6f1bd0-8275-4f6d-8ad2-4747541f0fbe,[Données non publiées],METROPOLE DU GRAND PARIS,CONSEILLER METROPOLITAIN,
+be77b108-225a-452a-b4eb-3cd83646ec15,[Données non publiées],Crédit Agricole Réunion,Animatrice d'activité,
+be79d253-e9cc-4864-9139-09677a53de68,[Données non publiées],activite liberale,Avocat [Données non publiées],
+be981bd7-b21c-47b6-8f03-9c190c3d8da9,[Données non publiées],Société EKNO,Directrice [Données non publiées] [Données non publiées],
+be9f6e6a-3d9a-491f-8bea-76854bb8d56e,[Données non publiées],Education Nationale,Enseignante,
+beaf51d4-64e8-4b32-b4d1-24d1791f7a19,[Données non publiées],retraitée de l'Université,néant,
+bebb0654-78cb-48c1-bd46-7f4d5f98ce7d,[Données non publiées],Etablissement public du musée d'Orsay et de l'Orangerie,Chef de cabinet du président,[Données non publiées]
+bec17d33-f74e-43b8-8e35-4c0261f9f05e,[Données non publiées],lui même,journaliste Président et directeur du journal Le petit mag Lens Liévin exploitant agricole [Données non publiées],[Données non publiées]
+bed05d76-44e7-4801-9ae9-9b1b887be418,[Données non publiées],CONSTELLIUM,EMPLOYEE [Données non publiées],
+bedba8e1-ffe7-405a-99cc-c0a223321b9c,[Données non publiées],[Données non publiées] Chirurgien dentiste [Données non publiées],Assistante dentaire,
+bedbcede-435d-449e-ad43-d2d9769a178a,[Données non publiées],NEANT,RETRAITEE,
+bedf9ffd-ee47-46d4-a594-dc6a260f9532,[Données non publiées],Profession libérale,orthophoniste en cabinet libéral,
+bef04546-b9dd-4a1f-8a7d-8070c26e2395,[Données non publiées],APAVE Sud Europe,[Données non publiées],
+bef5482e-ffc6-4154-8367-e65400cfcffb,[Données non publiées],neant,neant,[Données non publiées]
+bf013615-cd36-40b7-ab4e-f314ff0d2bba,[Données non publiées],Université Aix marseille et Institut Paoli Calmettes,PU-PH [Données non publiées] faculté de pharmacie [Données non publiées],
+bf0a6b28-4001-4803-98aa-3055524a5988,[Données non publiées],Education Nationale,Professeure des Ecoles,
+bf1cd31c-7fb4-4750-b3c1-1cc10233f47f,[Données non publiées],AUTOENTREPRENEUR,Etude Marketing,
+bf386b0c-60d4-4778-ad42-d8faa134a9bc,[Données non publiées],Education nationale,AESH,
+bf4074e2-aa97-4d50-8e21-1406944b6af3,[Données non publiées],Education Nationale,Secrétaire,Retraitée [Données non publiées]
+bf4f0c28-5da2-482c-b50d-57916718c2dc,[Données non publiées],Académie de La Réunion,Professeur [Données non publiées],
+bf589814-5369-4d39-8044-3845c923edf1,[Données non publiées],neant,sans,[Données non publiées]
+bf5e8cb0-a633-4415-aeef-72a39621da35,[Données non publiées],aucun,aucune,
+bf6037ee-9846-43eb-91e4-3ab2c2a69338,[Données non publiées],MINISTERE DES ARMEES,OFFICIER DE MARINE,
+bf6d1954-9425-4df9-b913-b63f4b396fad,[Données non publiées],centre hospitalier regional d'Orléans,directeur général [Données non publiées],
+bf6deb65-3e4a-4076-811f-feee317b2be0,[Données non publiées],NEANT,RETRAITE,
+bf6e3370-7427-465e-b051-9f1fec1a41df,[Données non publiées],[Données non publiées],Retraité,
+bf7cbf5d-e4ce-4c55-b154-639252ba88c4,[Données non publiées],néant,néant retraitée,
+bf808a10-dca5-4be2-ac17-06fab9a6d91b,[Données non publiées],[Données non publiées],RETRAITEE,
+bf903a21-0354-49e3-8561-4348ca9c019d,[Données non publiées],SARL IMMOBOX,[Données non publiées],
+bf995abe-acd0-45e9-82e0-ffc4b35f79cc,[Données non publiées],PROVENCE(S),[Données non publiées],
+bf9cffd0-5aea-4376-8ca4-1741aef93650,[Données non publiées],AP-HP,Infirmière,
+bf9e7639-8bd8-4e76-bda5-f850520c6a18,[Données non publiées],ENGEES,[Données non publiées],
+bfa276d6-f867-4abe-a270-d714ab6d2196,[Données non publiées],FONDATION PERE FAVRON,[Données non publiées],[Données non publiées]
+bfa8f135-ae85-4634-a055-acf6d4cf354f,[Données non publiées],BNPrealestate,DGA,
+bfab5002-9836-41f0-8d30-9da49fd0863a,[Données non publiées],Allianz Finance Conseil,Conseiller en Gestion de Patrimoine Certifié,
+bfb4ee3c-32aa-4954-bc5c-75fef20e300b,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+bfb5650f-162f-4b5a-a07e-5b89c2f2b91b,[Données non publiées],Néant,Néant,[Données non publiées]
+bfba68fc-3b24-4f8f-8682-44b922ef7cbf,[Données non publiées],Mission locale Bourgogne nivernaise,Conseillère en insertion professionnelle,
+bfc1d0d3-658d-43b6-bec7-2c44c221d5d0,[Données non publiées],Maison de la culture d'Amiens,Directrice de production [Données non publiées],
+bfc58c42-2aa2-4f58-909f-d297b2900294,[Données non publiées],Constellium,Fiabiliste,
+bfccab7b-8f4f-4ef6-af97-bdb0620f4741,[Données non publiées],Hopital [Données non publiées],Psychologue,
+bfd354fb-04a0-4d40-9de4-7ab5e6346e81,[Données non publiées],Néant,Néant,[Données non publiées]
+bfd41180-cb01-4cf9-9b6b-510a923518f3,[Données non publiées],CIAS,adjointe administrative,
+bfde9050-1db3-41dd-8bc4-17b643882bcc,[Données non publiées],Education nationale,Formatrice [Données non publiées],
+bfe9be86-0db5-4cf3-b8ea-57208a4f3762,[Données non publiées],Education Nationale,Professeur des Ecoles,
+bff5ddec-be42-44d8-85c9-30c40683e8a1,[Données non publiées],néant,[Données non publiées],retraité
+bffb89dd-c25f-42d0-ad85-829e38f56faa,[Données non publiées],NEANT,NEANT,
+c01fe42e-bd45-4ca3-ba49-3537e3547e94,[Données non publiées],SCP INFIRMIERS,INFIRMIERE LIBERALE,
+c028a399-b8d1-4ff1-878f-4369c6414901,[Données non publiées],centre hospitalier [Données non publiées],secrétaire médicale,
+c03dff34-eedc-47e1-9d2b-89d924ad643d,[Données non publiées],STAG - Villers Bretonneux,Assistante administrative,
+c041de78-de9e-40f6-9259-bf8724b6fc4a,[Données non publiées],sans,sans professsion,
+c044dd45-fb27-41a0-863f-251f3aca265e,[Données non publiées],Parents,assistante maternelle agréee,
+c0453709-6785-4497-94c9-286ce7784e9d,[Données non publiées],Education nationale,Directrice d'Ecole,
+c046aaa3-08f9-4049-8a72-919b6a9cf0e2,[Données non publiées],[Données non publiées] [Données non publiées],Retraité [Données non publiées],Plus aucune profession salarié depuis la retraite.
+c061227a-8262-4ba1-8494-5579ff5a0a7e,[Données non publiées],Néant,Gestion de son parc immobilier et de son patrimoine financier,[Données non publiées]
+c06c30e8-f9be-4f3c-8762-f9204ad6ddc2,[Données non publiées],MDPH,Adjointe au chef de service dépendance,
+c06d52bc-410d-4df9-a4cd-ade799d1389f,[Données non publiées],Néant,Néant,
+c06fd23a-ff46-4c38-ad99-de2ddf296ddb,[Données non publiées],Education nationale,"Professeur certifiée de sciences économiques et sociales,",
+c0710db2-bce2-4efe-8bbb-f7b63458363c,[Données non publiées],travailleur indépendant,CONSULTANT VITICOLE,[Données non publiées]
+c076a719-5f2b-455c-8f2a-429f6a11e6df,[Données non publiées],Conseil Départemental de la Gironde,[Données non publiées],[Données non publiées]
+c0771888-d2de-4961-a1d4-777a90a356e9,[Données non publiées],neant,retraité,
+c07c6b4b-241c-4c72-83af-6a39f3736459,[Données non publiées],Néant,Néant,
+c085e1f0-7867-4498-b2be-8892b8cb8abb,[Données non publiées],néant,[Données non publiées],[Données non publiées]
+c08ef000-b00a-4e31-a353-64ef61c2c1a5,[Données non publiées],ministère éducation nationale,SAENES,
+c094446b-af8f-4b19-a486-399ebe87cb75,[Données non publiées],neant,retraité,
+c095842a-fe4d-4dac-84e8-c0d9d028a9da,[Données non publiées],Agricultrice,Chef exploitation,
+c09700e0-fbd9-46c0-ac9f-1e4021e7dfe0,[Données non publiées],néant,néant,
+c0a2ccc8-25d5-4c1f-a82b-74405c4a886c,[Données non publiées],Education,professeur,
+c0a6c7fb-99e6-4c4d-85c2-12af98534c4a,[Données non publiées],néant,néant,néant
+c0ac27b3-c6cb-4d84-b18c-10e118cf2438,[Données non publiées],Centre hospitalier de Bergerac,Encadrant [Données non publiées],
+c0af2949-da7d-472d-a899-8222c909db66,[Données non publiées],CCIR pays de la loire,[Données non publiées] accueil,
+c0b757db-532c-45b6-b6c8-b308ee24e0ad,[Données non publiées],conseil départemental de l'Aude,[Données non publiées],
+c0bcb78f-095c-49ef-97e8-4e8139ca1deb,[Données non publiées],INRAE,[Données non publiées],
+c0bf3b03-c075-4985-8bb1-4bb21fb5cdef,[Données non publiées],Ministère des finances,[Données non publiées] Inspecteur divisionnaire hors classe,
+c0c2fa2a-d29d-4680-91a8-c511d2d0143a,[Données non publiées],Education Nationale,Auxiliaire de vie scolaire,
+c0d46142-80af-4223-95a2-eae694f1c418,[Données non publiées],RETRAITE,RETRAITE,RETRAITE [Données non publiées]
+c0d49f41-7a1b-40a1-8325-80d2b9451b19,[Données non publiées],AUCUN,RETRAITEE,
+c0d8b449-9952-4b74-ba36-7e74713d1184,[Données non publiées],ORECA,Référent Comptable,[Données non publiées]
+c0d9ab44-061d-4ce6-a4f4-bb9bf585b461,[Données non publiées],Travailleur non salarié,Président de ABE Consulting,
+c0dd9d3b-f213-4f96-9f3f-d5af75e65196,[Données non publiées],EDUCATION NATIONALE,Enseignant,
+c0dd9d3b-f213-4f96-9f3f-d5af75e65196,[Données non publiées],MEMBRE DU CA HARMONIMES EN SCENE,[Données non publiées],Activité bénévole
+c0dfcf2d-a9a3-4cae-bfc9-52ba00594187,[Données non publiées],Borel-Bouvard-Athau,[Données non publiées],
+c0e23038-c884-474f-828c-793b2d9666b2,[Données non publiées],AIES,directrice adjointe d'ESAT,
+c0eb3187-51bd-43e3-b2c8-9be8a7d7f09f,[Données non publiées],NEANT,NEANT,[Données non publiées] n'exerce plus d'activité [Données non publiées]
+c0ee90a8-4ebc-4923-8a19-689b96487831,[Données non publiées],Ville du Mans,[Données non publiées],
+c0f3d93f-02fd-42b0-a787-9735d1fcecd6,[Données non publiées],"Communauté d'agglomération Saint-Dizier, Der et Blaise",[Données non publiées],[Données non publiées]
+c0f76ab4-8769-4b14-89b7-598cea0a6773,[Données non publiées],Direction Générale des Douanes,retraitée,
+c0fb9755-64ca-4b7f-9fa4-8cb0fd7da067,[Données non publiées],Métropole du Grand Nancy,[Données non publiées],
+c0fdfcaa-b7e3-4b39-be24-6393056f1f4e,[Données non publiées],Groupe Abbvie,[Données non publiées],
+c1008743-9f5c-440c-ad9d-ec8db0c03ec6,[Données non publiées],Département 13,Fonctionnaire en détachement.,[Données non publiées]
+c1053dd5-6771-46aa-ac6e-507fa28169f0,[Données non publiées],SARL TRANSPORT DELMOULY GENINATTI,CHAUFFEUR ROUTIER,
+c10542fb-3717-43f5-b2f2-70d646a1f8fd,[Données non publiées],retraité,néant,
+c1175acf-d2d0-4ffc-91c8-996b6044dac2,[Données non publiées],France Télévision,Journaliste,
+c11f0ba6-875c-4918-9d15-826702cd69e2,[Données non publiées],Fondation Rotschild,[Données non publiées],
+c122c160-1e5b-44bd-bdc7-d1d71980b055,[Données non publiées],Université [Données non publiées],Enseignant-Chercheur,
+c126cb8f-6add-4663-8aa6-a6de09ad23fa,[Données non publiées],lycée [Données non publiées],enseignant,
+c1281d56-761f-4e10-8e03-1bb9cae301eb,[Données non publiées],Retraité,Retraité de l'Education Nationale.,
+c12c499b-68f6-46c0-8688-e61b0eed269f,[Données non publiées],Profession liberale,Notaire [Données non publiées],
+c14378e9-5bcb-456a-a499-17d18dd0fd63,[Données non publiées],Ecole d'Ingénieurs [Données non publiées],Enseignant - chercheur,
+c14b3309-6a68-48e5-91fb-81fb912d945e,[Données non publiées],DDCSPP,[Données non publiées],
+c153876d-cf77-4262-8f1c-2ec994ac5a11,[Données non publiées],RIO TINTO par PIMAN,Chef de projet,[Données non publiées]
+c15af4ed-5ce8-4d06-a708-1bd4015f5d23,[Données non publiées],NEANT,RETRAITE,
+c15e6577-ff5a-46fe-93ea-8cc2b59415d9,[Données non publiées],néant,néant,[Données non publiées]
+c16236ff-9725-4a93-9a9d-d8e2cf53db65,[Données non publiées],[Données non publiées],USINE PATE A PAPIER,
+c164c746-e62c-4493-b2fc-6ee59aebe369,[Données non publiées],Groupe Abbvie,[Données non publiées],
+c16746ae-1b94-4d4c-9f58-960d44919fa8,[Données non publiées],SKS Developpement,[Données non publiées],
+c16c5ff5-2a3b-4a41-9976-b7d92847df04,[Données non publiées],Néant,Néant,
+c1774c4a-dfd3-4a09-89ca-936ec54d06a4,[Données non publiées],Credit Agricole,Employée de banque,
+c17bde8a-3163-45c6-9e37-03ce888d9f19,[Données non publiées],Conseil regional Normandie,Redacteur territorial,
+c17c30c4-38b9-4fe0-ad55-e212d4101878,[Données non publiées],SIROLAISE DE CONSTRUCTION,[Données non publiées],
+c18ad33a-12eb-4513-8c40-59b97bdff4ea,[Données non publiées],RETRAITE,NEANT,
+c1942a9f-151e-4498-88fb-5cbed82624e5,[Données non publiées],Mairie de [Données non publiées],Agent territorial [Données non publiées],
+c19dcd4b-7856-4594-afa4-2e19e5d58ae9,[Données non publiées],Education Nationale,Professeure [Données non publiées],
+c1a2404b-99d2-4dcd-a30c-b99c848cd91d,[Données non publiées],[Données non publiées],Infirmière DE,
+c1a25270-ac84-4540-ad5d-bdda0cc6d310,[Données non publiées],[Données non publiées],magasin de vetements,responsable salariee
+c1a77f3a-8b18-46a1-b508-e6c514f80636,[Données non publiées],CNRS [Données non publiées],Directeur de Recherche,
+c1af6357-e0b6-47c9-b7f6-f22101d03793,[Données non publiées],Caisse d'épargne Hauts de France,Conseillère Clientelle,
+c1b992b7-70ac-4918-91bf-610a7ffd1e4f,[Données non publiées],néant,néant,Retraitée [Données non publiées]
+c1c69722-dd80-4d8f-a97a-c756d5023e17,[Données non publiées],Néant,Néant,[Données non publiées]
+c1d20d7a-1fa3-4c2c-ab6e-6c6722f890fb,[Données non publiées],Nespresso France,"Cadre commercial, responsable de secteur [Données non publiées]",
+c1d20d7a-1fa3-4c2c-ab6e-6c6722f890fb,[Données non publiées],SAS LE VAUBAN,Présidente de la société commerciale d'activités hôtelières et para-hôtelières.,
+c1d3e667-f84e-49b0-84fd-630e6141d62d,[Données non publiées],retraitée,néant,
+c1d48360-10f7-443c-bd75-9519a6da55d6,[Données non publiées],Educationnationale,enseignante,
+c1e77e2d-6553-4134-98a3-d0e6153df086,[Données non publiées],SCP,VETERINAIRE,
+c1ead806-9df3-4a75-be55-673c08ca03f9,[Données non publiées],néant,néant,
+c1f5298d-bcee-423b-9881-cb02b1105914,[Données non publiées],0,retraité,
+c1fe3c62-47b5-4141-adee-cb8e742f4e8d,[Données non publiées],Mairie de Paris,Sous Directrice [Données non publiées],
+c20b4b61-ea0b-4564-953a-f3155bea76cd,[Données non publiées],ETAT,DGFIP fonctionnaire.,
+c21284b9-e597-44cd-9332-baf8224808ae,[Données non publiées],GAGARAGE LITTORAL AUTOMOBILE,[Données non publiées],
+c21519a7-b799-490f-9b65-aebac2e0a7a1,[Données non publiées],pole emploi,conseilliere,
+c216fbd6-5a08-4f19-8c6c-a56827ccf176,[Données non publiées],Education Nationale,Professeur de Physique Chimie [Données non publiées],[Données non publiées]
+c223ca50-d1f4-4231-8939-a0998f998556,[Données non publiées],elle même,chirurgien dentiste,
+c22e8269-7421-491c-a90b-facd837adfb8,[Données non publiées],CABINET ROUX,Directeur [Données non publiées],
+c2358cc5-5d53-4f05-a314-301953ec7b04,[Données non publiées],[Données non publiées],Secretaire Générale adjointe [Données non publiées],
+c23d4abe-2da2-40b9-a322-9d72d29ee179,[Données non publiées],Casino France,[Données non publiées],
+c246a3b9-116e-4fb8-9afb-4ba63a8f2dec,[Données non publiées],Activité libérale,Avocate,[Données non publiées]
+c2493809-1a7a-4f87-b516-a258953a7285,[Données non publiées],Education nationale,Directrice [Données non publiées] de l'Université [Données non publiées],[Données non publiées]
+c24fc23e-8dd1-47ad-9f3a-8623c33ed6c4,[Données non publiées],Cabinet [Données non publiées],Consultante juridique [Données non publiées],
+c25492cf-2723-4b8f-a62b-4b2981cdff55,[Données non publiées],Néant,Retraitée de l'Education Nationale,
+c2561504-09bc-41c8-93bf-725e01fbdf03,[Données non publiées],néant,néant,retraitée
+c25a7eb9-9d50-4ccf-b976-6b6c9499f7c7,[Données non publiées],Auto entrepreneur,Psychologue,
+c26769ab-8d92-4170-a398-fcc273c4b242,[Données non publiées],Université de [Données non publiées],Enseignante-Chercheuse,
+c26cc1b1-aa26-4a7d-bd2d-5aa2924ede62,[Données non publiées],[Données non publiées],[Données non publiées],Retraitée
+c26cf56b-1c18-4379-9822-2436dd1d1f50,[Données non publiées],SCP,VETERINAIRE,
+c270b330-a1fb-4bf6-80e0-39e885de8c8f,[Données non publiées],Fonction publique hospitaliere,Retraitée,
+c2862a22-2f10-481a-b853-50814eba4796,[Données non publiées],SEARL [Données non publiées],Secretaire juridique,
+c296bc4d-b2bd-4e57-a3bc-c0560e9f861e,[Données non publiées],EARL des Galets,Secrétaire,
+c29ead4d-679e-41f4-bd1e-37787e7622c5,[Données non publiées],aduneo,[Données non publiées],
+c2a9fc4d-8ff7-4106-856c-50dc877b67f5,[Données non publiées],Fonction publique territoriale Ville de Chalons en Champagne,[Données non publiées],
+c2ad624c-931c-4ae5-9199-78304bbe0c91,[Données non publiées],AUTO / LIBERALE,KINE,
+c2b15a9e-b774-4a71-9d44-cc7d6066b272,[Données non publiées],Néant,Gestion de son parc immobilier et de son patrimoine financier,[Données non publiées]
+c2bb1aac-ae12-4ac4-89a3-69a82e470714,[Données non publiées],Département de Loire Atlantique,[Données non publiées],
+c2c3c020-97b2-4fb9-91f7-2002b163373a,[Données non publiées],lui même,journaliste Président et directeur du journal Le petit mag Lens Liévin exploitant agricole [Données non publiées],[Données non publiées]
+c2c9d9a9-f982-471c-a314-b2b40f583a93,[Données non publiées],PROFESSION LIBERALE,INFIRMIERE LIBERALE,
+c2cef78c-2e75-4c66-a80c-02d390230ccc,[Données non publiées],Université Bretagne Occidentale,Enseignant-chercheur,
+c2d4be3c-7567-4bb1-a054-208dd0b08604,[Données non publiées],[Données non publiées],notaire assistant salarié,
+c2d65bcc-3998-41e4-bf0e-560c8322b38f,[Données non publiées],ASSOCIATION ARCHANGE AUTISME,CHARGEE DE MISSION [Données non publiées],
+c2dede81-01bf-45e3-adfe-9dc71afdb0c7,[Données non publiées],SARP OUEST,Formateur activité assainissement [Données non publiées],
+c2e8af9c-d1c3-4032-bac7-07ea92a2d36b,[Données non publiées],AXIOME NOTAIRES,Notaire associé [Données non publiées],
+c2f1480e-f270-4905-ba92-644538c469f3,[Données non publiées],CANON FRANCE DIVISION COPIEURS,TECHNICIEN SAV,
+c2f3f980-c7bd-40bd-a0d3-90c1af1d6665,[Données non publiées],Crédit Agricole Nord-Est,Chargé de développement [Données non publiées],
+c2f603e7-87be-4a54-bf01-cb4cb1e4f154,[Données non publiées],SAS,Architecte,
+c30025dc-031b-4067-b0eb-3283f14eb0ec,[Données non publiées],FCPE,salarié dans une fromagerie,
+c305399d-da5e-498b-990b-3760a7f4e92a,[Données non publiées],Micro entreprise,Conseil en ingénierie historique,[Données non publiées]
+c305399d-da5e-498b-990b-3760a7f4e92a,[Données non publiées],SainteMarieduMont,[Données non publiées],salarié
+c30c17b9-d150-4947-b751-f2de5ae58417,[Données non publiées],Ministère de l'Education nationale,Professeure des écoles,
+c315bd4f-c739-4eaf-be51-c128cf4cda9d,[Données non publiées],Elu de la Ville de Marseille,[Données non publiées],
+c327197f-9c5a-4a4e-9e52-bdd87f47314e,[Données non publiées],ADIL [Données non publiées],[Données non publiées],
+c335e9b3-69f5-4234-9e12-46e5975fa001,[Données non publiées],Onrangetout,Gérante [Données non publiées],
+c336287d-7138-4496-93af-26cd9b67d383,[Données non publiées],CAESE,néant,[Données non publiées]
+c338f9ff-c778-4234-a44c-eb49c10f9a67,[Données non publiées],Limoges Metropole CU,[Données non publiées] [Données non publiées],[Données non publiées]
+c358c08d-b096-4b15-a07d-e233b7e10cfc,[Données non publiées],Fondation Rotschild,[Données non publiées],
+c35f4a11-864a-4d0c-8375-187b46e58b16,[Données non publiées],SUN'R GROUPE,OFFICE MANAGER,
+c3618b1a-2491-4e71-bd26-e87a2ca78c4f,[Données non publiées],Radiologie [Données non publiées],secrétaire administrative et comptable,
+c365ae33-f652-4706-ab98-4fd55569a107,[Données non publiées],[Données non publiées],EXPLOITANTE AGRICOLE,
+c36bb345-25fb-4557-bbd6-e5219dc2fa7e,[Données non publiées],néant,Adjoint au Maire de Reims et conseiller départemental de la Marne Auto-entrepreneur dans la vente de champagne,
+c36f2b41-4b1d-4cc3-9073-1787cfe7c87e,[Données non publiées],[Données non publiées],CHARGÉE DE MISSION RH [Données non publiées],
+c371c301-95a3-4eef-ae94-10969d607516,[Données non publiées],ORPAN,Chargé de mission,
+c3781706-1269-4f06-9301-e8d3c29c3bff,[Données non publiées],CNRACL,Retrairée,
+c378299f-aa00-4631-a0c6-c3e2297b2033,[Données non publiées],Centre hospitalier [Données non publiées],praticien hospitalier,
+c3872694-d447-4d54-93a7-15ab5995aede,[Données non publiées],Education Nationale,Professeur des écoles hors classe,[Données non publiées]
+c388b7bb-2b64-4c2a-8ca7-7fe58bcf91ac,[Données non publiées],NEANT,NEANT,
+c38c4bc9-4bbd-457d-b198-e7275c821694,[Données non publiées],Néant,Néant,Néant
+c3932107-abc8-4b59-ac01-69434e55b15f,[Données non publiées],[Données non publiées],Médecin radiologue,
+c3947449-ed90-46d0-b67f-6a61288980aa,[Données non publiées],[Données non publiées],ANIMATEUR SOCIO CULTURELLE,
+c3973090-e3fd-4ca5-8df5-5cb01fa4f4af,[Données non publiées],Artisan,Luthier,
+c3a16e22-8b1a-40b6-a2b4-c5ad7ba4d7f3,[Données non publiées],Education nationale,Personnel de Direction,
+c3a2aff8-eaf4-4dfb-8bad-50835b2d33f7,[Données non publiées],Allianz Finance Conseil,Conseiller en Gestion de Patrimoine Certifié,
+c3a81e95-c3ca-4a05-8e67-23d2654fac96,[Données non publiées],[Données non publiées],[Données non publiées],
+c3ba8915-15bb-44d9-af13-d637ca6bebbf,[Données non publiées],néant,néant,[Données non publiées]
+c3c574ce-47d5-4893-815b-b0aa03b472c8,[Données non publiées],CHRU de Brest,Vaguemestre [Données non publiées],[Données non publiées]
+c3ca561c-bc79-4aa9-850d-362d91678978,[Données non publiées],FILIERIS - CANSSM,EMPLOYEE [Données non publiées],
+c3df7dd3-b3ff-4759-90df-2c0bc78a74b2,[Données non publiées],[Données non publiées],journaliste sportive,
+c3e229dd-69bb-44f0-a9a0-84fbeb2d3e72,[Données non publiées],RETRAITEE,RETRAITEE,
+c3ec6286-db8b-4e97-9b44-994541464a4c,[Données non publiées],VILOFOSS,salariée,
+c3f9bbdf-6cdf-4386-89ff-be25080b7ffb,[Données non publiées],COLLEGE JOSEPH ROUMANILLE,[Données non publiées],
+c3fa3354-6d5e-4fd7-998c-317b47c06775,[Données non publiées],Mairie de Vals les Bains,[Données non publiées],
+c4024dff-d4fa-4023-bb03-6a60fba9724b,[Données non publiées],Pharmacie [Données non publiées],Pharmacien adjoint,[Données non publiées]
+c4107f28-705f-4c3c-be64-3762f90ee28a,[Données non publiées],neant,neant,
+c414704d-ff4e-4a33-80c1-c6e4342aa478,[Données non publiées],Est Ensemble,Professeur de danse,
+c41dd7a5-aa78-4135-ad6d-867f640c9869,[Données non publiées],EPCI,Attachée territoriale,
+c4221cda-18e7-4ee2-96a5-2bbfa7b584e9,[Données non publiées],Mairie de Draguignan [Données non publiées],[Données non publiées],
+c428bc6f-1126-4242-a6fe-23d012974e89,[Données non publiées],[Données non publiées],Ingénieur,Cumul emploi - retraite
+c42c0973-d3fd-4157-bbaf-66ba02e51294,[Données non publiées],EDUCATION NATIONALE,PROFESSEUR,
+c436edbe-8100-47ba-b85e-22f6fff686dc,[Données non publiées],TANDEM,SECRETAIRE [Données non publiées],
+c4403eb5-89cb-4c20-9422-0277f5d78871,[Données non publiées],[Données non publiées],Fabrication et vente de chaussures,
+c44cbe38-b944-4aa5-bacb-17f78f7df1b3,[Données non publiées],sans,sans,
+c45505a6-238e-4641-9615-2680dd7a8444,[Données non publiées],ECURIES [Données non publiées],[Données non publiées],Profession exercée: cavalier et moniteur d'équitation formateur d'enseignants en equitation
+c4587171-4074-4530-a483-54ac626e4159,[Données non publiées],A son compte,Fabrication de fusil de pêche + vente,
+c462b07d-2594-49f3-a639-61d585b3a6bf,[Données non publiées],CPAM 93,Cadre de la fonction publique,
+c4878a6d-8a08-4024-b4a7-de5f5829ea6a,[Données non publiées],GHER,[Données non publiées],
+c491ff61-67ee-4fdb-82f8-260c8698034f,[Données non publiées],Groupe Majorité CD 45,Collaboratrice [Données non publiées],[Données non publiées]
+c494537e-12eb-4388-a35c-90ea102af31b,[Données non publiées],Centre Hospitalier de Mauriac,Praticien Hospitalier,
+c49611c4-94c7-457b-b021-6be6fac8013a,[Données non publiées],SARL [Données non publiées],RESTAURANT,
+c49611c4-94c7-457b-b021-6be6fac8013a,[Données non publiées],SARL [Données non publiées],TRAITEUR 45% des parts,PAS DE REMUNERATION
+c49611c4-94c7-457b-b021-6be6fac8013a,[Données non publiées],SARL [Données non publiées],PARTICIPATION A HAUTEUR DE 34% DANS LA SARL [Données non publiées] AUCUNE REMUNERATION,AUCUNE REMUNERATION
+c49727d4-7149-4484-b593-3c2ac6bbd710,[Données non publiées],sans,sans,
+c49b69d3-3593-497e-80ea-a4839b239433,[Données non publiées],L'Express,Journaliste,
+c4a1cfa3-8b45-4c7d-a33c-0200f28a9e46,[Données non publiées],néant,néant,[Données non publiées]
+c4bd20fb-b7c2-4bad-b6d9-55e2162cb6d4,[Données non publiées],MMA IARD,Responsable Conseils juridiques. [Données non publiées],
+c4c1e4b0-613e-4feb-a080-cb3141865793,[Données non publiées],néant,Intermittente du spectacle,
+c4c8ebb5-9a82-4023-a36e-63b2e7722196,[Données non publiées],Université Paris 8,Maitre de conférence,
+c4d0d848-d38e-46db-8d19-7e20cec5497a,[Données non publiées],Elu de la Ville de Marseille et au département 13,[Données non publiées],[Données non publiées] dirigeante de la société DJAMBAE NOURIATI [Données non publiées] spécialisée dans le domaine du conseil pour les affaires et autres conseils de gestion mais cette société est en sommeil depuis 2014 [Données non publiées]
+c4dbbe3c-7e84-4592-9d8e-f52134566c3d,[Données non publiées],Centre Hospitalier [Données non publiées],Infirmière DE,[Données non publiées]
+c4def03b-d586-45a2-8af0-a854d9d1406a,[Données non publiées],Delfie Plus Coaching SARL,Gérante [Données non publiées],
+c4ec1f00-1939-418d-aad2-b1b5e94ad123,[Données non publiées],Hôpital [Données non publiées],ASH,[Données non publiées]
+c4ef887f-2101-4047-aa6b-443774a95ece,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+c4ef887f-2101-4047-aa6b-443774a95ece,[Données non publiées],Auto entrepreneur,Conseil en relations publiques,[Données non publiées]
+c4ffbb0c-4e2d-4b09-9101-e7e054fc0ba0,[Données non publiées],Education Nationale,Gestionnaire Comptable du Lycée [Données non publiées],[Données non publiées]
+c501621c-127b-4ab3-a1e8-335deed1c671,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+c501621c-127b-4ab3-a1e8-335deed1c671,[Données non publiées],Tadaweb,Directeur France et Europe du Sud,[Données non publiées]
+c51ba758-0784-42db-b02b-3a93b93dbf5a,[Données non publiées],auto-entrepreneur,Conseillère en décoration d'intérieur,
+c52d0abd-c135-439d-833c-59b91dcc0da0,[Données non publiées],[Données non publiées],[Données non publiées] coiffeuse.,
+c5337570-6f58-43f3-996d-422bb6570d00,[Données non publiées],RETRAITEE,RETRAITEE DE L'EDUCATION NATIONALE,[Données non publiées]
+c53be91a-9298-48a6-bdf1-7279324633a0,[Données non publiées],néant,néant,[Données non publiées]
+c53ccee2-3508-412b-ac23-da183e8009d4,[Données non publiées],CESSON RENNES METROPOLE HANDBALL,responsable administratif et financier [Données non publiées],
+c5430b66-be59-4498-ac21-917fe611d46b,[Données non publiées],bureau des guides,monitrice de ski (hiver) accueil bureau des guides (été),
+c553699b-bee0-4045-bac6-249f71007096,[Données non publiées],mairie,admitratif,
+c558732e-63fe-4805-a05f-611ce380f916,[Données non publiées],Lycée Professionnel [Données non publiées],Formateur / enseignement agricole privé sous contrat,
+c55919c3-4629-41ce-86a7-042ff54b76ff,[Données non publiées],Dentons,Avocat [Données non publiées],
+c55d03f6-6e98-4827-8200-8de251f85230,[Données non publiées],[Données non publiées],Viticulteur,
+c55e8aec-62f5-4bff-ae38-bfeebad61548,[Données non publiées],Education nationale,Professeure des écoles,
+c55fa757-2db5-441a-9bc6-7ee566f923db,[Données non publiées],VILLE D'ARRAS,ELECTRICIEN,
+c5778407-afb7-4037-b5a2-87da01026838,[Données non publiées],Agent commercial indépendant,Vente de biens immobiliers,
+c5778407-afb7-4037-b5a2-87da01026838,[Données non publiées],Président sasu be immo,Achat revente,[Données non publiées]
+c57d7f43-babf-4e06-ae74-5fbdf095313a,[Données non publiées],Groupe EVALIS,DGA [Données non publiées],
+c58cbd02-8e5f-4569-ae83-165d1d6dbc2e,[Données non publiées],Ville d'Aix-les-Bains,[Données non publiées] [Données non publiées],
+c5903fb1-8199-4e40-8f23-526e2b757996,[Données non publiées],Groupe CISN,[Données non publiées],[Données non publiées]
+c59ce2ef-1f90-4e9a-8d07-72b9fa31b3f4,[Données non publiées],ALYS,Auxiliaire de vie,[Données non publiées]
+c5a77da7-0b61-4e4f-824d-9a4767a21a89,[Données non publiées],Education Nationale,Gestionnaire - Agent comptable,
+c5b17fa7-2fec-47e3-bab3-8a13d674d800,[Données non publiées],NEANT,NEANT,
+c5b52c94-cd06-47ee-aa3e-272318c7018e,[Données non publiées],GERANTE SARL,EVENEMENTIEL,
+c5ca9e41-2f96-42ca-99fa-04197560e931,[Données non publiées],neant,neant,[Données non publiées]
+c5d8869f-36f8-4522-a797-b805fd7f5636,[Données non publiées],[Données non publiées],Professeur des écoles,
+c5e6c20e-236d-455d-bd1e-2f8cd30b018b,[Données non publiées],Ministère de la Justice,Elève-magistrat,
+c5ea40b1-29e3-4154-9a0b-e5085586ab38,[Données non publiées],[Données non publiées],Comptable,
+c5ea889e-a91a-41a6-8939-800473e6b6a7,[Données non publiées],CourdesComptes,conseillèremaitre,
+c5f0b733-7513-4ee5-8036-c541234f82ea,[Données non publiées],[Données non publiées],Conseil en decoration et photographe.,
+c5f69561-6379-4816-bc5b-231645ff3787,[Données non publiées],OGC SAINT ANDRE,INTERVENANTE [Données non publiées],
+c5f69561-6379-4816-bc5b-231645ff3787,[Données non publiées],CRECHE KOKIRI,INTRVENANTE [Données non publiées],
+c5fefb2c-3c37-4c4d-9704-a3f187360d21,[Données non publiées],TAXI [Données non publiées],Artisan Taxi,
+c601f761-fd67-4440-82fb-b02097fc8bc8,[Données non publiées],[Données non publiées],[Données non publiées],
+c601f761-fd67-4440-82fb-b02097fc8bc8,[Données non publiées],Association Union Patronale MEDEF 84,[Données non publiées] chargée de développement et communication [Données non publiées],
+c611aabe-bcbe-484d-862e-8b865402b659,[Données non publiées],St-Etienne Métropole,Ingénieur Territorial,
+c621ec65-d5d3-4a1a-97f7-fbd986203ae1,[Données non publiées],néant,néant,[Données non publiées]
+c6303d94-f83f-4412-9b76-1dd8c3331850,[Données non publiées],EDUCATION NATIOANLE,Professeur de collège,
+c632703e-cada-4bf8-a6b8-99cfec9b7d0b,[Données non publiées],Profession libérale,Avocate,
+c6341ba0-754e-4880-a032-d717968e7fdc,[Données non publiées],Art Escale,Galiériste,
+c6395d0e-43c8-4254-a776-f8cbafcd2cd5,[Données non publiées],BRUN SA,[Données non publiées],
+c63a49d8-013c-4805-ac93-1c33e61463e9,[Données non publiées],Neant,Neant,
+c63b87e9-fd43-4865-b77d-1b24935e63ed,[Données non publiées],Conseil départemental de la Mayenne,Directeur [Données non publiées],
+c63bebc5-3d5f-44ea-8b63-3ff021b92dad,[Données non publiées],Archipel,Auxiliaire de vie sociale,
+c64ba3b1-5568-480a-8de9-68d3daae0801,[Données non publiées],Retraitée,Secrétaire médicale,
+c64c28cd-a7ab-4285-92ff-16c18e131005,[Données non publiées],Neant,Retraite,
+c650ba95-be0b-4bd9-b9a1-dbb797b4b889,[Données non publiées],[Données non publiées],entreprise &gro alimentaire Directeur technique,[Données non publiées]
+c650e51d-e7e6-4a4f-9de2-870023bee1db,[Données non publiées],NEANT,[Données non publiées],
+c6549b93-f456-475d-854c-aac4f3414dfc,[Données non publiées],Centre hospitalier [Données non publiées],auxiliaire de puériculture,
+c65b50ac-d694-421e-b763-8dd97add4f48,[Données non publiées],GERANT EURL [Données non publiées],[Données non publiées] DANS LE DOMAINE DE L INFORMATIQUE,
+c6663285-2522-41ef-a3d0-79eaa929b5e4,[Données non publiées],Ministère de la Défense [Données non publiées],Ingénieur des études et techniques d'armement,
+c668e6e5-6952-4c17-a865-d5871b7e8cd5,[Données non publiées],retraité,RETRAITE,
+c6691c2b-ad3a-4c3a-90b8-972145cdea48,[Données non publiées],RETRAITEE,NEANT,
+c6698361-de67-44bb-942a-126597a032c3,[Données non publiées],sarl [Données non publiées],gérante expert comptable commissaire aux comptes,
+c66d9057-1e48-4cba-9597-05c7a8275f40,[Données non publiées],Mairie de Gennevilliers,Professeur d'enseignement artistique [Données non publiées],
+c66f270c-2720-4047-a0e5-5879e351627d,[Données non publiées],néant,sans activité professionnelle,
+c67f398e-8534-418f-b941-f86177986d12,[Données non publiées],[Données non publiées],Coiffeuse,
+c6843506-0073-4420-9903-6c027e4a972a,[Données non publiées],Libéral,Infirmière Libérale,
+c6ad4121-6400-456f-8221-c75da7a91662,[Données non publiées],[Données non publiées],GERANTE SOCIETE,
+c6af47a2-3a7d-4975-a4dc-6e27b8875b57,[Données non publiées],[Données non publiées],location/gestion d'appartements meublés,
+c6b21899-27b1-44e8-8c47-133f40336c86,[Données non publiées],SOFRASTOCK International,[Données non publiées],
+c6b66811-f7a7-44e3-b5c6-0fc19d3450a8,[Données non publiées],néant,néant,Retraitée de la fonction publique territoriale
+c6ba1a89-5478-40ff-b82f-541416fcaaec,[Données non publiées],MINISTERE INTERIEUR,SECRETAIRE ADMINISTRATIVE PREFECTURE VAL D OISE,
+c6bb693f-84ca-46d1-a872-6575c9e8f90a,[Données non publiées],Ministère du Travail,Inspectrice élève du travail,
+c6bc5ded-e790-4731-b1d5-2113f8d5a223,[Données non publiées],SPO EMSUR FRANCE SAS,AIDE BOBINEUR OUVRIER,
+c6bd6ab4-4c31-4545-9d2a-17af924db951,[Données non publiées],Centre-Sevres-Faculté-Jésuite-de-Paris,doctorat-en-théologie,[Données non publiées]
+c6dd1e63-7008-4775-9d06-ae93d73e1be1,[Données non publiées],néant,néant,
+c6e068ed-be6b-446d-85fa-40cf1803ee31,[Données non publiées],néant,néant,
+c6f640c6-5088-4d7e-9598-b9f289ae528a,[Données non publiées],AEP ND du Mont Carmel,Institutrice,[Données non publiées]
+c70a8996-6946-47ff-b2f2-f6ffc5d2701a,[Données non publiées],CNAM,Enseignant,
+c70a8996-6946-47ff-b2f2-f6ffc5d2701a,[Données non publiées],Sénat,Sénateur,
+c71374c1-08a0-4cc2-8399-ab2b80575d29,[Données non publiées],Ville de Lourdes,[Données non publiées],
+c71eab2c-0983-4598-9a41-1a74335bd51f,[Données non publiées],Centre hospitalier [Données non publiées],ambulancier,
+c72c5b38-90e3-41ab-be76-fc7efdf38a83,[Données non publiées],Profession libérale,Médecin généraliste,
+c732055a-278c-4a46-a4bf-1cdec992cc9f,[Données non publiées],Région Grand Est,[Données non publiées],[Données non publiées]
+c73477cf-a81e-460c-873f-ea416b7b9a5f,[Données non publiées],[Données non publiées],[Données non publiées] - retraitée [Données non publiées],[Données non publiées]
+c736c929-27fc-49ee-bda0-1e0cef82b80f,[Données non publiées],NEANT,NEANT,
+c7399324-4a06-4186-9d0b-bdab7b7e5604,[Données non publiées],neant,employée commerce,[Données non publiées]
+c739f1a6-fb11-4233-9ac8-d44e5332a073,[Données non publiées],[Données non publiées],[Données non publiées],retraité
+c73e6e79-34a6-4a12-816c-7708b7d31bc7,[Données non publiées],néant,néant,[Données non publiées]
+c754bf59-7e45-4d4c-9d07-b4412543050e,[Données non publiées],Nouvelle Région Aquitaine,[Données non publiées],
+c75ed1f4-461e-4a9e-8f76-8b485e1e050b,[Données non publiées],Education nationale,Professeur de français,
+c771dd8c-d531-4525-8cef-e59a918f561a,[Données non publiées],EUROFINS,AUDITRICE QUALITE,
+c7762156-2826-419c-a72e-188383870fbb,[Données non publiées],Education Nationale,Professeur d'EPS,
+c784f0c2-a2d8-4d1d-a835-4a7c79534f03,[Données non publiées],néant,Retraité,
+c7879411-a579-4bfa-b77d-9bf83cab0bea,[Données non publiées],ministere des finances publiques,contrôleur du trésor,[Données non publiées]
+c78c6b80-fe2a-448c-9b5d-d58aa8853103,[Données non publiées],indépendante,Artiste peintre [Données non publiées],
+c79b4c78-3ed0-4e67-925e-0eef0d51d7cb,[Données non publiées],[Données non publiées],OPTICIENNE-DIRECTRICE DE MAGASIN,
+c7ae191c-1ac6-43ac-ae01-0303db6ae8c8,[Données non publiées],CAFPI,COURTIER EN PRET IMMOBILIER,
+c7bdd5f0-27fd-479b-ba62-71e6be941c4c,[Données non publiées],NEANT,NEANT,[Données non publiées]
+c7cae8e5-75e1-4522-9aa1-7e14d49e0021,[Données non publiées],SAS DELICATESSE CONCIERGERIE,conciergerie location courte durée,
+c7e19d65-9ad7-45cd-988a-46643539f63f,[Données non publiées],SASU,Commerce de vetements pour hommes,Présidente d'une SAS Unilaterale
+c7e97bf5-7a09-493d-b433-21a3bd7ea2be,[Données non publiées],Retraité [Données non publiées],[Données non publiées],[Données non publiées]
+c7fdb848-ca3b-4e9e-acf3-2d1ec4e49be3,[Données non publiées],BIOROCK,COMMERCIAL,
+c800faff-4324-4916-ada1-ec4b61be0d40,[Données non publiées],EPDEF,[Données non publiées],
+c80615a5-3a2a-492d-9f69-586ca6e3ef05,[Données non publiées],Education nationale,Professeur des écoles,
+c80c235c-4670-4fd4-8147-386666f1fe3c,[Données non publiées],L'OREAL,Directeur Zone Europe [Données non publiées],
+c814c41d-23c6-46fb-83e3-8c0eaf391d01,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+c814c41d-23c6-46fb-83e3-8c0eaf391d01,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+c814c41d-23c6-46fb-83e3-8c0eaf391d01,[Données non publiées],SASU Cristobal,vente de pret à porter et accessoires,
+c83077a2-bb5c-4c27-bf1c-cd4a13eb05aa,[Données non publiées],Retraité,[Données non publiées],
+c837799f-6e85-44b0-993c-5c53e8dcad7f,[Données non publiées],Université [Données non publiées],Enseignant Chercheur,
+c83b9b31-3b8d-4451-bc34-0873393889e1,[Données non publiées],[Données non publiées],Président directeur général,
+c83cfcd4-d17d-4fb8-972e-6929ca3bc9b2,[Données non publiées],CONSEIL DEPARTEMENTAL DE L'ARIEGE,ASISTANTE FAMILIALE,
+c84f3512-6a71-48ab-ab08-459ffccc2d6b,[Données non publiées],[Données non publiées],COURTIER EN PRET IMMOBILIER,AUTO ENTREPRENEUR
+c8539d51-77fd-4dd9-9b0d-8cfcd70504a7,[Données non publiées],Néant,Psychologue en libéral,
+c85a134a-c64f-480b-a295-79b802a9bd3b,[Données non publiées],Société générale,Consultante interne,
+c85fb225-a8bb-49cc-862d-ddb180b9d5ea,[Données non publiées],Bred,Conseiller bancaire,
+c85fb481-f7af-4484-96e0-6de0ce622997,[Données non publiées],SELARL JURIS 38 [Données non publiées],COMMISSAIRE DE JUSTICE ASSOCIEE,
+c865a0e6-3f53-4ce1-9a32-e083ebe7ed84,[Données non publiées],CHD LA CANDELIE,AGENT ADMINISTRATIF,
+c868df8d-3bb5-464c-b724-23126a8242ef,[Données non publiées],ARS Nouvelle - Aquitaine,Directeur de cabinet,
+c878033b-f85e-4d51-a295-c1bc736a0d67,[Données non publiées],[Données non publiées],Cabinet dentaire,
+c8797003-f7a4-4f44-97bd-9b25cc246ce0,[Données non publiées],Néant,Néant,En retraite [Données non publiées]
+c87dd447-06a7-44cd-a9b3-59020fb8e3c5,[Données non publiées],[Données non publiées],SECRETAIRE,
+c87dd447-06a7-44cd-a9b3-59020fb8e3c5,[Données non publiées],neant,neant,
+c87fc91a-f81c-4114-b919-90ab2de0cbeb,[Données non publiées],SAS MAISON DU GAUCHER,Président DIRECTEUR GENERAL,
+c88ea74f-d250-4e7f-939e-6f9f953696bd,[Données non publiées],néant,Retraitée,
+c8987616-0984-4754-a647-0db08f85428b,[Données non publiées],Collectivités locales,"Attachée principale (FPT, catégorie A) [Données non publiées]",
+c8aa3c80-ac51-4cad-a9d0-ee473fbc11f6,[Données non publiées],Ville de Val de Reuil,Néant,"Depuis décembre 2022, [Données non publiées] directrice ""sports, culture et vie associative"" à la mairie de Val de Reuil."
+c8aa3c80-ac51-4cad-a9d0-ee473fbc11f6,[Données non publiées],Ville de Canteleu,Maire,[Données non publiées]
+c8aa3c80-ac51-4cad-a9d0-ee473fbc11f6,[Données non publiées],Région Normandie,Conseillère régionale,[Données non publiées]
+c8aa3c80-ac51-4cad-a9d0-ee473fbc11f6,[Données non publiées],Métropole Rouen Normandie,Conseillère métropolitaine,[Données non publiées]
+c8aa3c80-ac51-4cad-a9d0-ee473fbc11f6,[Données non publiées],LOGEAL,Membre du conseil d'administration,[Données non publiées]
+c8aa3c80-ac51-4cad-a9d0-ee473fbc11f6,[Données non publiées],HABITAT 76,Membre du conseil d'administration,[Données non publiées]
+c8aa3c80-ac51-4cad-a9d0-ee473fbc11f6,[Données non publiées],CCAS de Canteleu,Présidente du Conseil d'administration,[Données non publiées]
+c8aa3c80-ac51-4cad-a9d0-ee473fbc11f6,[Données non publiées],Centre de Gestion de la Fonction Publique Territoriale,Membre du conseil d'administration,[Données non publiées]
+c8ae43a3-3c94-4774-8c68-65f87eb358ce,[Données non publiées],inertam,[Données non publiées],
+c8b7eb65-e4b2-412d-a5fa-fb88ede57638,[Données non publiées],GAMA [Données non publiées],directeur [Données non publiées],
+c8b88372-d85b-4cec-908a-4d471de58065,[Données non publiées],CARSAT [Données non publiées],[Données non publiées],
+c8bd6630-d6e5-4e0a-92f4-4b400c92ec66,[Données non publiées],Conseil Départemental,[Données non publiées] muséum d'histoire naturelle,
+c8c4795e-c2f9-45e0-a82c-3a1da529c5cf,[Données non publiées],[Données non publiées],Administrateur Réseau,
+c8c4c3a7-daeb-4725-860d-ee43f7454833,[Données non publiées],Université UPEC Paris 12,professeur,
+c8c54924-694e-47ac-a223-fc44217fece0,[Données non publiées],entrepreur individuel,Pharmacienne à [Données non publiées],
+c8dd39cc-55a8-4472-b3ce-fe0f3d6868ae,[Données non publiées],ministère de l'éducation nationale,professeur d'EPS certifiée,
+c8e50eb2-fbc7-4992-9304-374d09dcc587,[Données non publiées],éducation nationale,professeur de l'enseignement secondaire,[Données non publiées]
+c8e8088d-f0ab-427f-8427-8329da37cf3d,[Données non publiées],Activité Libérale,Architecte,[Données non publiées]
+c8fc01f7-b263-4106-9256-feca9180047d,[Données non publiées],Conseil départemental,dirigeant de musée,
+c8ff41fd-1316-406c-b963-bcc2f5fa6fe5,[Données non publiées],Education Nationale,Professeur documentaliste,
+c9042a43-083d-4de6-98dc-b3154e672f87,[Données non publiées],Education nationale,Professeure certifiée de lettres modernes,
+c907da7f-b8d2-48a9-aafa-98a7b631e0b2,[Données non publiées],néant,néant,[Données non publiées]
+c91032b9-864d-446b-9bc7-59142a502685,[Données non publiées],Cabinet Marc Merlin,Chargé d'affaires [Données non publiées],
+c9194739-5eae-4cf5-9178-9323bbbf8de8,[Données non publiées],GHM [Données non publiées],Infirmière,
+c920295c-c9e0-4017-a09f-f20600998979,[Données non publiées],Néant,Néant,
+c9211eff-9c18-490e-9c68-8327047f1022,[Données non publiées],General Electric,Senior Vice President [Données non publiées],
+c922ccba-d354-48ba-8eb0-30d90cd4e206,[Données non publiées],Coformatique,informaticien,
+c92e18a4-96d1-4c11-9098-8dc7cacf1ea5,[Données non publiées],[Données non publiées],chirurgien dentiste,
+c9336a22-2452-4eeb-b3c8-7b127072842b,[Données non publiées],Mairie de Carcassonne,[Données non publiées] [Données non publiées],
+c941b1f0-01b4-4675-8d92-8ca873c08da8,[Données non publiées],OBJECTWARE,[Données non publiées],
+c942e343-0e5a-499b-8288-f0bb29eaeae9,[Données non publiées],Métropole Aix Marseille Provence,responsable de division [Données non publiées],[Données non publiées]
+c94fbb19-60d6-44ce-93c6-9e148015aedf,[Données non publiées],NEANT,NEANT,[Données non publiées] retraitée [Données non publiées]
+c988ce38-e9a7-4248-a576-9ec8afe72122,[Données non publiées],Ville de Narbonne,[Données non publiées],
+c99041b0-fe39-467c-ba51-857a787f1d4e,[Données non publiées],SYNERGIE,interim,
+c9916064-9908-4f43-b9e0-721eb5010c12,[Données non publiées],retraité,[Données non publiées],
+c99431c3-b351-44d3-a09d-0190bb883835,[Données non publiées],Le printemps,[Données non publiées],
+c999fdf7-4a5a-4959-a3ca-c79f39c883c3,[Données non publiées],maison de l'architecture et de l'environnement de Dijon métropole,[Données non publiées],
+c9a368b7-833e-4b90-b8e5-466d57241468,[Données non publiées],NEANT,NEANT,EN RETRAITE [Données non publiées]
+c9a3935d-f07c-4c76-8268-b2b2a1719852,[Données non publiées],POLE EMPLOI,Cadre,
+c9a4ed39-f5c4-48e3-9103-77f4a3e57523,[Données non publiées],[Données non publiées],[Données non publiées],retraitée
+c9a939b6-7773-4e82-ab51-b511b44d77a2,[Données non publiées],Département de Loire-Atlantique,Attaché Territorial,
+c9aace20-62ef-4a0d-a553-1f94e57f60de,[Données non publiées],[Données non publiées],Conseiller en immobilier autoentrepreneur,
+c9b03705-92e7-407c-bbd9-db103e2b4b5c,[Données non publiées],Education Nationale,Proviseur de lycée,[Données non publiées]
+c9cd8b72-e822-4b7f-a00f-f0fc484e585a,[Données non publiées],Ville de Paris,Communication et relations presse,
+c9cf3691-13b9-4a7d-9812-d8c185063bc9,[Données non publiées],Education Nationale,Professeur 2nd degré,
+c9db20b0-e611-42e3-8bf8-990953404f2b,[Données non publiées],Descours&Cabaud,[Données non publiées],
+c9e186be-dab3-4102-adfa-3e5f2edd51da,[Données non publiées],retraitée,aucune,[Données non publiées] retraite depuis le 1/09/2020
+c9e316b4-6ade-46a8-9f0b-b7089c2c3950,[Données non publiées],Nantes Métropole,Conseillère municipale de Saint Sébastien sur Loire Conseillère Métropole de Nantes,
+c9e7ec40-cb0c-4e10-a4c9-a61ae116d242,[Données non publiées],Retraité,Retraité de la fonction publique territoriale,[Données non publiées]
+c9e7ec40-cb0c-4e10-a4c9-a61ae116d242,[Données non publiées],SAS CAMPET Entreprise,Ouvrier niveau II [Données non publiées],
+c9fd1cef-cf84-4e1d-89f4-d53ebbb3259a,[Données non publiées],TAHITI RAVAAI [Données non publiées],Marin pêcheur,
+ca0c8fea-5cd6-4972-b803-3d8fcf22f0c2,[Données non publiées],[Données non publiées],Viticulteur,
+ca0eb9fa-1d41-42d7-96c9-d211da8c6a16,[Données non publiées],NEANT,NEANT,
+ca0f00d7-4da3-4f32-9d31-ba49351a5047,[Données non publiées],[Données non publiées],PRESIDENT DU CENTRE SCIENTIFIQUE [Données non publiées],
+ca27eca8-521b-4d6c-84ca-bba07b85138f,[Données non publiées],CENTRE HOSPITALIER DE BIGORRE,Directrice adjointe [Données non publiées],
+ca39befe-4b3d-41fb-9190-242c5d2e52be,[Données non publiées],Ville de Vaires sur Marne 77,Directrice Générale des Services,
+ca3f98c6-811d-4d95-90ed-4deb46552ec7,[Données non publiées],Education Nationale,Professeur,
+ca4607a3-e990-43ed-9ce5-92d8ecf11054,[Données non publiées],aucun,[Données non publiées],
+ca56eedd-34ca-4193-be88-d5922cc30599,[Données non publiées],Ministère de l'Education Nationale,Enseignant,
+ca5d1890-3a7d-47d7-83b4-074a4a25920d,[Données non publiées],[Données non publiées],Esthéticienne,
+ca6743b6-40ca-4216-b7aa-25b638049c9f,[Données non publiées],INFIRMIERE LIBERALE,INFIRMIERE LIBERALE,
+ca6c2cda-726b-4c16-ad74-e88cf84ba847,[Données non publiées],MGB,Directeur commercial,
+ca7e3eca-50c9-4382-99e9-5848d54df513,[Données non publiées],[Données non publiées],Notaire,
+ca829e62-47c9-4f32-8a10-8ac9171d1de9,[Données non publiées],AS60 AGC Association [Données non publiées],Comptable Catégorie 2,
+ca831a8e-51bc-43c4-83c3-ee4cfa59bfa7,[Données non publiées],SOGARIS,[Données non publiées],[Données non publiées]
+ca831a8e-51bc-43c4-83c3-ee4cfa59bfa7,[Données non publiées],Société Sogaris (SEM Ville de Paris),[Données non publiées],
+ca903cb0-5720-4a24-8f04-2d15c4940df0,[Données non publiées],SAS CHADIS,[Données non publiées],
+ca97dfd6-5960-4757-b5de-b54d489058cb,[Données non publiées],NEANT,NEANT,[Données non publiées] ELU LOCAL
+ca9ba213-587e-410f-a589-ccd42aaf654c,[Données non publiées],Musée des Arts Déco - Ecole Camondo,[Données non publiées],
+ca9fc0a4-be03-43db-acf2-7f011b8fe34d,[Données non publiées],CHU Nantes,"Ingenieur Hospitalier, [Données non publiées]",
+caa68bfb-d444-4787-945d-3ac999c4b5fb,[Données non publiées],PAYPERWEAR,COMMERCIALE,
+caa9e0bd-bba7-4879-ac9e-a45e0eb56d04,[Données non publiées],NEANT,NEANT,N EXERCE PAS D'ACTIVITE
+caab1e4d-979e-4fbb-89b6-32d31157a349,[Données non publiées],néant,néant,[Données non publiées]
+caae1e66-e55f-4f00-9bd5-96484a688433,[Données non publiées],Retraitée,Retraitée,
+cab2a71a-93bd-43fd-878b-435a6bde9077,[Données non publiées],pharmacie [Données non publiées],préparatrice en pharmacie,[Données non publiées]
+cab3291f-a1b6-4727-bf2e-41d3378b758f,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+cab35c26-be89-4b6a-82fe-a029817d331d,[Données non publiées],Education Nationale,Professeur des écoles hors classe,[Données non publiées]
+cab6c9df-2c2d-4f50-b23a-4b23cfe0c032,[Données non publiées],Ministère de la santé et Ministère de l'enseignement supérieur et de la recherche,Docteur [Données non publiées] [Données non publiées] au CHU [Données non publiées],
+cab95714-8e62-4a0a-8a26-8a1c8d10ce87,[Données non publiées],Société Béguet,Soudeur,
+caba60fd-79b9-426c-9fca-5e3c187fbdc4,[Données non publiées],Ministère de l'éducation nationale,Directrice d'école maternelle et formatrice,
+cac6bbb2-7231-4fa7-a4f8-fd3d7fcb22d2,[Données non publiées],MAIRIE [Données non publiées],Agent administratif,[Données non publiées]
+cad19ffa-e6af-4d99-9544-a0827b412e4b,[Données non publiées],[Données non publiées],MENUISERIE,
+cad19ffa-e6af-4d99-9544-a0827b412e4b,[Données non publiées],[Données non publiées],MENUISERIE ALU,
+cad2307b-14ad-4f28-aaa4-a049fc488a34,[Données non publiées],MICRO ENTREPRISE,COIFFURE A DOMICILE,[Données non publiées]
+cad754f6-55e5-482c-b1b7-8684f608f21b,[Données non publiées],LE ROUGE,Responsable [Données non publiées],
+caeb7b9b-c241-48a0-8b8e-7e50da2c85bb,[Données non publiées],retraitée,retraitée,
+cafa33ec-2660-4d25-8cda-a5662c33d182,[Données non publiées],Ville d'Aix-les-Bains,[Données non publiées],[Données non publiées]
+cb0de3b2-35cf-44e0-8ed2-ed6f6c8b4d38,[Données non publiées],AUCUNE ACTIVITE,AUCUNE ACTIVITE,
+cb0fe852-71f6-4648-a7bb-4de5ddb574b0,[Données non publiées],travailleur indépendant,Docteur en medecine,
+cb1879c7-46c8-4425-8216-4cb94026c7e5,[Données non publiées],[Données non publiées],infirmière coordinatrice [Données non publiées],
+cb1bbfc1-1874-4a12-8364-f60363aaf026,[Données non publiées],Groupama Méditerranée,[Données non publiées],[Données non publiées] retraite depuis le 1/09/2020
+cb224b3f-685b-44b0-ba60-4728ad2e05d7,[Données non publiées],ASTBTP,Secrétaire Médicale,
+cb2465cc-f6f0-4cf7-83fd-430c36e17c5f,[Données non publiées],Education Nationale,Professeur des Ecoles,
+cb27b58e-5903-4112-ad29-44ab095d6938,[Données non publiées],USOL,[Données non publiées],
+cb2e8a7d-328c-41dd-9b10-dd3f382e01ff,[Données non publiées],Chambre de Métiers et de l'Artisanat de région Centre Val de Loire,Responsable [Données non publiées],
+cb320648-b177-41df-88d5-0a8116357b1c,[Données non publiées],PIMAN CONSULTANTS,Directrice Générale Adjointe et Associée de PIMAN CONSULTANTS,
+cb36383d-dda4-43d8-9142-1b8be0c4bb9e,[Données non publiées],CCAS ville de Boulogne sur mer,responsable du service [Données non publiées],
+cb4153fc-18e0-4a92-b984-bc8039a36969,[Données non publiées],néant,retraité [Données non publiées],
+cb535424-d5f0-4636-8c14-90c890e89539,[Données non publiées],SELARL [Données non publiées],secrétaire,
+cb5a1b7a-cd62-4ed8-8a2a-6490aef49521,[Données non publiées],Groupama Méditerranée,[Données non publiées],[Données non publiées] retraite [Données non publiées]
+cb6baaae-1fab-4e8e-980a-81a0aa0c5538,[Données non publiées],Mairie de Troyes,Chargé [Données non publiées],
+cb6cd106-6b8b-408e-b638-525de6c14c80,[Données non publiées],Crédit Agricole [Données non publiées],Chargé de clientèle agricole [Données non publiées] [Données non publiées] [Données non publiées],
+cb6cd106-6b8b-408e-b638-525de6c14c80,[Données non publiées],SCEA [Données non publiées],Gérant de cette exploitation agricole [Données non publiées],
+cb767624-0c05-488a-8f5c-dd1fbfbf64b0,[Données non publiées],SARL GEOFIMO,[Données non publiées],
+cb7b6b79-eb50-4603-af86-1dd4490dca6e,[Données non publiées],association [Données non publiées],Infirmière,
+cb7cee69-4020-49c5-8bbd-dc2311a633c6,[Données non publiées],societe [Données non publiées],commerce,[Données non publiées]
+cb80f221-65f8-4306-a2ac-bf2b08360b95,[Données non publiées],Groupe Thivolle,[Données non publiées],[Données non publiées]
+cb84a500-0df2-4c69-aac8-75405c1c5bf1,[Données non publiées],aucun,aucune,Aucune rémunération
+cb852600-7cc4-4410-a7f4-07552ae7eefe,[Données non publiées],Retraitée,Retraitée,
+cb8bf9e1-e4a7-4d7c-806d-cfa423e16c99,[Données non publiées],DAMAE medical,Ingénieur [Données non publiées],
+cb8c90dd-a0ae-4ce3-8461-32599def0f48,[Données non publiées],[Données non publiées],Pharmacien [Données non publiées] officine de Cherveux,
+cb8cd82d-a3b3-4a0a-bd5e-7b3a27724ff9,[Données non publiées],[Données non publiées],Gérant majoritaire (non salarié) de la société [Données non publiées] Bureau d'Étude en Thermique du bâtiment.,
+cba6fab4-07d9-4d68-aa2a-ab5a19c9e8e2,[Données non publiées],SNCFConseil,Présidente,
+cba83878-c4dc-473f-9c4f-a8b172297b9b,[Données non publiées],Pharmacie [Données non publiées] à Le Mée sur Seine,pharmacien,
+cba91a0e-0258-4050-9c27-4f000a660e21,[Données non publiées],SARL [Données non publiées],DIRECTRICE,
+cbaff4da-867c-47e6-bddf-d064b063e4b8,[Données non publiées],Education nationale,[Données non publiées] accompagnant d'élève en situation de handicap [Données non publiées],
+cbb87a18-b904-4fae-9685-fa0acb2d4f91,[Données non publiées],[Données non publiées],Préparatrice en pharmacie,
+cbb8bc7c-7755-49cb-b9f5-addf323d094a,[Données non publiées],néant,néant,
+cbb90d87-2c41-4c70-a376-c277946233f1,[Données non publiées],pharmacien,pharmacie,
+cbc89184-185a-40fa-be9d-c6e183810e3d,[Données non publiées],RETRAITE,RETRAITÉE DE L'AGRICULTURE,[Données non publiées]
+cbd2f2ab-6c10-4f9d-a1b0-dcfca69676df,[Données non publiées],Alisée,conseiller énergie,
+cbe3e424-f4f1-4a12-9022-968cdd094e1b,[Données non publiées],Retraitée,Retraitée Education Nationale,
+cbf8a2e8-abbc-49b6-a2e3-0dbe6e72955f,[Données non publiées],RETRAITEE,NEANT,
+cbfb84a0-2600-490f-a083-903148d48b0e,[Données non publiées],RETRAITE,RETRAITE,
+cc0ac653-dac8-44d0-a8c1-2d55187c0a04,[Données non publiées],Région Nouvelle-Aquitaine,Chargé de mission,
+cc172391-4be1-4137-9e18-90c9c5c462b1,[Données non publiées],néant,retraité,
+cc1850d7-18a9-42dd-9c8b-cdc9a5356525,[Données non publiées],Néant,Néant,
+cc2093b6-5479-4f3f-9bdc-1987cf53fa7c,[Données non publiées],Education Nationale,Enseignant d'Histoire Géographie et Sciences Politique. [Données non publiées],
+cc2af8dd-448b-441b-b87e-5376db6b8fd8,[Données non publiées],avocat,avocat,
+cc2d1e57-7fa4-4e14-889f-cb18797a6584,[Données non publiées],Concept multimedia,[Données non publiées],
+cc3900aa-1b3e-43ef-965c-557763ae8ac5,[Données non publiées],sans emploi,[Données non publiées],[Données non publiées]
+cc3a3e9b-8478-43b3-9f72-4f3e1fd35846,[Données non publiées],La Poste,[Données non publiées],[Données non publiées]
+cc3c145a-dc18-4c87-b51f-c5c0c6e39c64,[Données non publiées],General Electric,[Données non publiées],
+cc50907b-5b6a-41fa-8e0e-008cd100cbd5,[Données non publiées],CREDIT MUTUEL,DIRECTRICE D AGENCE BANCAIRE,
+cc7462f6-45c8-4681-8155-6a3f2d5c0c18,[Données non publiées],Centre Hospitalier des Pyrénées,Aide Médicale en Psychologie,
+cc797cbe-b7ea-499d-b4d7-78e5c32433df,[Données non publiées],SAFIGEC,juriste [Données non publiées],
+cc83e245-3717-4bf7-a441-97e5269a78e0,[Données non publiées],Centre Psychothérapique de l'Orne,Assistante Sociale [Données non publiées],
+cc880d3c-33af-4df0-9271-fd4bb482a085,[Données non publiées],MINISTERE DES ARMEES,FONCTIONNAIRE (SECRETAIRE ADMINISTRATIF),
+cc8b1364-e318-49b3-bab2-4dc8cb579990,[Données non publiées],NEANT,NEANT,[Données non publiées]
+cc9c4b43-e415-46b3-a4cd-9bf52f7d2a71,[Données non publiées],SA SYRINXPAN [Données non publiées] et Association E.T.A.I.,Chargé de formation (SYRINXPAN) et Agent commercial Technico Commercial (ETAI),
+cca21802-4180-4e73-934c-a75734348c93,[Données non publiées],Université Lille 3,Maître de conférence en Sociologie,
+ccacf9de-1cc8-40df-a87b-3b4a41c454db,[Données non publiées],[Données non publiées],Économiste de la construction,
+ccb6d516-9bb1-4c94-b5d5-ae19c51c94c5,[Données non publiées],Préfecture [Données non publiées],Chargé de mission [Données non publiées],
+ccbbe015-e353-44d2-abd9-065489122c13,[Données non publiées],EDUCATION NATIONALE,PERSONNEL DE DIRECTION,
+ccc1a2d2-6ee6-4af3-b208-82762d67e81a,[Données non publiées],Activité libérale,Diététicienne,
+ccc5c707-403b-478c-b29c-fe7eac830d48,[Données non publiées],[Données non publiées],Gérante,
+ccc5c707-403b-478c-b29c-fe7eac830d48,[Données non publiées],[Données non publiées],Gérante,
+ccc5c707-403b-478c-b29c-fe7eac830d48,[Données non publiées],[Données non publiées],Gérante,
+ccc5c707-403b-478c-b29c-fe7eac830d48,[Données non publiées],[Données non publiées],Gérante,
+ccc5c707-403b-478c-b29c-fe7eac830d48,[Données non publiées],[Données non publiées],Gérante,
+ccc5c707-403b-478c-b29c-fe7eac830d48,[Données non publiées],[Données non publiées],Gérante,
+ccc5c707-403b-478c-b29c-fe7eac830d48,[Données non publiées],[Données non publiées],Gérante,
+ccc5c707-403b-478c-b29c-fe7eac830d48,[Données non publiées],[Données non publiées],Gérante,
+ccc5c707-403b-478c-b29c-fe7eac830d48,[Données non publiées],[Données non publiées],Co-gérante,
+ccca286a-2168-4d5d-ab8c-f381423795e2,[Données non publiées],Entreprise GABARE,Cadre,
+ccdb5e58-ac27-47f5-b9fe-3758bec79157,[Données non publiées],VILLE DE MONTPELLIER,ATTACHE FONCTION PUBLIQUE,
+cce9b75a-8b0d-43f7-93d7-c8cacf85f65a,[Données non publiées],Éducation Nationale,Professeur des écoles,
+cceb08ce-3393-4a40-b9a9-a921e297f387,[Données non publiées],néant,néant,
+cd04ea7c-d53f-4458-80b8-90e9218a1f1a,[Données non publiées],Mairie de Cannes,dgs,
+cd12b5d2-d828-4904-b4a9-c92d687118e2,[Données non publiées],retraité,[Données non publiées],
+cd23c847-f25c-4260-b649-05e260d00e83,[Données non publiées],Gérante de l'EURL [Données non publiées],Architecte [Données non publiées],
+cd29b222-30d0-4dd8-ab10-3266806df6c7,[Données non publiées],Néant,Néant,
+cd3875ee-e42a-479c-bab8-2407fdcc0591,[Données non publiées],FERTÉ PARE BRISE,[Données non publiées],
+cd39da80-bc3e-45b9-8db5-14293a800c87,[Données non publiées],Entrepreneur individuel.,prestations culturelles et associatives,[Données non publiées]
+cd3e96e0-4dc6-49c1-a958-225dbfb3ac3d,[Données non publiées],ABL EMPLOI,cabinet de recrutement,
+cd4a88f9-befd-47c5-bc56-332c9a8a83a2,[Données non publiées],Alliance Healthcare,Chargé de mission [Données non publiées],[Données non publiées]
+cd5832d7-8e01-4379-88fe-28a71770dc0d,[Données non publiées],commune de ydes,[Données non publiées],
+cd665bb8-d96c-4c68-ad08-e0321e57c252,[Données non publiées],ADEME,Directeur adjoint,
+cd69ad5e-8b1e-4b12-a9fb-533db7f9205a,[Données non publiées],[Données non publiées],[Données non publiées],retraitée [Données non publiées]
+cd7070c7-82bc-406e-a99b-e6c6410f6bac,[Données non publiées],Education nationale,Directrice départementale [Données non publiées],
+cd761eec-c384-4dad-9da1-e0d3847e035a,[Données non publiées],Enseignement privé de la Drôme,Enseignante,
+cd7cd273-146f-424a-9a94-60254449bf20,[Données non publiées],SAS financière de l'achigan,Adjoint administratif,
+cd89116e-022d-4542-b53f-27f1364c9194,[Données non publiées],EURL LE CYPRES,Co-gérante,
+cd94d8a4-5f9b-4628-bbe5-b6c97bbf8ef3,[Données non publiées],NES FRANCE,[Données non publiées],
+cda9934e-234e-4eed-8cd1-1825c5e26603,[Données non publiées],DANONE,Cell manager [Données non publiées],
+cdca4ee5-ed01-4748-8194-b926ba2201a1,[Données non publiées],activité exercée à titre libéral sous la forme d'une société de fait,kinésithérapeute,
+cde5c207-bb9f-45ad-b69d-dd7b2bab955d,[Données non publiées],[Données non publiées],Responsable administrative Gère l'administratif et les RH Statut cadre,
+cde8bb4e-7710-4e8e-965c-5a1237a90b43,[Données non publiées],[Données non publiées] SAS,Présidente bureau d'études économie de la construction,[Données non publiées]
+cdeb66dd-de03-410c-bfcf-a8d5696205ca,[Données non publiées],Educationnationale,professeure,
+cdf1f302-2c3a-4dfe-9958-65d8dd53534f,[Données non publiées],Nouvelle Région Aquitaine,[Données non publiées],
+cdf6b170-d5fc-4341-aa68-4b7a02d98c87,[Données non publiées],cci,cci,
+cdfb823f-03a1-4b28-aef7-89188bec69ca,[Données non publiées],Tout en Vélo Grenoble,Dirigeant,
+ce006469-4bc7-4964-933a-e4e238a89838,[Données non publiées],Ministère de la Justice,Fonctionnaire d'Etat de catégorie C,
+ce00cb62-1ea2-4f36-a6ff-584b98c18f90,[Données non publiées],[Données non publiées],CHIRURGIEN ORTHOPEDISTE,[Données non publiées]
+ce06ef24-304c-49e5-9ed6-e29101d30903,[Données non publiées],[Données non publiées],veterinaire,
+ce1fec33-10d3-4213-8f44-aa1ea1c7f7a5,[Données non publiées],Procter et Gamble,infirmière en santé au travail,[Données non publiées] [Données non publiées]
+ce26a416-f6c6-44bc-bcd1-e1945107480d,[Données non publiées],TDL Ingenierie,[Données non publiées],
+ce391c2c-8878-4bb2-99e0-ab149778db12,[Données non publiées],Naval Group,Directeur de programme,
+ce3a0f2a-74c7-455d-87bf-eeb5fb90a224,[Données non publiées],Groupement Hospitalier [Données non publiées],Assistant de direction,
+ce3bac93-3c87-43b7-b576-442b0bf78f20,[Données non publiées],AGRI-INDUS SAS,Directeur Général,
+ce3c7c51-19bd-4863-a774-339a1c8a6c81,[Données non publiées],Groupe France Télévision,journaliste,
+ce4d7d91-1234-4d8c-9c1c-501169ccd519,[Données non publiées],0,RETRAITEE,
+ce513d71-58cf-46f9-87b7-b129243aeb24,[Données non publiées],SOGARIS,[Données non publiées],[Données non publiées]
+ce513d71-58cf-46f9-87b7-b129243aeb24,[Données non publiées],Société Sogaris (SEM Ville de Paris),[Données non publiées],
+ce559bf1-8ac7-4148-8552-f810b40e2c3c,[Données non publiées],Ministère de la Défense,Militaire de carrière,
+ce656be1-e210-4599-94d0-8cb3c411536b,[Données non publiées],Education nationale,enseignant,
+ce665ad4-c350-4154-855a-2ac961d5f768,[Données non publiées],Fond de la Recherche Scientifique belge,Chargée de recherche,
+ce690c6a-0349-441d-abb9-9319d0ee7cd1,[Données non publiées],Conseil départemental du Cantal,[Données non publiées],[Données non publiées]
+ce8257e5-3406-4018-9faf-80421bddfea8,[Données non publiées],Auto entrepreneuse,Traductrice Psychothérapeute,[Données non publiées]
+ce8d18ed-c57e-4620-beae-8d9d4c29990e,[Données non publiées],Néant,Néant,
+ce8ffce1-b7eb-4682-8d2d-343835b3020c,[Données non publiées],néant,néant,[Données non publiées]
+ce90f66c-10c9-4777-9257-ee0714ae07d1,[Données non publiées],caisse d'épargne,responsable sécurité,
+ce9235bb-87b8-4812-a389-bd76b1cd3de8,[Données non publiées],[Données non publiées],co-gerante,
+cea11470-6999-4564-bbb0-5bd96a5ae927,[Données non publiées],GE,Secrétaire commerciale,
+cea1a274-e468-44bf-a295-0dd0869862f4,[Données non publiées],Education Nationale,Professeur de physique chimie,
+cea4c1db-8b02-4211-8d75-46e285ac0ffc,[Données non publiées],Clinique [Données non publiées],Gouvernante,
+cea80c8e-575b-4fd9-a64f-4ae79dbded5e,[Données non publiées],IET,[Données non publiées],
+ceb7669d-5c95-4021-a9fc-4d0219f4f3ba,[Données non publiées],Editions 2031,secrétaire d'édition,
+cec46e04-a83c-437d-bf2f-a4306ada267f,[Données non publiées],Retraité de la fonction publique NC,Néant,
+cecb4af9-577c-4ab1-8e00-f2201865dab9,[Données non publiées],[Données non publiées] [Données non publiées],[Données non publiées] [Données non publiées],
+cecb4af9-577c-4ab1-8e00-f2201865dab9,[Données non publiées],Libérale,Activité d'avocate libérale en droit de la fonction publique [Données non publiées],
+ced5ab72-78b1-4fa2-8243-990e5b526372,[Données non publiées],ETAT,ENSEIGNANTE,
+cedbc300-a075-432b-bd13-f40a65311402,[Données non publiées],VISITATIO VOISINS ET SOINS,référent association soins palliatifs,
+cede0e43-7195-443e-9471-790f1a9504c8,[Données non publiées],Education Nationale,Chargé de mission au Rectorat Départ à la retraite [Données non publiées],
+cedf7ac1-4549-41c7-aad5-098c4bfcb052,[Données non publiées],Ville de Paris,[Données non publiées],
+cee043a5-ccb2-4302-843e-7a23bd601a00,[Données non publiées],Nexans Power Accessories France,Product Line Manager [Données non publiées],
+cee6be84-6785-4b17-ac14-8982a926f7f4,[Données non publiées],MAIRIE [Données non publiées],Agent administratif,[Données non publiées]
+cef858f7-04e8-4c37-bf71-7431e8689de8,[Données non publiées],Google,Membre de l équipe des affaires publiques chez Google France.,
+cf05a995-9837-447c-b22f-97647400fe6a,[Données non publiées],Artisan,Coiffeuse,
+cf0bc4c1-03fa-4b2d-a8ee-1140dabc902a,[Données non publiées],GSK,directeur [Données non publiées],
+cf0c9f66-1351-4bc3-be37-9cfc29a17a7d,[Données non publiées],Education nationale,Professeur [Données non publiées],[Données non publiées]
+cf1c2a27-a156-4d5b-84d1-e00130fb03a8,[Données non publiées],AS NORMANDIE,[Données non publiées],
+cf31a7ba-a0cf-434f-94b5-c2ce8d2a3b8f,[Données non publiées],GSK,directeur [Données non publiées],
+cf442235-4cba-48bd-9c8d-6cd3ae6349db,[Données non publiées],Retraitée,Néant,
+cf44f066-d2f9-4ebc-8604-538ea1e3982c,[Données non publiées],Education Nationale,Professeur des écoles - Conseillère pédagogique départementale,
+cf48284b-d056-4f80-b33e-647c2432e576,[Données non publiées],NANTES METROPOLE,agent,
+cf4be3cb-1772-452f-9bd1-df92ff598260,[Données non publiées],MTD Pure Water,Plombier [Données non publiées],[Données non publiées]
+cf5f5a29-27ae-423a-92ed-010841158949,[Données non publiées],Auroentrepreneur,Programmateur informatique,[Données non publiées]
+cf63ace9-05cb-4233-b6a6-a72b00a88ee5,[Données non publiées],Néant,Ecrivain et scénariste,
+cf81eb92-2463-4af3-9858-8c3b64a89c4f,[Données non publiées],CPAM,Responsable de Centre,
+cf888956-6fbf-4a71-babb-845c919d0ec0,[Données non publiées],Profession libérale,Masseur Kinésithérapeute,
+cf8991da-700d-406b-abf7-895363a809a0,[Données non publiées],EDUCATION NATIONALE,Enseignant,
+cf9364ef-7152-4c50-9de7-d6ef9e0d2b8f,[Données non publiées],SDTech Micro,Directrice de laboratoire,
+cf9b684b-e672-4f92-af28-c23b399b9cea,[Données non publiées],Co-Gérant SARL Holding MOUTON,Fabrication/Vente Alimentaire [Données non publiées],[Données non publiées]
+cfb209ef-a792-4ff2-a137-82c20dca59ec,[Données non publiées],EKIP'ELEVAGE [Données non publiées],Commercial,
+cfc0f1f4-9f61-4d7d-85b3-cf79a706b446,[Données non publiées],France Télévision/Autres média,Journaliste,[Données non publiées]
+cfc6ae40-88bc-4d38-ba4c-ee81762953ed,[Données non publiées],CDG69,Attaché principal,
+cfc88de0-c4d7-4be7-860f-e46f527e3303,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+cfc88de0-c4d7-4be7-860f-e46f527e3303,[Données non publiées],Stone Holding,[Données non publiées],embauche le 18 janvier 2021
+cfc88de0-c4d7-4be7-860f-e46f527e3303,[Données non publiées],Cabinet Hoche Avocats,[Données non publiées],depuis novembre 2021
+cfd8f183-1b89-422d-a8d9-cc33f39de7b6,[Données non publiées],Auto entrepreneur,Agent commercial mandataire en immobilier,
+cfe2306d-386f-407d-84ac-22344f198aeb,[Données non publiées],ASSOCIATION LE RULEAU,Aide Médico Psycologique en EHPAD [Données non publiées],
+cff17823-dc66-4968-9e58-aab850188b3f,[Données non publiées],Retraitée fonction publique,Néant,
+cffc83a8-d257-4cfe-bbc6-8752a72ca5a6,[Données non publiées],Neant,RetraitéeNéant,
+d003181d-f824-4be3-9329-50d241fbec5e,[Données non publiées],[Données non publiées] Conseil départemental de l’Orne,[Données non publiées],[Données non publiées]
+d003181d-f824-4be3-9329-50d241fbec5e,[Données non publiées],Région des Pays-de-la-loire,[Données non publiées],
+d008f752-f927-403e-8ae4-e2dde964de89,[Données non publiées],Néant,Néant,Retraitée
+d00b0a45-1b11-4ea2-afab-b416a277b884,[Données non publiées],Aéroport de Paris,Contrôleuse de gestion,[Données non publiées]
+d00c7dd9-d675-46bf-98f6-4aa3e018ffa5,[Données non publiées],Député,[Données non publiées],
+d015c329-0833-4a31-9b14-087e010724e6,[Données non publiées],L’assemblée de la Polynésie française,[Données non publiées] [Données non publiées],
+d01ac2f3-4193-4364-b95c-cb0c77d4f412,[Données non publiées],[Données non publiées],Correspondante de presse,[Données non publiées]
+d021afcd-6c08-4ad8-8f7f-08a9484e071f,[Données non publiées],Education Nationale,Directeur de Segpa,
+d03547aa-1ef9-4808-a4a1-7d25cbff9e23,[Données non publiées],Hôpital CHD,Ambulancière [Données non publiées],
+d0388635-7f61-4aed-97d9-b9069f3d6e82,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+d0388635-7f61-4aed-97d9-b9069f3d6e82,[Données non publiées],Association l'Oiseau Bleu,chef de service [Données non publiées],démarrage le 4/07/2022
+d04199fa-bc95-48b9-bf1f-ffb0ea7e0689,[Données non publiées],CCAS [Données non publiées],responsable du [Données non publiées],
+d04efe13-dcd0-4176-b154-4e2052d956da,[Données non publiées],CCI Imprimerie,[Données non publiées],
+d051fff8-1fe1-480b-9d95-1b64402c8acc,[Données non publiées],médecin RETRAITEE,[Données non publiées],
+d07205b6-1dd4-4ab3-bf69-6d5da1c30d9e,[Données non publiées],néant,néant,
+d0806512-a310-4ddf-81b1-6ff760731f67,[Données non publiées],[Données non publiées],ASSISTANTE LOCALE D'UN DÉPUTÉ EUROPÉEN,
+d08733f9-c588-4d95-83c4-a6a3cb05da82,[Données non publiées],EDUCATION NATIONALE,ENSEIGNEMENT,
+d08b08a0-509c-4c89-99bb-841660dabed5,[Données non publiées],SAFER [Données non publiées],Directrice generale,
+d08db142-9ae6-428e-87f9-fb008327e574,[Données non publiées],Education Nationale,Institutrice,
+d0a71a4f-25ff-49a6-adec-e8fda1c6b969,[Données non publiées],Néant,Néant,[Données non publiées]
+d0aad9f5-c04a-4d39-a370-0f8e2e6b5dc9,[Données non publiées],Crédit Agricole [Données non publiées],Directeur [Données non publiées],
+d0b3a081-da34-4305-9869-710bb355ab36,[Données non publiées],EPEFIP,[Données non publiées] Coordonnateur Général,
+d0c4a5bc-688e-45b6-a44d-901db9bcf6ef,[Données non publiées],NÉANT,NEANT,
+d0c72c94-933d-4698-868a-359fda060a63,[Données non publiées],CH [Données non publiées] + activité liberale,Chirurgien,PH temps partiel
+d0c9d12f-b47b-448e-bc33-29d6bc1176bf,[Données non publiées],Rectorat Aix-Marseille,Professeur de lycée,
+d0d67c3c-a2bc-443b-8419-3c783fc4c95a,[Données non publiées],[Données non publiées],[Données non publiées],
+d0d67c3c-a2bc-443b-8419-3c783fc4c95a,[Données non publiées],Mairie de Réotier,[Données non publiées],[Données non publiées]
+d0e06bbb-28d4-439f-8daf-5f643b1312b8,[Données non publiées],Education Nationale,Retraitée,néant
+d0e1a71d-1754-433a-9cb6-30d7055a04c1,[Données non publiées],AGRIAL,Cadre commercial agroalimentaire,
+d0e6cddc-255d-4601-b3a2-c27e5dcf1b9e,[Données non publiées],GERANT [Données non publiées],EXPLOITANT AGRICOLE,
+d0e86b54-aa31-413c-8159-73d4e66ee9c4,[Données non publiées],BIOMERIEUX,ingenieur [Données non publiées],
+d0eb3b41-2ebc-4fcd-aaed-85c7808b3bf1,[Données non publiées],néant,néant,
+d0f39523-a93a-4d58-b8e7-be3894a5ee4a,[Données non publiées],[Données non publiées],GÉRANTE DE SOCIÉTÉ GARAGE DE RÉPARATION AUTOMOBILE,
+d0f64991-2305-4174-9d6d-094a20f375d7,[Données non publiées],NEANT,néant,seulement élu local
+d1063587-a619-4c9a-ba25-d7a19c940db5,[Données non publiées],Le Revenu,journaliste,
+d107d970-96ea-423c-bfa0-583ee7b89cbb,[Données non publiées],REGION SUD - CABINET,Conseiller spécial,[Données non publiées]
+d109cba9-6683-4f24-91c4-c1b3d44f3c71,[Données non publiées],Centre Hospitalier de Dieppe,Technicienne de laboratoire,
+d10a898f-8cb5-4c93-b3af-56b5c36b10b4,[Données non publiées],Travailleur indépendant,Immobilier et commerce de détail (vêtements et décoration),
+d126fd53-88ee-487b-829f-3bc0e734ca68,[Données non publiées],Communauté de communes [Données non publiées],Responsable RH,
+d12acc06-3203-4008-b780-03ff4069c376,[Données non publiées],[Données non publiées],Assistante sociale,
+d131ee43-5fab-4f79-814a-bd9c96790523,[Données non publiées],la Caisse d'allocations Familiales,Charge [Données non publiées],
+d1332fb4-8b1b-4957-b7c9-2176c0da82dd,[Données non publiées],Ministère de l'Economie et des Finances,Agent de constatation des douanesFonctionnaire,
+d13aa616-0cec-439f-bf70-1ef0524a813e,[Données non publiées],SARL PHILMAR,Artisan Commerçant [Données non publiées],
+d13b4bfd-4eec-40b8-aaf4-ceb96eebf99a,[Données non publiées],assurance maladie,Assistante administrative,
+d13d8dfe-ced0-4d32-a4bb-3f2f7f3e9c1c,[Données non publiées],REGION SUD - CABINET,Conseiller spécial,[Données non publiées]
+d1448f29-09db-4cf4-8e43-7bd846d9734a,[Données non publiées],SA Massebeuf Textiles,Activité industrielle de production de fils,[Données non publiées]
+d14689d6-a8f1-4221-a330-57003dfb8bb2,[Données non publiées],Education Nationale,Professeur des écoles,
+d148b53e-90f3-4a8b-8032-a0f96f65cfb7,[Données non publiées],ASSOCIEE DE GAEC,AGRICULTRICE,
+d1649a9d-08ac-4224-96d3-23fcd4140eaa,[Données non publiées],[Données non publiées],Président,[Données non publiées] SAS [Données non publiées]
+d177f829-f028-472c-ae84-3f859ad89d2b,[Données non publiées],retraité,retraité [Données non publiées],[Données non publiées]
+d1877bc0-5308-4b53-bede-674dc5b58920,[Données non publiées],Artisan,Coiffure à domicile,
+d187a5af-9c75-46a2-b157-e7dc7d3a0eec,[Données non publiées],Finances publiques,Agent catégorie C,
+d188d464-1442-4b35-97c9-25b191074d3f,[Données non publiées],FlexThings,Responsable [Données non publiées],[Données non publiées]
+d1a0a881-136d-44f8-a042-e05e6f16f244,[Données non publiées],GHER,Psychologue,
+d1a63d73-c718-411f-8d5c-489fe426be1e,[Données non publiées],SAS [Données non publiées],Président,
+d1b4384d-29bf-41b0-b689-f852d5ee8eb4,[Données non publiées],DIRECTION DU CONTROLE FISCAL [Données non publiées],VERIFICATION DE SITUATION FISCALE PERSONNELLE,
+d1c98461-3ec1-4281-8ae4-55b789488bdc,[Données non publiées],STMicroelectronics Tours SAS,Ingénieur,
+d1c9dc6a-48f7-4e1c-800c-7046339f128b,[Données non publiées],Cabinet Kléber Avocats,Avocate,
+d1cd8188-eff2-406d-8808-0d39b6e98f19,[Données non publiées],Sénat,Assistant parlementaire,
+d1d39342-9f60-4dee-80bd-15600899092b,[Données non publiées],BCI,Guichettière,
+d1d86b33-7724-404f-9053-5f6e76d520a5,[Données non publiées],néant,[Données non publiées],"néant, en retraite"
+d1d8dc29-14d4-42b5-a951-9eeba5263a52,[Données non publiées],Ville de Paris,[Données non publiées],
+d1dd9f17-fb8e-48c9-9e14-837581247ab8,[Données non publiées],Mairie [Données non publiées],Assistante Administrative - [Données non publiées] [Données non publiées],[Données non publiées]
+d1f0448d-d177-491c-9b40-a6f651240124,[Données non publiées],IME,Employée de restauration,
+d1f3428f-3831-45e6-865d-14b4dd17f878,[Données non publiées],SONEPAR,Cadre commercial,
+d1f5e5a9-f47d-45e2-9ec0-fa47f3e3a80e,[Données non publiées],Gérant [Données non publiées],buraliste,
+d1fba6df-e7ce-4a58-8f18-583edf457107,[Données non publiées],ECURIES [Données non publiées],[Données non publiées],"Profession exercée: cavalier et moniteur d'équitation, formateur d'enseignants en equitation"
+d2093443-2ec8-4a89-a4fd-5a527fb47c63,[Données non publiées],Groupe hospitalier La Rochelle/Ré/ Aunis,Assistante médico administrative,
+d20ea841-6694-4e9c-bc35-3ecb41de75db,[Données non publiées],Conseil régional Nouvelle Aquitaine,Secrétaire Générale du pôle [Données non publiées],[Données non publiées]
+d21394b9-0467-4982-9395-aec1193ebc32,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] [Données non publiées] retraite [Données non publiées]
+d213e7ba-85dc-404a-9455-b85c0a8f819f,[Données non publiées],Clermont Auvergne Métropole,[Données non publiées],
+d21815be-8e16-493c-8721-f6b330e24052,[Données non publiées],VILLE [Données non publiées],REDACTRICE,
+d21f82f8-1b38-4aff-b848-ae293046522b,[Données non publiées],[Données non publiées],Auto-entrepreneur dans le domaine de l'évènementiel et de la culture.,
+d22398cd-97be-4344-940f-1de21f9c0c98,[Données non publiées],INFOCOM GROUP,Consultant [Données non publiées],
+d2396b0d-473f-4fc3-a90d-1cd18dd669b6,[Données non publiées],[Données non publiées],Assistante vétérinaire,
+d24e5ad6-5cc6-4fc4-ad5f-599e7dcaf5cb,[Données non publiées],cave cooperative [Données non publiées] [Données non publiées],Directeur,
+d256af26-6a4f-4820-ba5c-a7f6ad0e2dc7,[Données non publiées],Entreprise individuelle,Infographiste,
+d2669880-9be3-40f1-8053-d570b8604d4f,[Données non publiées],Fonction Publique Hopsitalière,Retraitée,
+d266f08b-80cb-4aff-888a-d28a9e187539,[Données non publiées],Conseil départemental de la Gironde,Cheffe de projet [Données non publiées],
+d26eb4fc-3be8-45a3-a78c-7ba399f0008a,[Données non publiées],fonctionnaire territorial CARF [Données non publiées],[Données non publiées],
+d2764614-0364-4117-9d1e-da80e5da6c97,[Données non publiées],Artisan,Artisan dans le batiment,
+d288e042-cc39-4bcf-8a17-744b6ac2062d,[Données non publiées],transmediale - art & digital culture,Assistent [Données non publiées],
+d292cbb0-5a50-45c5-8a15-0b288b2145f3,[Données non publiées],MSP [Données non publiées],Médecin Endocrinologue,
+d2be85c2-fcbe-4523-922a-b319ed57d6ec,[Données non publiées],ORPAN,Chargé de mission,
+d2bebd81-0615-4a63-be7c-3661f8457b0c,[Données non publiées],[Données non publiées],Ergonome/Psychologue du travail [Données non publiées],
+d2c1f7e0-ec31-4386-89f0-3acb984184e5,[Données non publiées],Cabinet dentaire [Données non publiées],Cabinet dentaire,Assistante dentaire
+d2c52f00-1f25-4096-899d-f25aea78e094,[Données non publiées],Banque de France,Juriste,
+d2cbdd74-8559-4bb3-a684-d2bbd8c69ab6,[Données non publiées],Retraité,Retraité,
+d2cd255d-845b-44f7-86dc-5872ef4e8c35,[Données non publiées],Néant,Retraitée,
+d2cf7fc7-caf0-4484-8434-2ce091f252e7,[Données non publiées],NEANT,Historien de l'architecture,[Données non publiées]
+d2ead43a-8cb4-42d5-8672-b99dfa0cd94e,[Données non publiées],[Données non publiées],[Données non publiées],
+d2ead43a-8cb4-42d5-8672-b99dfa0cd94e,[Données non publiées],SAS LE VAUBAN,Présidente de la société commerciale d'activités hôtelières et para-hôtelières.,
+d2ecb0e8-8120-4492-bd75-cf0315418e3e,[Données non publiées],RDG,GERANT DE SOCIETE AGENT D'USINES IMPRIMERIE ET EMBALLAGE,[Données non publiées]
+d2eeb1bc-9f3b-4eef-8081-a4f1a99c431f,[Données non publiées],[Données non publiées],Plomberie. [Données non publiées],
+d2fe5779-50d2-47e1-ac71-58cd157b39e8,[Données non publiées],SO SAVEURS,[Données non publiées],
+d308208c-5179-413f-8347-34c293ff48da,[Données non publiées],retraitée éducation nationale,Retraitée,[Données non publiées]
+d3109b10-759d-4d51-a86d-199cad5b04b3,[Données non publiées],conseil départemental de la Mayenne,[Données non publiées],
+d318d07d-2b69-4cea-8a33-a526952d0c76,[Données non publiées],UP,Commercial - employé,
+d31fb147-3469-45ce-88da-ad076e7914fc,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] retraitée [Données non publiées]
+d32054b8-1e50-49ea-898a-e53e2ad7fa98,[Données non publiées],Education Nationale,néant,[Données non publiées]
+d33642a2-a0d1-4525-af10-1d3e7fa90d39,[Données non publiées],ADMR [Données non publiées],assistante de vie,
+d35082c0-f9b6-4a3a-ad61-d3a8def0405e,[Données non publiées],SAS [Données non publiées],Restauration,Président de la SAS
+d357e1dc-6928-413a-a0ff-a51b1c63d1d5,[Données non publiées],Néant,Retraitée,
+d359a3f7-1fe2-4f02-91b1-95fa17b53052,[Données non publiées],DIRECTION DES FINANCES PUBLIQUES,AGENT DES IMPOTS,
+d36642c3-3f12-4969-99d1-c8c398330a79,[Données non publiées],Département Seine Maritime,Agent territorial,
+d36a5f7c-836b-4b02-a1bd-2dd8b3535f3f,[Données non publiées],INSA de [Données non publiées],"Professeur des universités, chercheur [Données non publiées]",
+d36f48ca-2240-4726-bd66-5c5a2d7ef8fc,[Données non publiées],MARTIN ASSOCIES,Avocate,
+d37bb11a-44ae-4df6-9fd5-27dd7eb7e9bf,[Données non publiées],EDUCATION NATIONALE,PROFESSEUR DES ECOLES,
+d384879b-1002-4244-be9b-c2f0da032d50,[Données non publiées],Néant,Retraitée de l'enseignement,
+d395926c-3b3c-46ed-9de0-ef67d7d76646,[Données non publiées],La Fabrique de patrimoines en Normandie,[Données non publiées],
+d39c06a4-6168-40cc-aaa2-c38a2fd7df05,[Données non publiées],France Télévision,Journaliste,
+d3a4bbe9-0a6e-41b0-a586-e1eacbb0dad1,[Données non publiées],Société EKNO,Directrice Conseil [Données non publiées],
+d3a5d669-8f22-4dd6-8b85-5d43e2040f2b,[Données non publiées],Conseil départemental Seine-St-Denis,collaborateur de groupe politique,
+d3b533d0-6c3c-49cd-8bdc-bc5860b1bbf4,[Données non publiées],Retraitée Renault,néant,
+d3c540d5-7f03-4256-ae7a-1b6e5bbd5f30,[Données non publiées],CREDIT MUTUEL,DIRECTRICE D AGENCE BANCAIRE,
+d3d35458-68ee-4312-bb5f-ae9cfb0e70cc,[Données non publiées],La Banque Postale,chargée de clientèle [Données non publiées],
+d3f7801d-92d6-4899-871e-bbda8501b9f4,[Données non publiées],Education natiuonale,Directrices d’un dispositif relais [Données non publiées],
+d417c687-8aad-4259-8bfb-c8b8100f2982,[Données non publiées],retraitée,Retraitée,
+d4305c42-bed8-4e04-97f2-6e4d62672ace,[Données non publiées],lui même,journaliste Président et directeur du journal Le petit mag Lens Liévin exploitant agricole [Données non publiées],[Données non publiées]
+d43246b1-565b-4599-99e9-fb3dcccb84d7,[Données non publiées],éducation nationale,directrice d'école maternelle,retraitée [Données non publiées]
+d435cfe4-0d1b-4fcd-9219-4ca9ddbfc185,[Données non publiées],Financière de [Données non publiées],Investisseur,
+d443912f-4cc2-46e5-843b-fa438dec3f7f,[Données non publiées],CONSEIL DEPTAL DES HAUTS DE SEINE,[Données non publiées],
+d4685e79-86df-4083-aedc-4963c3ce7e45,[Données non publiées],Néant,Membre du conseil de surveillance de UNIBAIL RODAMCO WESTFIELS Vice-présidente du conseil d'administration du groupe BANIJAY Membre du conseil d'administration de la SA GOODGROWER,
+d46a0ee0-a8ad-478d-98a3-e8b4c7578a20,[Données non publiées],L'Express,Journaliste,
+d46eb8ff-d0b2-4b7d-9a9c-766fcf7b2a38,[Données non publiées],Fouré Lagadec Rhone Alpes,Employé,
+d46fff01-f130-4d89-84db-3426a27eb7ad,[Données non publiées],Université de Lille,[Données non publiées],
+d477234f-8413-4c4b-8357-707742a26304,[Données non publiées],Université [Données non publiées],Professeur Agrégé,[Données non publiées]
+d47e370f-a78d-4d65-9997-c0e96b613ff4,[Données non publiées],auto-entreprise,"conseil, formation",
+d48b5faa-4902-4485-bbad-b0b1b1375a09,[Données non publiées],DAHER [Données non publiées],Technicien d'atelier,
+d49435d7-cb24-4c67-a542-f98ab6e2b2a1,[Données non publiées],EURL [Données non publiées],gérant majoritaire d'une société de lavages automobiles,
+d49435d7-cb24-4c67-a542-f98ab6e2b2a1,[Données non publiées],SASU NB IMMOBILIER,Conseiller en immobilier,
+d4a02767-155e-4b7b-b2fe-f7efcbe6d573,[Données non publiées],CDC CONCHES,Directrice [Données non publiées],
+d4a9269d-6480-4882-976b-b9204ecc9703,[Données non publiées],Néant,Conseils aux associations,Exerce en profession libérale
+d4ace08f-e868-4fbf-935b-8cbdbcb8eb08,[Données non publiées],[Données non publiées],Clerc de Notaire,
+d4b1d3ff-02d3-4b9f-88a5-9f7b8ecbbc82,[Données non publiées],Retraitée,Retraitée,
+d4b8ec8c-544c-41ba-a5f2-74bda4d9e4c0,[Données non publiées],L’assemblée de la Polynésie française,[Données non publiées] collaborateur [Données non publiées],[Données non publiées]
+d4b90360-466c-4527-9d63-f89a05d83784,[Données non publiées],[Données non publiées],Gerant,
+d4bdc97b-5e00-45b4-a8fe-85c32257b1bc,[Données non publiées],[Données non publiées],[Données non publiées],
+d4c01858-3db5-46d1-bce4-76c55f6890cb,[Données non publiées],Conseil départemental de Seine-Saint-Denis,Cadre de la fonction publique territoriale,
+d4c93a9d-a49c-4fd3-b86f-dd71f2e3eccd,[Données non publiées],Retraite,Retraité,[Données non publiées]
+d4cdeef3-ad48-4358-888a-971536d29253,[Données non publiées],Assemblée nationale,Collaboratrice parlementaire [Données non publiées],
+d4d3f95e-66f5-4e30-8402-dea19ea5810a,[Données non publiées],Néant,Néant,[Données non publiées]
+d4db4576-9280-44a3-8cf2-f26e29501150,[Données non publiées],Ville de Saint-Denis,Ingénieur sans activité. élu local depuis le 4 juillet 2020 (ville de Saint-Denis et EPT Plaine COmmune),[Données non publiées]
+d4dc764f-920f-4432-a9d0-4a99c184e721,[Données non publiées],NEANT,RETRAITÉ,
+d50574a5-b6f3-49fa-b2ce-945ada2ed279,[Données non publiées],Département de Loire Atlantique,[Données non publiées],
+d506e5b7-ce8b-449c-a9ac-6f9a351d0d55,[Données non publiées],[Données non publiées],Dirigeant de société,
+d508ac91-c2fc-4cc2-b345-51c87de20ce4,[Données non publiées],Ministère des armées,Cheffe de service [Données non publiées],
+d518603c-6f97-45fd-bbf3-82ed173e3832,[Données non publiées],Fédération Française de Randonnée 35,animatrice,
+d51be26b-dcf8-4208-9dfa-a780c1e6f6ab,[Données non publiées],Spie ICS,Ingénieur Télécom,
+d51cb637-6302-4dec-97bd-bf4f2c43df54,[Données non publiées],Province Sud,Collaboratrice du cabinet du président,
+d51d5dd4-6469-4c6b-a6b7-f6dc07c6b185,[Données non publiées],Banque LCL,assistante administrative,[Données non publiées]
+d520186c-f9ca-4d37-91bb-9683f0a88544,[Données non publiées],néant,retraitée,
+d5218a9b-97c4-44b9-8473-ba564acf63ab,[Données non publiées],Ministère de la Justice,Magistrat [Données non publiées],[Données non publiées]
+d52d0bc8-a389-4fff-9289-0e0993f3d375,[Données non publiées],Sylvain Carrière député de l'Hérault,Collaborateur parlementaire,De juillet 2022 à juin 2024
+d5304eed-6c1d-4c98-84c1-4924af27449c,[Données non publiées],[Données non publiées],Retraite,
+d5361878-e358-464e-8151-ade81394aba4,[Données non publiées],IGAM,Comptable en association d'expertise comptable,[Données non publiées]
+d5361878-e358-464e-8151-ade81394aba4,[Données non publiées],AURHOM,[Données non publiées],[Données non publiées]
+d53c04fa-779f-4cb6-acb6-c840d623a4da,[Données non publiées],[Données non publiées],CONJOINT COLLABORATEUR,[Données non publiées]
+d53dad73-4210-42a2-910f-0a0cc795e7e6,[Données non publiées],caisse primaire d'assurance maladie,Technicien prestation.,[Données non publiées]
+d53ffb2f-3558-4742-9870-1942a2d333e0,[Données non publiées],TNS,Commercante,
+d544c6d3-a358-4bdf-982b-28428a7a8cf8,[Données non publiées],Mairie de Lessay,[Données non publiées],
+d550781b-9e3f-4aaa-a568-78b8e8317d31,[Données non publiées],aucun,pas d'activité,
+d56da965-53ff-4671-b35b-8bb33c0e2eb3,[Données non publiées],AKZO NOBEL DECORATIVE PAINTS FRANCE,Responsable [Données non publiées],
+d577e6d6-4a25-4912-a59b-a10d5fbdf972,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+d577e6d6-4a25-4912-a59b-a10d5fbdf972,[Données non publiées],NEANT,NEANT,[Données non publiées] SASU de designer concepteur [Données non publiées]
+d57d7696-f68b-4f2e-9f1a-094ec54507ba,[Données non publiées],Assemblée nationale,Assistant parlementaire,
+d5844eb7-87af-4eaf-bc97-6dd4e31241d1,[Données non publiées],Ministère des Finances,Directeur centre informatique [Données non publiées],
+d58c5ce9-2606-49da-9d58-182064fc0eaa,[Données non publiées],Ville de FOSSES,Fonctionnaire [Données non publiées],
+d598860f-5517-4397-bf38-b914c143d9f6,[Données non publiées],retraitée,néant,
+d5bacd77-363d-4c2a-abff-06522d1c8c8d,[Données non publiées],Éducation nationale,Professeur des écoles,
+d5cae8d3-3839-44ef-a9b0-b696472424d6,[Données non publiées],NEANT,NEANT,
+d5e0c829-1fcf-430b-a47f-47f5e2967025,[Données non publiées],AUCUN,RETRAITEE,
+d5e46b2f-993f-4063-8383-80f2a90983a9,[Données non publiées],CENTRE HOSPITALIER [Données non publiées],TECHNICIENNE EN IMAGERIE MEDICALE,
+d5f88588-290e-4c76-a31f-c1c796185550,[Données non publiées],sarl [Données non publiées],artisan macon,
+d611c190-386e-4851-8e1a-579c88117401,[Données non publiées],[Données non publiées],Neurologue,
+d6162120-b073-4f2d-8bbf-9837d1b54a8a,[Données non publiées],DELPHARM,directeur [Données non publiées],[Données non publiées]
+d6193098-bc23-47c5-bc0b-6d956690b8dd,[Données non publiées],EARL [Données non publiées],Commerciale,
+d624ff12-5d6e-45d5-a19d-5fc150f54697,[Données non publiées],Néant,Néant,
+d62e8e43-d05a-4647-a34a-b33ee8ed7a65,[Données non publiées],NANTES METROPOLE,agent,
+d633ef70-1191-4719-bf03-a97d9a09afaa,[Données non publiées],néant,Retraitée,
+d63d27c6-51fe-40ee-9ea7-a15bea33c0f3,[Données non publiées],DSDEN de la Marne,Accompagnante d'élèves en situation de handicap (AESH),
+d6411d44-ece5-424e-9b3b-8654a4da9538,[Données non publiées],[Données non publiées],ANIMATEUR SOCIO CULTURELLE,
+d643a395-5be4-44e3-beba-c35833d0deec,[Données non publiées],cabinet dentraire [Données non publiées],Secrétaire médicale,[Données non publiées]
+d64aac7f-ece1-4735-a690-873bad43476e,[Données non publiées],BPALC,[Données non publiées],
+d64ff2b0-01f9-461c-b87b-f98d9a8b5ee3,[Données non publiées],Education Nationale,Enseignante,
+d65a4379-d87d-4224-8e02-70592f382fd8,[Données non publiées],[Données non publiées],[Données non publiées],Retraitée
+d65e133f-3b63-41d7-9ad6-222beb983a2a,[Données non publiées],[Données non publiées] [Données non publiées],[Données non publiées] [Données non publiées],[Données non publiées]
+d663f51a-37ab-4edf-9570-b7b66d1accc3,[Données non publiées],retraité,[Données non publiées],mandat parlementaire + conseiller régional
+d6687ffe-1fd0-4644-8e7e-1a3c0dcf174a,[Données non publiées],OGEC [Données non publiées],[Données non publiées],
+d6687ffe-1fd0-4644-8e7e-1a3c0dcf174a,[Données non publiées],OGEC [Données non publiées],[Données non publiées] [Données non publiées],
+d6777c17-c0cd-4d84-a7f2-3070f039f79a,[Données non publiées],SARL cabinet 2H,Gérant,[Données non publiées]
+d6809554-7fef-4205-b62d-703611a73ea9,[Données non publiées],Retraite Education Nationale,Retraite,
+d688cab2-f094-45ea-abb2-7e1dc60c6124,[Données non publiées],néant,néant,[Données non publiées]
+d68ebf5f-d63d-438d-9d34-154b3eff8484,[Données non publiées],Éducation nationale,Enseignant agrégé,
+d699c1f3-096d-48bb-8cce-9e15bf27c26c,[Données non publiées],Éducation Nationale,Professeur des Écoles,
+d6a14ce4-f788-460a-b114-a6fb4aadfa88,[Données non publiées],Mairie [Données non publiées],Employée communale,
+d6a26eff-d33b-4265-8794-4239964ec724,[Données non publiées],néant,néant,Retraitée de l'administration territoriale
+d6ad1dc1-8e29-4656-950a-0cee9dc783f1,[Données non publiées],Ministère de la cohésion sociale,DDCS [Données non publiées],[Données non publiées]
+d6b30988-172a-45a6-aceb-b909e9968264,[Données non publiées],exercee a titre individuel,auteur compositeur interprete,
+d6bdbbc1-2e0f-4b63-9ddb-a4210037dd97,[Données non publiées],néant,néant,
+d6c7c7dd-db31-4528-8c99-2f4065eb4ca1,[Données non publiées],EIPM,Business School,[Données non publiées]
+d6d07dd8-1afb-445a-b9c5-4c737bf64ef2,[Données non publiées],earl [Données non publiées],agriculture,[Données non publiées]
+d6d47517-18dd-443c-895d-223167e433c7,[Données non publiées],Pharmacie [Données non publiées],Pharmacienne,
+d6d76c7f-00b1-4f06-9ee8-320abd2ea6aa,[Données non publiées],commerçante,Esthéticienne,
+d6ebab78-f325-464d-8c72-37769f3b6168,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] En retraite [Données non publiées]
+d6f09f0e-5392-4f3f-8eb1-afb8559fd5c4,[Données non publiées],[Données non publiées],EXPLOITANTE AGRICOLE GESTIONNAIRE DE GITES RURAUX,
+d6fb9102-fd83-49c0-a9d7-eb4db2be61a2,[Données non publiées],CAPR,Commercial,
+d70eac61-267a-424f-bb70-49418fc46322,[Données non publiées],SELARL [Données non publiées],secrétaire,
+d70fd275-fdad-48db-b3d5-60165e21dbf1,[Données non publiées],GROUPEMENT D'EMPLOYEUR DE BELZAISES,Salarié,
+d717c0af-06fd-4b5a-89bd-8a91b5f021d5,[Données non publiées],STAG - Villers Bretonneux,Assistante administrative,
+d71c49e0-64a4-4210-9611-f44659e29802,[Données non publiées],Ministère de l'éducation nationale,Directrice d'école maternelle et formatrice,
+d722ea32-a646-4630-b7ad-c98541932e7e,[Données non publiées],education nationale,professeure certifiée de Français en Lycée,
+d72a20db-acf0-41e8-9a0d-8dda9cd96552,[Données non publiées],[Données non publiées],Gérant de la Sàrl [Données non publiées],
+d72b952a-d63f-4667-b261-1241d8690425,[Données non publiées],neant,en retraite,
+d73b183f-fde5-4486-86a4-8c1a64717535,[Données non publiées],SYADEN,CONSEILLER ENR,
+d73be342-b4c4-4d0e-82ff-b4019cb386a5,[Données non publiées],ARTISAN,Coiffure à domicile,[Données non publiées]
+d73be342-b4c4-4d0e-82ff-b4019cb386a5,[Données non publiées],ARTISAN,Location de meublé de tourisme non professionnel,[Données non publiées]
+d748361a-835e-4fd6-b4de-ea53145c944f,[Données non publiées],NEANT,NEANT,
+d756f908-2735-4239-ac09-074012f45bec,[Données non publiées],DREAL Auvergne-Rhône-Alpes,Technicien Supérieur [Données non publiées],
+d756f908-2735-4239-ac09-074012f45bec,[Données non publiées],[Données non publiées],réalisation d'évaluations et d'audits en tant qu'auto entrepreneur,
+d758cd16-0020-45fc-88c3-593e34495351,[Données non publiées],EARL,Exploitant Agricole,
+d761dfe9-ce99-492f-be8e-a1459f2a8eec,[Données non publiées],[Données non publiées],Entreprise de Travaux publics Gérant,
+d767d685-6497-4859-b6a1-46b496429c44,[Données non publiées],aucun,Retraitée,
+d767d685-6497-4859-b6a1-46b496429c44,[Données non publiées],néant,Retraitée,
+d771dbdd-bb73-4433-bf18-09ae4ec77efa,[Données non publiées],artisan,plombier,
+d785870c-1680-4891-b90f-d841576e3c95,[Données non publiées],Algoé [Données non publiées],Consultante [Données non publiées],
+d785eb88-6f69-45f4-80e9-bb3dc7e6d536,[Données non publiées],néant,néant,[Données non publiées]
+d794a1ab-af2c-4589-894b-6fa129c1ba76,[Données non publiées],MSP [Données non publiées],Médecin,
+d796ce6e-532c-4cff-951c-d3a4266509a6,[Données non publiées],Retraitée,Retraitée,
+d79a1096-df49-411c-ab29-9b07a82451ac,[Données non publiées],Jump,Directeur des Opérations,[Données non publiées]
+d79c5f61-6891-4923-a401-3c88a6c38d40,[Données non publiées],Avermes Distribution,Employée de Commerce,
+d7a247ab-63a6-496e-ab96-b7816634f7e9,[Données non publiées],ABACA,Activité de photographe professionnelle. [Données non publiées],
+d7a3a482-31e8-46ac-80af-ea032aa6d6d8,[Données non publiées],Association Villevieille,Chef du service [Données non publiées],
+d7aa374e-4620-43ac-9034-df728eadba43,[Données non publiées],[Données non publiées],gestion parc immobilier,
+d7ac4571-17a8-416c-b3c3-02ae61bfe382,[Données non publiées],[Données non publiées],Journaliste presse documentaire,[Données non publiées]
+d7affdbf-cb23-4a0b-a6bd-87308d03d823,[Données non publiées],SDIS DE LA GIRONDE,SAPEUR POMPIER,
+d7c0ac7f-582c-4b5d-8a9d-e220be814c8b,[Données non publiées],néant,néant,
+d7ca43a7-5df3-4cc8-b540-f330a5d0d740,[Données non publiées],Parlement européen,[Données non publiées],
+d7cd7489-1a92-421e-b8ff-999625f5e10f,[Données non publiées],Boulevard Voltaire,Journaliste,
+d7cdd5e1-586d-4d69-9a59-e79e14b5a92a,[Données non publiées],Micro entreprise,Réflexologie plantaire,
+d7d3794c-7441-4a0f-b046-d92be757b369,[Données non publiées],Liebherr Aerospace Toulouse,Ingénieur,
+d7d4e892-dbbe-4802-bf34-21e00e1ef325,[Données non publiées],[Données non publiées],Soins esthétiques,
+d7d8dcbe-3dec-4291-b63b-deebb443b66e,[Données non publiées],Pole Emploi,[Données non publiées] SIMPLIC,[Données non publiées]
+d7e19ded-5864-4356-9435-63787e18d4ed,[Données non publiées],Ministère de l'Education Nationale,Enseignant,
+d7eeb5b5-0f16-49dc-8e17-1c7728733628,[Données non publiées],retraitée [Données non publiées],[Données non publiées],sans activité professionnelle ni lien avec société ou association
+d7f72b66-ccee-4e7c-9022-8e893c40cb37,[Données non publiées],DEPARTEMENT [Données non publiées],ADJOINT TECHNIQUE,[Données non publiées]
+d7f72b66-ccee-4e7c-9022-8e893c40cb37,[Données non publiées],DIRECTION DES FINANCES PUBLIQUES,AGENT DES IMPOTS,[Données non publiées]
+d7f7ad33-b884-4607-94cf-a18d40a3db7d,[Données non publiées],Néant,Retraitée,
+d7f8fddf-ae40-40ed-bb5f-3b06ca9072bd,[Données non publiées],[Données non publiées],professeure des Universités en histoire contemporaine [Données non publiées],
+d82c6048-88b2-420a-9d78-0df384cc9a7d,[Données non publiées],Education nationale,Personnel de Direction,
+d83668e9-8a04-41f1-9ca3-99758b4aadec,[Données non publiées],SARL [Données non publiées],DIRECTRICE,
+d83882bf-f3e0-47af-825f-b04c52bfaf36,[Données non publiées],[Données non publiées],Directrice du Service des Transports,[Données non publiées]
+d83da245-6b26-4d6f-a654-ce5f3faabd6a,[Données non publiées],retraité,[Données non publiées],
+d842baf9-c0e0-4739-85f9-96580bdfa685,[Données non publiées],Retraitée,aucune activité professionnelle à son actif,
+d854798a-f98f-4c4c-9a37-eefe29b65541,[Données non publiées],[Données non publiées],Auto-entrepreneur dans le domaine de l'évènementiel et de la culture.,
+d8596ebc-6a26-46b8-992c-683dec643132,[Données non publiées],Ministère de l'Education,professeur,
+d85b4a2d-42bf-4020-822f-4b72ed3a5c33,[Données non publiées],Sans employeur,Retraitée,
+d8643e99-e92e-4ae1-a09a-dd86386a1208,[Données non publiées],General Electric,Technicien Qualité,
+d8648aa3-2e7c-4bfb-a713-0550790528eb,[Données non publiées],NEANT,[Données non publiées],
+d86545e4-c123-4c17-8a9b-436e2fd50f91,[Données non publiées],Commissariat à l'Energie Atomique,[Données non publiées],
+d874286e-c6a0-4c34-bacd-af2ca3ae32df,[Données non publiées],Agent de voyages et salariée agence d'assurances,[Données non publiées],
+d881d37b-ea79-46a2-b502-645f5bcbd461,[Données non publiées],Profession libérale,Expert-Comptable - [Données non publiées],
+d8832efa-93a9-4765-8cb2-d74417af925d,[Données non publiées],Néant,Retraité,
+d8849b58-e876-4893-b240-d9d94cf559b2,[Données non publiées],[Données non publiées],Professeur des écoles,
+d88bb84b-dd87-4bda-8b12-0c9e6cc158c2,[Données non publiées],retraitée,néant,
+d8914d1e-f1c9-458e-96e2-f7d0f101277d,[Données non publiées],Auto-entrepreneur,Editrice,
+d891bca2-d655-4d31-b286-1fd83adcb86a,[Données non publiées],Mairie de Montmorillon,[Données non publiées],
+d89d0c98-412e-4453-86bb-90451f4b8377,[Données non publiées],Retraité [Données non publiées],Précédemment Agriculteur exploitant,
+d89e8cb6-dd47-45f2-9d43-5076e2f07386,[Données non publiées],Direction Générale des Finances Publiques,[Données non publiées],
+d8a5f0bc-0a03-4b05-8827-6328f4c2e52e,[Données non publiées],Néant,Avocate,
+d8b198ab-d96b-47c2-a7e5-a037067f4e6e,[Données non publiées],CNRS,[Données non publiées],
+d8b220df-8829-4048-bb1d-1c974b5262ca,[Données non publiées],NSK,DIRECTEUR COMMERCIAL EUROPE,[Données non publiées]
+d8b6d976-6cb9-4234-9f63-7fd226eeba66,[Données non publiées],Bordeaux Métropole,[Données non publiées],
+d8b9bd16-2853-43ef-9d36-2c5b010dc12a,[Données non publiées],Centre Hospitalier [Données non publiées],Infirmière,[Données non publiées]
+d8ba3a9f-babb-4582-9efb-1737c11d08ad,[Données non publiées],[Données non publiées],bijouterie,
+d8ba498d-7e51-4f2c-a1f5-2c9a78e3386c,[Données non publiées],EDUCATION NATIONAL,PROFESSEUR DES ECOLE DANS LE 1ER DEGRES,[Données non publiées]
+d8bf203d-5be2-464c-a812-722a458ca501,[Données non publiées],Education Nationale,Professeur des écoles,
+d8c10d07-3eff-41f8-8857-2ca7bdd62721,[Données non publiées],Education nationale,professeure de lettres histoire,
+d8c8518e-3c67-4171-aac1-dc881a033307,[Données non publiées],CCIR pays de la loire,[Données non publiées] accueil,
+d8e03339-5deb-4a54-9edb-7de8b09579bb,[Données non publiées],REGION REUNION,Agent d'exploitation,
+d8e51410-28f2-4975-9a67-562c832e53f0,[Données non publiées],Education Nationale,Institutrice,
+d8e77dfc-7b82-420b-b8a8-e99212a041cf,[Données non publiées],Education natiuonale,Directrices d’un dispositif relais [Données non publiées],
+d8e86db8-6e00-4190-8d34-36906bdc2945,[Données non publiées],lui même,journaliste Président et directeur du journal Le petit mag Lens Liévin exploitant agricole [Données non publiées],[Données non publiées]
+d8e8cb7e-d067-4d72-ace7-3def79f0003e,[Données non publiées],ADMR [Données non publiées],assistante de vie,
+d8eea619-aaa2-4bbf-b8f9-61c8e02cefa8,[Données non publiées],Gérante de l'EURL [Données non publiées],Architecte [Données non publiées],
+d8f161b0-3b24-4207-9692-215133ed988d,[Données non publiées],retraitee,neant,
+d8fac56d-5036-4b5e-bc40-fc4bb5b478cb,[Données non publiées],[Données non publiées],NEANT,
+d902957d-5f84-44d4-8556-069ac47ba678,[Données non publiées],MICHELIN,INFORMATICIEN,
+d906d7e3-6314-491c-aab9-c80f55d2f47a,[Données non publiées],Retraitée,Retraitée,
+d90f2d34-5625-4fc9-a017-f4d8481467fa,[Données non publiées],retraité,néant,[Données non publiées]
+d90f3fb6-f6c4-4dad-a999-55580bf57ea7,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+d912a962-9145-4543-8702-c75f565f2352,[Données non publiées],Ville de Marseille,Retraité,
+d92778bf-6d5e-418d-9db8-c319e7810ccf,[Données non publiées],Association Compagnons Batisseurs Bretagne,[Données non publiées],
+d9317226-dd40-481f-ad30-971d6d1a1896,[Données non publiées],neant,neant,
+d934838c-0bb7-474a-977b-24676db7bc8d,[Données non publiées],Finaduc,[Données non publiées] Ressources Humaines,
+d93735b7-c7b8-4197-9f14-885ab367922f,[Données non publiées],Conseil départemental [Données non publiées],[Données non publiées],
+d94409cd-270e-4440-abf5-8ae5997e4c2f,[Données non publiées],NEANT,NEANT,
+d94670d9-8b50-409a-8c66-2217499145bf,[Données non publiées],Indépendant,Avocat,
+d9731066-8c90-42a9-9136-4809c04960b4,[Données non publiées],Travailleur Indépendant,Vente de Vêtements au détail pour femmes.,
+d976b9ee-7c9e-40d8-beb2-51aee7030b35,[Données non publiées],[Données non publiées],Exploitant agricole,
+d9810d51-6cb6-4aa2-a066-537298de0a7b,[Données non publiées],Ministère de l'éducation,Professeur des écoles,[Données non publiées]
+d9827c17-c60f-43d8-8a32-f70c24b9b5a6,[Données non publiées],MINISTERE EDUCATION NATIONALE,Professeur agrégé de classes préparatoires aux grandes écoles,
+d9960fdf-f46c-421f-bc32-651b5fb0c20f,[Données non publiées],CENTRE HOSPITALIER GENERAL AUCH,Auxiliaire de Puériculture,
+d99cfff9-1414-4531-9fb3-89c8a295dca5,[Données non publiées],communauté de communes de Gémozac,[Données non publiées],
+d9a6d4b4-6fc5-41d3-865a-df79fc7c9959,[Données non publiées],CourdesComptes,conseillèremaitre,
+d9b346a0-9df9-4aac-ae1a-7936b11a4180,[Données non publiées],SCP [Données non publiées] notaires associés,Notaire,
+d9b85d0e-33bf-4623-9818-87338d7cf27d,[Données non publiées],Indépendant,agent immobilier,
+d9beb724-ea7f-440b-9511-ee25860b7ff6,[Données non publiées],SNCF Voyageurs,Opérateur assistance,[Données non publiées]
+d9ca5237-1b9b-40f8-b7e0-932afb6512da,[Données non publiées],SAS HELI-MOTORS,[Données non publiées],
+d9cf2be4-1573-4f2e-a628-eb3affcf0b60,[Données non publiées],Ville de Paris,Directrice de cabinet adjointe,
+d9d12d84-182f-4beb-908b-39fe00a2f681,[Données non publiées],SAS La Canne à sucre,[Données non publiées],
+d9d1fbe2-aa37-47b2-a408-39355df862e3,[Données non publiées],CCI Occitanie,Chargée [Données non publiées],
+d9ea4d19-6dc9-4798-ab51-a1f56fd86da8,[Données non publiées],chambre de commerce et d'industrie de GUYANE,[Données non publiées],
+d9f2316a-1cac-437b-b48d-f46a2118920b,[Données non publiées],NEANT,NEANT,
+d9f2acb2-5e96-473d-83b1-3de2d482d52f,[Données non publiées],IDVERDE,Assistante de direction,
+d9f497ba-7a70-47fd-a139-1e2e350f1f74,[Données non publiées],Exercice en nom propre,Avocat,[Données non publiées]
+d9f50985-b8ff-4b52-becf-5d07c66237e8,[Données non publiées],RETRAITE,RETRAITÉE DE L'AGRICULTURE,[Données non publiées]
+da0841f4-8f55-46c0-a258-e654998a045e,[Données non publiées],KTM Advance,[Données non publiées],
+da0841f4-8f55-46c0-a258-e654998a045e,[Données non publiées],Holix,[Données non publiées],
+da0a73f8-555e-4fe2-ba1d-94871d541b0e,[Données non publiées],néant,néant,
+da0c5264-322a-4c49-94b0-c46bcd663923,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+da0c5264-322a-4c49-94b0-c46bcd663923,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+da0c5264-322a-4c49-94b0-c46bcd663923,[Données non publiées],Association pour La développement en Région du Cinéma ( ADRC),Présidente Bénévole,[Données non publiées]
+da16a28a-6175-4454-a7cc-12a3bbbfab4d,[Données non publiées],[Données non publiées],[Données non publiées],retraitee
+da17a2b8-92db-4ae3-af86-c309ceba97a1,[Données non publiées],Friedrichstadt Palast Berlin,[Données non publiées],
+da17a4a6-91af-417f-b888-b73b0749ff84,[Données non publiées],SARL [Données non publiées],[Données non publiées] Cheffe d'entreprise [Données non publiées] [Données non publiées] société de vente en ligne de graines d'arbres d'arbustes et de plantes.,
+da46f736-dd20-4838-aff7-14ae6f9e4eb1,[Données non publiées],CABINET [Données non publiées],ASSISTANTE DENTAIRE,
+da48bd9d-aa34-49f2-bb64-9a0eb218deff,[Données non publiées],Communauté de communes,auxilière petite enfance [Données non publiées],
+da5f2f59-1a80-4f9a-b5de-7bebf1440c61,[Données non publiées],NORCAN,[Données non publiées] [Données non publiées],[Données non publiées]
+da6825d1-efc7-4ec6-bae1-54a204ae004f,[Données non publiées],Hôpital Louis Pasteur 28000 Chartres,Infirmier en soins généraux [Données non publiées] [Données non publiées],
+da6c7f62-020f-4536-8530-3effc6cfe7dd,[Données non publiées],.,[Données non publiées],[Données non publiées]
+da71e58d-6185-4188-a4d3-878d7c3cae12,[Données non publiées],ARS Nouvelle - Aquitaine,Directeur de cabinet,
+da78f5a9-232f-4053-a2ee-ed174de582bc,[Données non publiées],lui même,journaliste Président et directeur du journal Le petit mag Lens Liévin exploitant agricole [Données non publiées],[Données non publiées]
+da7c1dfc-5f17-4cb2-81a7-c990e0bbd048,[Données non publiées],SODANG,[Données non publiées],
+da8ee627-ddae-42de-bef3-10fa119f40dc,[Données non publiées],Néant,Néant,Néant
+da98a8dd-572e-437d-8cad-ca1bad240eec,[Données non publiées],[Données non publiées],COMPTABLE ACTIVITÉ : Céréales du petit déjeuner en BIO,[Données non publiées]
+da9c853b-30e9-487e-980d-39cca34ef9b8,[Données non publiées],Retraitée,Retraitée Education Nationale,
+daa63e39-9e8a-4d95-9259-212f71111174,[Données non publiées],Cabinet [Données non publiées],Avocat,[Données non publiées]
+daaa36ab-e9da-4837-a6a1-a7bdec0d85e5,[Données non publiées],Visuel Centre,Formation en langue des signes,
+daaef402-5207-4ede-96e7-b3fe5b9aa3b4,[Données non publiées],Retraitée,Retraitée,[Données non publiées]
+dab38e73-5c36-4ba6-b09f-f1f08f3189dd,[Données non publiées],NEANT,NEANT,
+dac126e0-bbfa-456b-9423-aa0c892b7e81,[Données non publiées],CCGP,[Données non publiées] Conseiller en courtage de patrimoine,
+dac13ac1-d6de-412b-ae75-068cbb9291fb,[Données non publiées],Redimm,Conseil en immobilier,
+dacaa07e-b06b-4f0f-9f5c-faaeb4f8b765,[Données non publiées],CKS Public,Conseil en achat public,
+dacab653-6b42-41c3-8991-9d6d093f657f,[Données non publiées],Centre Hospitalier [Données non publiées],Infirmière DE,[Données non publiées]
+dadcdf1d-129c-47b7-81d6-418ce34a9753,[Données non publiées],Education nationale,Directrice d'école [Données non publiées],
+dadf856f-a596-4ea4-b245-db343a06b52b,[Données non publiées],Parlement européen,Député européen,
+dae7b7c6-8bd5-4f7d-9566-0e229b3f5fa7,[Données non publiées],BACCARAT SA,[Données non publiées],[Données non publiées]
+dae82dd2-b97a-4c60-a1ba-f6c8d14e35d2,[Données non publiées],GRETA 21,Conseiller en Formation Continue,
+dafd350d-3190-4425-8b4c-b54f922942f0,[Données non publiées],médecin,gynécologue,
+daff3ab7-55dc-46a1-a512-fd5cedfa0445,[Données non publiées],NES FRANCE,[Données non publiées],
+db034c08-8742-46ce-be57-5795454900d5,[Données non publiées],néant,retraité,
+db05b051-ff09-4973-844a-7a24fd4a9365,[Données non publiées],Hôpitaux Universitaires de Strasbourg,ergothérapeute,[Données non publiées]
+db0ee1f5-a19d-4f95-aa18-b42cb16f9b06,[Données non publiées],Education nationale (retraitée),Attachée d'administration [Données non publiées],
+db10b53a-13d7-49d0-81b0-4f0100576bdc,[Données non publiées],Conseil départemental,dirigeant de musée,
+db12a736-8ce6-4132-9d21-be2293a1f3c1,[Données non publiées],néant,néant,
+db1440ff-1049-4320-a94e-e53845f9055b,[Données non publiées],[Données non publiées],[Données non publiées],A la retraite [Données non publiées]
+db191ccf-b2b0-4f5d-af26-cb49dc73d232,[Données non publiées],MERICQ,RESPONSABLE ACHATS,
+db1a31f6-2f27-4eed-8d3d-944d9bc6c6d0,[Données non publiées],Mairie du Pontet,Agent Territorial,
+db245379-ac37-4951-abfc-c43592d47918,[Données non publiées],Néant,Néant,[Données non publiées]
+db2ae079-fffd-422a-8d57-dfb802c25863,[Données non publiées],Centre hospitalier [Données non publiées],Psychomotricienne,
+db3b322e-c6c1-479f-853c-2270a1178160,[Données non publiées],Conseil Départemental 31,"Ingénieur territorial, chargé de mission [Données non publiées]",[Données non publiées]
+db3d33cd-998e-4041-9bfd-6d6c10ea787a,[Données non publiées],Parfums DIOR [Données non publiées],Retraitee,
+db42028b-e30f-4116-87c6-9eaa1513d849,[Données non publiées],néant,Retraité,
+db469f7b-a420-4afd-873b-ad5603021a62,[Données non publiées],SARL MELAND,RESTAURANT MC DONALD RESTAURATION RAPIDE,[Données non publiées]
+db52c370-fc70-4f22-a51a-01a38e191792,[Données non publiées],AIR CORSICA,[Données non publiées] (Superviseur Vente b2c),
+db537658-621a-4ca9-b3ee-2c86f806fdd6,[Données non publiées],Ville de Nancy,[Données non publiées],
+db546e5f-aeb3-4519-b714-60c2ca5dcb92,[Données non publiées],MMA IARD,Responsable Conseils juridiques. [Données non publiées],
+db548d51-f861-4014-afb2-5a1731919481,[Données non publiées],LOCATOUMAT,Technico-commercial,
+db5638ab-816d-410f-98cc-06ed0c5f5e34,[Données non publiées],retraitée,retraitée,
+db59360a-8dd4-4957-848c-5bc74f125903,[Données non publiées],Département de Loire Atlantique,[Données non publiées],
+db68d182-771f-4443-9e62-71c05e1b71fd,[Données non publiées],[Données non publiées],Responsable d'une société d'Intérim,
+db6d7525-7aa8-4819-a00a-779fa2e2f098,[Données non publiées],Cabinet d'Avocat CADART,Conjointe collaboratrice non rémunérée,Madame n'exerce plus au sein du cabinet depuis décembre 2021 [Données non publiées]
+db7cd900-1984-41f2-82c3-c94035df0975,[Données non publiées],Assistante maternelle exerçant à titre individuel,Assistante maternelle,
+dba71a5f-ed13-49f3-b042-248d0193ca1a,[Données non publiées],DSDEN [Données non publiées],Assistante de service social mise à disposition à la [Données non publiées] en tant qu'experte médico-sociale,
+dbb13c2a-283a-4dbd-8af6-ac5fb3001c1a,[Données non publiées],Institut Vancauwenberghe [Données non publiées],Aide Soignante [Données non publiées],
+dbb1ad44-a3cc-4a38-935c-efe8aaa791f6,[Données non publiées],Viticulteur ( son propre employeur),Viticulteur,
+dbc2d6b4-f347-43c4-9b0b-e3c5db5145cb,[Données non publiées],SAS [Données non publiées],Président,
+dbc46dcc-49df-4066-b255-44650bfa36c7,[Données non publiées],néant,néant,Retraitée
+dbd09d36-289d-4e8b-b227-ffcf5f8a9f34,[Données non publiées],[Données non publiées],secrétaire medicale,
+dbd49ae4-426f-4587-b1c6-4752f111ccd6,[Données non publiées],Nouvelle-Caledonie,Fonctionnaire [Données non publiées],
+dbd79748-8a3f-4689-b59c-d9d241a7e610,[Données non publiées],Ville de Nice et Métropole NCA,[Données non publiées],[Données non publiées]
+dbed8774-a3ae-429c-a93e-0b3ea9f9ec99,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] ne travaille plus [Données non publiées]
+dbf2def4-10bf-4f2c-8706-87e1139ca026,[Données non publiées],Chef d'exploitation,Exploitant agricole EARL HERAUD [Données non publiées],[Données non publiées]
+dbf56f84-af63-4f9c-b839-ad1e5a4d0566,[Données non publiées],neant,neant,
+dc01940c-bd48-46e9-b7ed-08656a0bc3b0,[Données non publiées],NEANT,Retraité,
+dc1ad848-5d71-4a40-a71d-035d67a6883c,[Données non publiées],Lcée [Données non publiées],Comptable,
+dc1d5dc5-df36-48c1-bd48-ed538e6f900a,[Données non publiées],Maison de la culture d'Amiens,Directrice de production [Données non publiées],
+dc24be25-7c58-4fd0-9016-069da7780005,[Données non publiées],MARKESS BY EXAEGIS,Analyste [Données non publiées],
+dc259a7c-605a-449f-a034-d43f6c663cf8,[Données non publiées],néant,néant,Retraitée
+dc27fd31-7fde-40b1-85b1-b2cca8a6aa46,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] en retraite [Données non publiées]
+dc38defa-790a-4381-aedc-b5a758ffafd9,[Données non publiées],ADMR [Données non publiées],assistante de vie,
+dc422a45-f44d-47d1-8eaa-302f72125134,[Données non publiées],Assemblée Nationale,Assistante parlementaire,
+dc422a45-f44d-47d1-8eaa-302f72125134,,ASSEMBLEE NATIONALE,DEPUTE [Données non publiées],
+dc43fe6f-f2d8-4684-a19b-89a164d61ce9,[Données non publiées],neant,neant,
+dc48d4a9-41fc-48ce-b565-0e6d6f841437,[Données non publiées],Foncière de la tour,gérant,
+dc4a081c-7e4e-4b55-9d69-74b121b70052,[Données non publiées],Agence Limite,Directeur général délégué,
+dc4c1910-0293-43f6-a1e4-9795910de341,[Données non publiées],SPB,DRH,
+dc572ff7-5e28-4645-ab7f-6033a41c0d87,[Données non publiées],Education Nationale,Professeur des écoles,
+dc5b1a92-4ba9-4dd3-8a06-dd025f0102b7,[Données non publiées],DIVERS,MUSICIEN,
+dc61f049-4af3-4569-9a91-31ec13711744,[Données non publiées],Fédération Agirc-Arrco,[Données non publiées],
+dc6987a6-7d1e-4221-9e06-60294c2e78c4,[Données non publiées],[Données non publiées],[Données non publiées],
+dc6987a6-7d1e-4221-9e06-60294c2e78c4,[Données non publiées],Mairie de Réotier,[Données non publiées],[Données non publiées]
+dc863348-1873-4fb6-8f71-afbf4424fcde,[Données non publiées],inrae,[Données non publiées],
+dc868817-b681-4e1f-b16e-ded9088f32c6,[Données non publiées],Auto-entrepreneur,Conseil en communication et aux entreprises,
+dc8facec-a32b-4fdf-80df-68081ee48d94,[Données non publiées],AKZO NOBEL DECORATIVE PAINTS FRANCE,[Données non publiées],
+dc94e1c8-328d-423c-8bb7-21f2d58a7927,[Données non publiées],inertam,[Données non publiées],
+dcafc500-6e7c-463b-bb2d-bdd0ad1b6bf2,[Données non publiées],Néant,Néant,
+dcb168cc-6c22-4287-8e1d-30e6da37dda2,[Données non publiées],RATP,Chargé d'affaire [Données non publiées],
+dcb1b121-a3ec-4d4d-b4f5-537b202b1bdc,[Données non publiées],Intermittent du spectacle,Compositeur de Musique,
+dcb3ba75-5504-4ba8-8ce8-ba66c36f309c,[Données non publiées],Chef d'entreprise,[Données non publiées],
+dcb76f1e-70a4-40dd-adca-47e12fe6819d,[Données non publiées],EDF,Cadre de formation,
+dcbc202c-e87f-427c-a2b8-c97176532926,[Données non publiées],SELAS LPACGR,Avocat,
+dcbc5bb2-5d4e-49ba-a5ff-c37cd2093dab,[Données non publiées],/,Cours de voile charter convoyage.,[Données non publiées]
+dcbd6567-6b94-4e71-befd-dc38501bfca4,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] retraite [Données non publiées]
+dccba1f5-aa26-4d0f-8b88-73ca006928a6,[Données non publiées],SOGARIS,[Données non publiées],[Données non publiées]
+dccba1f5-aa26-4d0f-8b88-73ca006928a6,[Données non publiées],Société Sogaris (SEM Ville de Paris),[Données non publiées],
+dcdc86b8-8a1d-4fd9-828a-d81007bd44d8,[Données non publiées],[Données non publiées],INFIRMIERE LIBERALE,
+dcdd11ab-10f4-4cab-9c67-a37ba4f32b45,[Données non publiées],HSBC,Cadre bancaire,
+dce6cbc1-a012-4d17-b35d-3fd6a44b4408,[Données non publiées],retraité de la Fonction Publique,retraité,
+dcea7427-9c85-480a-abf3-5122f46e855e,[Données non publiées],Education Nationale,Assistante d'Education,
+dceb1b83-65ad-48c4-ad8f-941d3fc953ca,[Données non publiées],CENTRE HOSPITALIER [Données non publiées],AUXILIAIRE PERICULTRICE,
+dcfd59d5-d848-465b-9899-5f3e12dbc50f,[Données non publiées],Université de Rennes1,enseignant chercheur,
+dd0412b5-9a15-470d-aa2c-7b2bc4e56241,[Données non publiées],Intermittent du spectacle,Artiste de spectacle vivant (magicien)Comédien,
+dd047f4f-dfac-4e5c-89f5-78e4c4157063,[Données non publiées],MEDECIN,MEDECIN DU SPORT [Données non publiées],
+dd0be323-39c8-4f29-9945-760c06b7cd83,[Données non publiées],Education Nationale,Professeur des écoles,
+dd316dfc-1417-404b-b285-10149b4549dc,[Données non publiées],AET,Agent d'accompagnement dans une Association Intermédiaire,
+dd341f64-42a9-4922-996d-07db51b16b09,[Données non publiées],ville de Sainte Adresse,directeur général des services,
+dd37cb42-8679-4426-9f9b-e402f8f2e9a2,[Données non publiées],en retraite,néant,[Données non publiées]
+dd395bb5-8a43-4486-b975-976033c6e42a,[Données non publiées],néant,retraité,
+dd39a8b4-17ea-4972-b98b-7547198153a9,[Données non publiées],Néant,Néant,
+dd483c4d-24ae-4afe-8a60-e6d9315eda64,[Données non publiées],[Données non publiées],[Données non publiées],
+dd4d6275-dcf8-46ff-9ef4-89911a7a313a,[Données non publiées],COFIDIS,"CHEF D'EQUIPE, [Données non publiées]",
+dd514985-5f4c-4d28-897d-334673a58602,[Données non publiées],Communauté de commune Rhôny-Vistre-Vidourle,Agent territorial contractuel - [Données non publiées],
+dd514dea-c91c-4184-b108-e6371379502e,[Données non publiées],néant,retraité de la Société Taxis Cousin,"Au 27 août 2021, gérant de la SCI [Données non publiées] (terrains et bâtiments)"
+dd52b3d8-d474-48e2-a227-b8cfa2abe33f,[Données non publiées],Département de la Moselle,Employée administrative,
+dd5e938f-ca6f-465c-bbf0-e72825c68e22,[Données non publiées],Neant,Neant,
+dd611e66-e0d2-4f55-8049-764fc572df0b,[Données non publiées],EFINOR engineering [Données non publiées],Technicien d'études [Données non publiées],
+dd715137-87b8-46be-bc1b-d0eeb7d6ca13,[Données non publiées],"Domaine de fantaisie,maison de quartier des Eyquems",Association 1901 socio-culturelle [Données non publiées],
+dd81b8f0-307d-4bab-8f70-5a0292278bbc,[Données non publiées],SANS,AGRICULTEUR,
+dd8a0732-2b7f-4bff-bc7f-f3665b057b10,[Données non publiées],Atelier Mima,[Données non publiées],
+dd963796-fdd2-422a-906e-1740a4fdc094,[Données non publiées],SCP [Données non publiées],Notaire,
+ddadb26f-0099-4297-a747-2d2240d0950f,[Données non publiées],Lycée [Données non publiées],Enseignante,
+ddbb241a-d1f0-4e85-8d21-8b267bea1567,[Données non publiées],Retraitée,retraitée,
+ddd229d3-c546-4d27-b270-0e49e63733a9,[Données non publiées],gerant,artisan,
+ddd33c59-fc4e-4c02-9f15-9420e39ba5d0,[Données non publiées],SOGARIS,[Données non publiées],[Données non publiées]
+ddd33c59-fc4e-4c02-9f15-9420e39ba5d0,[Données non publiées],Société Sogaris (SEM Ville de Paris),[Données non publiées],
+ddd67c63-32c4-4b0d-9e97-10975dec7656,[Données non publiées],SARL ABIME,Chef Cuisinier [Données non publiées],
+dde02afa-1b9e-494f-9cd8-de9b7b17cc8b,[Données non publiées],[Données non publiées],GERANTE,
+dde31ed6-f200-456e-81bc-50def0d65eb2,[Données non publiées],[Données non publiées],Psychologue,
+ddf6ec5d-669f-4c20-818e-5f32a85fc39a,[Données non publiées],Conseil Départemental 31,"Ingénieur territorial, chargé de mission [Données non publiées]",[Données non publiées]
+de0a2aa7-df5a-45a8-a991-f0b85fb4fae7,[Données non publiées],Fonction Publique Hopsitalière,Retraitée,
+de0aa788-470c-4ae3-9cf2-4a4bdd8cd8af,[Données non publiées],Libérale,Orthoptiste,
+de0fab6c-f862-453f-86c0-d0713b4f0e8a,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+de0fab6c-f862-453f-86c0-d0713b4f0e8a,[Données non publiées],JNM Concept SASU,Bureau d'études économie de la construction,[Données non publiées]
+de11e532-e7b0-4b20-bfc1-8e428ff7639d,[Données non publiées],CONSEIL REGIONAL DE NORMANDIE,COLLABORATEUR DE GROUPE,
+de182f44-c6a4-481c-8287-b13341d604e9,[Données non publiées],neant,neant,[Données non publiées]
+de18d211-5482-4d2a-87de-090e4c18888c,[Données non publiées],mairie du plessis trevise,infirmiere puericultrice [Données non publiées],
+de1df024-fc30-4e98-9816-1bf444032e30,[Données non publiées],[Données non publiées],Société de conseil en communication et relations publiques,
+de288eec-ed42-4ec9-90d3-2de6293140c1,[Données non publiées],néant,néant,
+de28baf8-995c-4bf8-83a8-5e899d86f9db,[Données non publiées],profession libérale,Vétérinaire,
+de29350f-6dfb-4cd9-8941-0ff1e551e874,[Données non publiées],abbvie,Visiteuse médicale,[Données non publiées]
+de2e0763-9fa7-4c18-850b-1acab4c66a82,[Données non publiées],retraite,néant,
+de2fb438-a36e-431b-8f6f-4864e429df94,[Données non publiées],GAEC [Données non publiées],Exploitante agricole,
+de4dec1a-3825-4be8-a098-c0b544b3787f,[Données non publiées],ge,employée,
+de579eb8-6a2a-41e5-8010-261a6cb8b502,[Données non publiées],AKTO,[Données non publiées],[Données non publiées]
+de5f8cd7-7cd0-40f7-a2a8-79935de60a08,[Données non publiées],[Données non publiées],SALON DE COIFFURE,[Données non publiées]
+de644a01-d0b6-4679-9a3a-fd8cf22e4305,[Données non publiées],retraitée,néant,
+de6880dd-761a-4be8-84b6-ce527c614fde,[Données non publiées],EDUCATION NATIONALE,PRINCIPAL D'UN COLLEGE,
+de8d8aef-8c2d-4219-826f-39781b37e6eb,[Données non publiées],Co-Gérante SARL,"SARL Le Petit Quai [Données non publiées] Commercialisation au détail de vins, de bières, de boisons non alcoolisés, de produits d'épicerie fine frais ou secs et de plats cuisinés en bocaux.",
+de8f7063-2b3d-467c-a70a-9c3dc6a0cf84,[Données non publiées],Département du Lot,Agent d'exploitation des routes,[Données non publiées]
+de93be1e-35b8-453f-9078-d67a61270531,[Données non publiées],Conseil départemental de la Manche,Cadre Médicale Sociale,[Données non publiées]
+de949ea7-3116-4a86-9555-0c82a20620af,[Données non publiées],neant,neant,
+de997da6-3689-4251-9d10-41e33e7e5e92,[Données non publiées],neant,neant,[Données non publiées]
+dea5530a-5207-4377-aa6f-5203c5013d59,[Données non publiées],artisan,entreprise artisanale de maçonnerie,
+dea9fc87-abb6-4754-97bd-e8d514f2bc0f,[Données non publiées],vice rectorat,professeur,
+debda7ef-336b-47a2-8faa-fb21f146c214,[Données non publiées],Co-Gérant SARL Holding MOUTON,Fabrication/Vente Alimentaire [Données non publiées],[Données non publiées]
+debde961-832c-4ad4-a9e6-de917fa6673d,[Données non publiées],parti communiste français,[Données non publiées],
+dec3a4ba-17be-41e0-abfe-ac6021ab5f47,[Données non publiées],Cabinet de la Première ministre,Conseillère technique,
+dec62aa7-b6e5-4343-b8f6-dd7a166c447e,[Données non publiées],RETRAITEE,[Données non publiées],
+ded02f1f-4fce-424a-a5a7-3f85c5ae25c2,[Données non publiées],Artisan,Coiffeuse,
+deed9c05-e60d-41cd-b95b-ca8dba891eaa,[Données non publiées],CAISSE REGIONALE DU CREDIT AGRICOLE MUTUEL DE LA REUNION,[Données non publiées] [Données non publiées],
+deed9f9f-8bed-41b3-a739-fdbebcac45fa,[Données non publiées],Vice-Rectorat,Personnelle de cuisine,[Données non publiées]
+deee2f49-f9e3-4b6a-bd69-3bbbb8bca569,[Données non publiées],[Données non publiées],Infirmière en santé au travail,
+defaa357-20cc-4703-9c9a-d9dfd4c6ca59,[Données non publiées],[Données non publiées],Dirigeant de société,
+df09a7ae-3bee-48e9-a98f-bc890935a282,[Données non publiées],Indépendante,Journaliste,
+df0b0ef8-adcb-4e6f-a258-d39ffc20b58b,[Données non publiées],SYCTOM,Chargé de mission,
+df1a1373-f233-4cf1-8268-06d3e253bbf8,[Données non publiées],[Données non publiées],[Données non publiées],retraitée [Données non publiées]
+df1d73eb-22b6-429e-a67e-281d5f872544,[Données non publiées],néant,néant,[Données non publiées]
+df1f9b34-e87e-422a-a9b3-dc609ac46b18,[Données non publiées],Firmenich SA,Assurance qualité manager,[Données non publiées]
+df215964-102d-433e-8c74-1cd753138c0f,[Données non publiées],Education Nationale,Professeur d'Allemand,
+df21cc45-1819-441c-8292-705161aee142,[Données non publiées],DCC,Conseil en ressources humaines. [Données non publiées],
+df272ebc-ac5d-4986-999c-ef39cf7339cf,[Données non publiées],Néant,Néant,[Données non publiées]
+df2ca2e7-7305-430f-b35e-c462d69f86ce,[Données non publiées],Etat: DIR [Données non publiées],[Données non publiées],retraité [Données non publiées]
+df313688-6276-4313-a8db-24813e6f59d5,[Données non publiées],retraité,retraité,
+df409821-8005-4f3a-a188-4f31e2debfcc,[Données non publiées],Groupe CISN,[Données non publiées],[Données non publiées]
+df43cdcb-6e8a-4d13-9f41-b42a23055241,[Données non publiées],HCL,MEDECIN HOSPITALIER,
+df46acae-b7bf-4bf3-a6dc-c92ac624e686,[Données non publiées],Alisée,conseiller énergie,
+df4c32ff-3a32-48e8-b189-1f41eb07448e,[Données non publiées],[Données non publiées],Exploitant agricole,[Données non publiées]
+df4f6829-17ad-4376-be49-16703a44451f,[Données non publiées],artisan peintre,auto entrepreneur,
+df522255-684c-40d2-b661-93eb86221dbd,[Données non publiées],Département du Puy-de-dôme,Conseillère juridique,
+df5a4bb1-8745-401a-91bc-2a0a85ccbcff,[Données non publiées],NANTES METROPOLE,agent,
+df5f31c7-2c77-4610-9944-c2e96ed11ec3,[Données non publiées],Education Nationale,Gestionnaire Comptable du Lycée [Données non publiées],[Données non publiées]
+df60370c-e520-4426-8ac4-c2fdeea60f9f,[Données non publiées],Education Nationale,Enseignante,
+df76aa10-ddae-4234-9ce7-2a49295b35dd,[Données non publiées],auto-entrepreneur,Conseil en marketingFormation,
+df7b2872-e07f-4361-9a3c-1ead1625a4d5,[Données non publiées],BACCARAT SA,[Données non publiées],[Données non publiées]
+df80dcf0-bfca-4969-8e4e-b74d916c0343,[Données non publiées],mairie Loire-Authion,Directrice de cabinet,
+df91bfb7-0c5c-43ac-80c4-779ca77550c5,[Données non publiées],CENTRE DE GESTION 22,ADJOINT TERRITORIAL [Données non publiées],
+df932c55-8a44-444e-addf-e26314253403,[Données non publiées],Néant,Médecin retraité,
+df998ba8-d9c3-4170-b58b-175776aee93a,[Données non publiées],Conseil départemental du Cantal,[Données non publiées],[Données non publiées]
+df9fce5d-1785-4580-aec0-e7d0400ad83e,[Données non publiées],SCC,Ingénieur commercial,
+dfa17b06-f0a2-4b09-9f36-28248f214701,[Données non publiées],[Données non publiées],Conseil en Gestion de Patrimoine [Données non publiées],
+dfa8c38c-7c66-430e-a64f-4b333f65b38b,[Données non publiées],[Données non publiées],Technicienne de Laboratoire,[Données non publiées] [Données non publiées]
+dfc2f33b-2716-470e-8cfd-79344b5f758a,[Données non publiées],EPCI DIJON METROPOLE,[Données non publiées],
+dfc37a49-8bbf-4ec3-9e06-885c99a772df,[Données non publiées],[Données non publiées],[Données non publiées],RETRAITEE
+dfc4d1db-d15c-44d4-9164-5545b50536aa,[Données non publiées],Département du Puy-de-dôme,Conseillère juridique,
+dfc72ca3-b5d5-4f3b-b69a-6249a0d65f31,[Données non publiées],ENEDIS,Responsable d'équipe,
+dfce1ca9-bdad-4f42-802f-7bb388ad21f4,[Données non publiées],[Données non publiées],Consultante,
+dfd20497-af68-43ef-a58a-bae591878575,[Données non publiées],mairie de saint paul cap de joux,secretaire,
+dfd52f65-a7c5-4db8-a2fa-4ca3fbff0a38,[Données non publiées],Laboratoire Defrance - Maison de Santé du Pays Neufchâtelois - [Données non publiées],Secrétaire Médicale [Données non publiées],
+dfd541df-9615-4705-b286-a015ae7643e2,[Données non publiées],Hôpitaux Universitaires de Strasbourg,ergothérapeute,[Données non publiées]
+dfd74c9f-d09a-4326-9c29-6e12c2a64196,[Données non publiées],Ministère de l'Intérieur,Préfet de département,
+dff54010-ef79-4924-8129-339dd52440ea,[Données non publiées],ADAPEI [Données non publiées],Infirmière,
+dff9d0e9-19f6-47fe-95f5-041da676c27b,[Données non publiées],GBH,ELECTRICIEN,[Données non publiées]
+e001c10d-c65f-4855-a727-1c78eda940da,[Données non publiées],MANPOWER,Mission d'intérim en tant qu'agent administratif [Données non publiées],
+e01e6ca1-9092-43fd-a7ab-82a97b9c59b8,[Données non publiées],SARL TRANSPORT DELMOULY GENINATTI,CHAUFFEUR ROUTIER,
+e01e910f-f22e-4e9e-a325-8fd47ec457ef,[Données non publiées],Education nationale,Enseignant Bac Pro et BTS Pro,
+e025d0e8-fca9-4a5f-bfac-580595c66779,[Données non publiées],Bat' expert,gérant de la Société de bureau d'études dans le bâtiment,
+e0262196-d2d3-4736-a90a-e85ff345939a,[Données non publiées],AIES,directrice adjointe d'ESAT,
+e026b784-6854-42aa-b42b-1aa4344b1876,[Données non publiées],Parlement européen,[Données non publiées],[Données non publiées]
+e02d46b5-2abe-4abd-8721-bae04caaac07,[Données non publiées],néant,néant,
+e02e2d1f-89cd-458b-b2d7-424bfe671519,[Données non publiées],Neant,Neant,
+e02f1f6c-ccae-47c6-b74d-c39e36eccc4e,[Données non publiées],BPIFRANCE FINANCEMENT,[Données non publiées],
+e030f127-8997-4bf0-ab40-cb8cba614191,[Données non publiées],Retraite Education Nationale,Retraite,
+e038e0e6-abb7-4ac3-aa54-c235ab567eb0,[Données non publiées],Nespresso France,"Cadre commercial, responsable de secteur [Données non publiées] pour les établissements de débits de boissons, hôteliers et de restauration.",
+e03accc3-eb0c-4acb-9c2e-41b64cb8e077,[Données non publiées],RETRAITEE,retraitée,
+e04eec38-39ca-4145-925a-8dae505dac53,[Données non publiées],Orchestre Génération / association on tour,Intermittent du spectacle,
+e0560322-50f6-4e7e-b0e4-69bc30488c56,[Données non publiées],conseil départemental de La Réunion,[Données non publiées],[Données non publiées]
+e0560d4e-933b-4388-bf53-88604abb6fb6,[Données non publiées],Education nationale,Enseignante,
+e0565a47-5660-4c97-b554-9293a363692f,[Données non publiées],BIOROCK,COMMERCIAL,
+e061e470-4980-4058-b47f-d39a3ba04952,[Données non publiées],SOCOTEC,Assistante Commerciale [Données non publiées],
+e076fe65-beaa-43e6-aca7-62c6988687af,[Données non publiées],EDF,Chef de quart,
+e07bbe7b-157b-4aa9-97f8-016f233f83ea,[Données non publiées],DGAC,Ingénieur [Données non publiées],
+e08a937c-3b6f-487a-92df-b83e0596702b,[Données non publiées],sas [Données non publiées],Travaux administratifs et participation aux travaux d'élevage,
+e091f67f-14a7-42f2-99f6-c0469f1c77b3,[Données non publiées],Education Nationale,institutrice Maternelle [Données non publiées],[Données non publiées]
+e091f67f-14a7-42f2-99f6-c0469f1c77b3,[Données non publiées],Education nationale,Professeur des écoles,[Données non publiées]
+e0929f13-2222-4790-990c-66ba6e3d0f88,[Données non publiées],Néant,Néant,
+e0a8e9c7-b45c-4fda-928a-18413eeaffe7,[Données non publiées],néant,néant,
+e0ad3238-fc26-4179-90cf-16ee12c9669e,[Données non publiées],Centre Hospitalier de Cayenne,Directrice; de [Données non publiées],
+e0b4b200-8e79-4868-bfbc-58706293e566,[Données non publiées],STP,MEDECIN DU TRAVAIL,Retraitée [Données non publiées]
+e0bb1594-c84c-492e-b179-afe39d2f8425,[Données non publiées],Education nationale,Directrice [Données non publiées] de l'Université [Données non publiées],[Données non publiées]
+e0ce10ee-e72a-46e1-ad04-60cad3679661,[Données non publiées],INSEE,[Données non publiées],
+e0e61f41-2477-4384-a271-d0104cb8176c,[Données non publiées],collège [Données non publiées],animatrice pastorale,
+e0f8b416-39ae-4fa1-b382-c1461c7d7217,[Données non publiées],Education nationale,Professeur certifié de physique et chimie,
+e110c8f7-0235-4ddc-a116-2ec087551b78,[Données non publiées],Néant,Pédicure-podologue en activité libérale,
+e1138dc2-792e-4622-9a5b-63e5ea003cfe,[Données non publiées],[Données non publiées],AVOCAT,
+e11c8fad-c5e2-4d48-a056-957ba08176bb,[Données non publiées],ARTISAN,Coiffure à domicile,[Données non publiées]
+e11c8fad-c5e2-4d48-a056-957ba08176bb,[Données non publiées],ARTISAN,Location de meublé de tourisme non professionnel,[Données non publiées]
+e125c248-12d6-44d8-ba24-ff5df58e8d37,[Données non publiées],PHARMACIE DES COMBRAILLES,[Données non publiées],[Données non publiées]
+e12c1dd1-87df-463b-998c-0c0f92250b6f,[Données non publiées],Education nationale,Fonctionnaire d'étatProfesseur d'anglais,
+e1324f5c-2880-4466-8466-4f154856ed71,[Données non publiées],NEANT,retraiitée,
+e137225e-85f9-4abc-bd72-bda5eb6ac0af,[Données non publiées],Néant,Néant,Néant
+e137a47d-b31b-44a5-9a3d-b5af3db1d226,[Données non publiées],[Données non publiées],Coiffeuse à domicile.,
+e13c4b5d-66a1-488d-8521-2754649db7c5,[Données non publiées],Rio Tinto (Royaume Uni),Président Exécutif - Aluminium,[Données non publiées]
+e13c4b5d-66a1-488d-8521-2754649db7c5,[Données non publiées],JPCR Conseil SAS,Gérant,[Données non publiées]
+e13c4b5d-66a1-488d-8521-2754649db7c5,[Données non publiées],John Cockerill (Belgique),Administrateur,[Données non publiées]
+e13cad48-5899-48c0-a772-0e7395edee14,[Données non publiées],Retraité,Retraité,
+e143ab3f-f7eb-4508-bc87-3c2ad4bf17e9,[Données non publiées],EURA ENERGIE,Responsable de communication,
+e143ab3f-f7eb-4508-bc87-3c2ad4bf17e9,[Données non publiées],[Données non publiées],[Données non publiées],
+e1469eef-70d7-4acd-806e-bb8d7ffa6b00,[Données non publiées],centre hospitalier Agen-Nérac,médecin psychiatre,
+e14de8f9-043a-4d9b-bdea-5f6c57efba6f,[Données non publiées],[Données non publiées],[Données non publiées],retraité
+e152604e-61f7-49ba-912a-06e8cb385ce5,[Données non publiées],Travailleur indépendant,[Données non publiées] (réseau immobilier). [Données non publiées],
+e1709d0b-d4b7-4032-959c-5071650fc1ae,[Données non publiées],LIBERAL,MEDECIN GENERALISTE,
+e177394a-c92b-4333-81de-336b031c0a4d,[Données non publiées],NEANT,NEANT,RETRAITE
+e188f370-522d-4afd-980c-246a3f169685,[Données non publiées],mairie de Bégard,[Données non publiées],
+e18b4a80-550a-448e-a014-baca96dbe43b,[Données non publiées],CENTRE HOSPITALIER DE MAYOTTE,ASH,
+e18fee5a-444c-4812-b6d1-f902159eaca6,[Données non publiées],Mairie d'Aulnay-sous-Bois,Fonctionnaire territorial,
+e19e4939-5422-482b-9d59-6e6c0b152a28,[Données non publiées],collège des Ormeaux Le Havre,[Données non publiées],
+e1a141c5-d6df-4577-b6c3-91c3d491a840,[Données non publiées],Education Nationale,enseignant,
+e1a6c86a-2457-447c-802b-68abeeb5db11,[Données non publiées],Pôle Emploi Nouvelle Aquitaine,Conseillère à l'emploi,[Données non publiées]
+e1ac5e05-12e6-4430-8dc6-f294ea757eaf,[Données non publiées],néant,retraité,
+e1b098e8-8dfd-4bcd-b906-06bb36c49256,[Données non publiées],EDUCATION NATIONALE,Enseignant,
+e1b9ffd7-6639-4810-b0f8-3cc096e26e9b,[Données non publiées],Thales LAS,[Données non publiées],[Données non publiées]
+e1c10d46-7195-43d5-b205-2419bd09c3e3,[Données non publiées],sans emploi,[Données non publiées],
+e1d274c6-c4c4-41d1-ba12-fededc373e8f,[Données non publiées],indépendant,Producteur,
+e1d535b8-885f-4750-a1ee-0604ffcc9da8,[Données non publiées],[Données non publiées],Releveur de compteurs,
+e1d63161-5162-4b7c-9019-d88849379731,[Données non publiées],Néant,Néant,[Données non publiées]
+e1e07394-b939-4105-85e6-8d821c31422c,[Données non publiées],Groupement Hospitalier [Données non publiées],Assistant de direction,
+e1e28fa4-c2d2-408e-93d3-65504773a1d6,[Données non publiées],FRANCEMET,Assistante commerciale,[Données non publiées]
+e1ead87e-1099-496b-a894-207d509fbe73,[Données non publiées],CMA [Données non publiées],Formatrice,
+e1ec9bc9-8c90-4d5b-8510-f1cb79c6a9df,[Données non publiées],CHU de Pointe à pitre,Adjoint administratif [Données non publiées],
+e1efec96-dd69-496a-9083-e69fe1c4b114,[Données non publiées],Education nationale,enseignant,
+e1f178f4-32ba-4461-bf00-a9c222f64dc9,[Données non publiées],PAYET Johnny Bernard,[Données non publiées],
+e1f2519b-30bd-42ed-9ea9-ba77cf1261d8,[Données non publiées],NEANT,NEANT,
+e1f6642d-2ea3-4609-b929-4a7d1563e271,[Données non publiées],néant,néant,
+e1f8a832-1d40-4e34-a450-9bdfa971064e,[Données non publiées],néant,Retraité,
+e1fbb2c4-8bef-493c-bbed-51baf6ad8056,[Données non publiées],CH Genevieve de Gaulle Antonioz,SAGE FEMME [Données non publiées],
+e1ff7c5e-d5d7-48bf-9b0a-74bb507d3f5f,[Données non publiées],Caisse d'épargne,Employée bancaire,
+e2003cbc-90c0-4365-b0cc-0127afa4f249,[Données non publiées],CHU de Toulouse et Université de Toulouse,Praticienne hospitalière et maitresse de conférence des universités,[Données non publiées]
+e201a149-e059-46b8-881b-9e359f02ad8c,[Données non publiées],Conseil Départemental,Assistante direction,
+e202e4b2-e17f-49f7-b51f-d1c684ffb005,[Données non publiées],néant,retraitée agricole,
+e2057a84-8186-41db-b6b1-db07d40d9254,[Données non publiées],France Télévision,Journaliste,
+e20d9ab2-8f04-4335-97dc-73e9a832911e,[Données non publiées],Macocco Ouest,Assistante commerciale,
+e218e904-18f1-4b7a-a24b-117fff6daed2,[Données non publiées],SAFIM DEXIS,Commercial,
+e219ccc1-cd82-4ef1-b4e8-add874a156d1,[Données non publiées],Mairie de Oignies,Directrice de crèche,[Données non publiées]
+e21af4fb-01a6-406d-826c-737de2e30cc5,[Données non publiées],PROFESSION LIBERALE,AGENT GENERAL D'ASSURANCES,
+e22298d2-471c-44f4-99da-e1158b97e302,[Données non publiées],[Données non publiées],Location d'immeubles,[Données non publiées] Président [Données non publiées]
+e2374677-a77b-4edf-b762-2315b2faec82,[Données non publiées],retraité,néant,
+e2398ac0-776a-4d61-b987-82073ef56c60,[Données non publiées],[Données non publiées],Président de la SAS [Données non publiées] Statut de commerçant (bar à vin).,
+e23b720c-994c-4893-83bc-4146bc7061b5,[Données non publiées],UBS,Banquier d'affaires,
+e262de68-0123-4850-8591-fdbfc9a76377,[Données non publiées],Gérant de Formatext,[Données non publiées],
+e2643c89-9390-4a36-975a-5fc320205638,[Données non publiées],NEANT,NEANT,[Données non publiées]
+e26a754a-f31d-4548-9d2d-e0c38bfcc4df,[Données non publiées],Retraitée,retraitée,
+e26c3db5-56c9-4d07-8b05-9fd90e8da8e4,[Données non publiées],CPAM de l'Eure,[Données non publiées],
+e27860d8-369f-4f68-8f1e-15d798687f7c,[Données non publiées],RETRAITEE,FONCTIONNAIRE,[Données non publiées]
+e27c6230-1362-4b47-a030-b4edec0662cc,[Données non publiées],Home Ouest Immobilier,Agent immobilier [Données non publiées],
+e27cb8c0-7a8e-4d7e-afb6-88672ae454eb,[Données non publiées],retraitée,retraitée,
+e27d08d0-1c7f-4eec-9a88-4d445f8aa056,[Données non publiées],mairie de paris,adjoint administratif,
+e27ef2ab-62aa-4dc7-8b20-dcaa002d2436,[Données non publiées],Néant,Néant,
+e283a22d-9cc4-40be-8242-c9f366d933eb,[Données non publiées],snc [Données non publiées],gerante bar tabac,
+e28e1c94-7df6-4ab7-b1a3-381f99d94d35,[Données non publiées],Education Nationale,Professeur documentaliste,
+e28fd1d2-88d0-46ef-8b16-eb57e7bc0ddc,[Données non publiées],Etat,Retraitée professeur des écoles,
+e2ae7abc-34a2-48be-bb49-8afb0e83bcc4,[Données non publiées],CABINET [Données non publiées],ASSISTANTE DENTAIRE,
+e2afb945-4728-4071-b6da-658696b9e557,[Données non publiées],Cave POULET et Fils,Aide comptable,
+e2c321ca-5665-4706-a1b6-354278efd236,[Données non publiées],Néant,Néant,
+e2cc1468-05b7-45d2-9cd1-fca8a4ac5da1,[Données non publiées],Fonctionnaire territoriai,Agent Administratif [Données non publiées],
+e2d4bb49-2c54-4d50-9150-dd30ba1a5fcb,[Données non publiées],Pôle Emploi Nouvelle Aquitaine,Conseillère à l'emploi,[Données non publiées]
+e2d5b23e-eb14-4ac3-bd65-62c1032cf3ce,[Données non publiées],Auto-entrepreneur,Réflexologie plantaire,
+e2d5c3e3-418d-45cd-872d-8d7d72a3c02c,[Données non publiées],[Données non publiées],Infirmière,
+e2d8925b-0887-4fa0-98f3-521f2032f7c1,[Données non publiées],CENTRE HOSPITALIER [Données non publiées],AUXILIAIRE PERICULTRICE,
+e2d9022b-fd67-462c-84a8-dbce5d063005,[Données non publiées],[Données non publiées],agriculture,[Données non publiées]
+e2e979e2-7d45-4701-8155-037d033498ba,[Données non publiées],soins assistance,responsable d'équipe aide sociale,[Données non publiées]
+e2eeeab8-424f-44be-9dbd-c64b7f70b4ab,[Données non publiées],retraité,retraité,
+e3040ef1-99a3-4a75-8f89-06a5e4bc2e91,[Données non publiées],France Télévision,Journaliste,
+e3076a0a-b791-4111-98b6-06fd9c19a3b7,[Données non publiées],Association Reseau ViF(Violence intra familiale),Directrice,
+e30931d5-77d9-4e2a-8565-01afc67c4ee5,[Données non publiées],Mairie [Données non publiées],Secrétaire,Retraitée [Données non publiées]
+e31d1919-d2a0-4e8b-984b-a0f3df0a6008,[Données non publiées],NOM PROPRE,RESTAURATEUR,
+e3231773-072b-44ea-b131-606d83f31859,[Données non publiées],GL Events,[Données non publiées],
+e3272fa3-8712-47f7-a31e-4bba5ac921e8,[Données non publiées],Education Nationale,Gestionnaire Comptable [Données non publiées],[Données non publiées]
+e32c0dd9-c447-41db-9159-a600e79a300c,[Données non publiées],gerflor,coordinateur d'équipe,
+e333c61a-c14c-4722-aa13-8fad619d02f7,[Données non publiées],autoentrepreneur,psychologue,
+e33a8410-69ea-4566-9c26-38e32217d539,[Données non publiées],Associée - EURL,[Données non publiées],
+e33ef131-61e8-4922-adc0-d19347afa945,[Données non publiées],retraité,retraité,[Données non publiées]
+e3408640-960e-4c7d-8535-b45c13754f2a,[Données non publiées],CD14,Responsable de pôle,
+e34fc95e-ca07-4f93-8426-b794c25cbfc8,[Données non publiées],à son compte,Agent immobilier sous l'enseigne SAFTI,
+e351e6b9-0f66-4441-9733-ed252ab933d4,[Données non publiées],Néant,Néant,
+e3551cfe-ae51-4eb8-b494-6b89afc67a16,[Données non publiées],CPAM 93,Cadre de la fonction publique,
+e36289b0-1626-4d70-99f8-8292551180d1,[Données non publiées],Néant,Néant,[Données non publiées]
+e37057c3-68d8-4eca-95ee-48aa987ad8bc,[Données non publiées],CNAM,Directricedéléguée,
+e3736785-5808-41fc-8ad9-ec3e034a1ef8,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+e38ccdb7-c0a4-4953-9a09-0cf41e947edc,[Données non publiées],CHG [Données non publiées],Infirmiere,
+e394d052-5e44-4714-9a36-a4659bc9a085,[Données non publiées],MAIRIE CHEF BOUTONNE,DGS,
+e39a00a4-0cd6-42f5-8fb2-368dc5d6c2d3,[Données non publiées],Mairie de Paris,Sous Directrice [Données non publiées],
+e39ff2de-f88b-4f40-9f94-befea8274ca0,[Données non publiées],elle,viticultrice,
+e3a6372d-7eb1-4b97-84ae-6ff867c1ffd4,[Données non publiées],[Données non publiées],Aide opératoire,
+e3a78311-2c3f-4615-961f-8b9ea0e41dc5,[Données non publiées],[Données non publiées],néant,[Données non publiées]
+e3a81734-2c69-477e-8e54-10219d1e3617,[Données non publiées],RECTORAT ENSEIGNEMENT PRIVE MORBIHAN,PROFESSEUR,
+e3bb04d7-f69b-4208-9053-d6f73ee30fdd,[Données non publiées],la Caisse d'allocations Familiales,Charge [Données non publiées],
+e3c26343-4d32-420d-898d-f85e4d102355,[Données non publiées],Ministère de L'Europe et des Affaires Etrangères,[Données non publiées] Ambassadrice [Données non publiées],
+e3c4cf96-eea4-4d70-8033-14e69e68231a,[Données non publiées],Saint Pierre Chanel,Employé de restauration collective,
+e3c4f560-c342-4596-9f33-5fdee8f22795,[Données non publiées],SAS [Données non publiées],Transport de voyageurs et pompes funèbres,
+e3c60094-704b-46e9-98a8-4686dd370851,[Données non publiées],Veolia,Directrice de [Données non publiées],
+e3ca338a-0510-450c-b42d-eabeef681965,[Données non publiées],chu [Données non publiées],[Données non publiées] technicien superieur hospitalier [Données non publiées],
+e3cd0c69-bcb7-4a83-a21d-3853d80cd2fe,[Données non publiées],Education nationale,Enseignante,
+e3d4801a-664f-4710-aa44-eb81c11de893,[Données non publiées],Association des Métiers de l'Art et de la Culture (AMAC Touraine),[Données non publiées],
+e3e149d9-83d0-4c40-8ee2-800f4943f52b,[Données non publiées],[Données non publiées],Collaboratrice parlementaire,
+e3e45a9d-62fb-433b-abfc-2b8f1a48aba8,[Données non publiées],néant,néant,[Données non publiées]
+e3ecc3e3-aa23-4478-9926-6e140e6c9175,[Données non publiées],TILLY LOCATION,CHEF D'EQUIPE MECANICIEN,
+e3f2420b-fe9a-4ed8-afda-6633c8f95943,[Données non publiées],nom propre,Auto école,
+e3f768ad-adf1-4bff-8792-b89916437d5f,[Données non publiées],[Données non publiées],Masseur Kinésithérapeute DE,
+e400c56f-5892-466a-8421-960415a24371,[Données non publiées],Education Nationale,AVS - AESH,
+e4014efb-4e3b-435f-9c80-d668bacca79c,[Données non publiées],Retraitée,Retraitée,
+e40b9d7e-451f-4de5-8f48-46d793e6063d,[Données non publiées],neant,neant,
+e40da655-15bb-4728-8923-067de339be65,[Données non publiées],SARL [Données non publiées],gérant d'une entreprise de bâtiment,
+e40dfb12-a51a-4113-abd4-38c2f412b259,[Données non publiées],Néant,Néant,
+e4133d77-cb9b-4c58-8d27-464de5524b86,[Données non publiées],EDUCATION NATIONALE,Professeure des écoles,
+e4179023-02e2-4712-9a2d-cccf87c1f502,[Données non publiées],néant,[Données non publiées],[Données non publiées]
+e4186a10-7fff-4377-9133-a6e1f2143e46,[Données non publiées],Education Nationale,Professeur des écoles et Directrice d'école,
+e41d31b5-8056-4b44-8890-92ac1620917a,[Données non publiées],Conseil départemental [Données non publiées],Attachée territoriale [Données non publiées],
+e41d58b3-1048-404f-859e-56e62d068ba5,[Données non publiées],Maison de quartier [Données non publiées],Directrice adjointe,
+e41ddf47-62ef-48dc-a52c-dd13a066cc16,[Données non publiées],LIVCER,[Données non publiées] Expert de l'impression en continu pour l'industrie,
+e421d5cc-f6ce-481a-9751-a161b047ae13,[Données non publiées],RTCA Régie transport Cté Agglomération du Puy en Velay,[Données non publiées],
+e423896d-5b7c-4579-b319-0df1a54497e6,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+e423896d-5b7c-4579-b319-0df1a54497e6,[Données non publiées],NEANT,NEANT,[Données non publiées]
+e427e1f4-b588-4745-b40d-0f67be3ddf52,[Données non publiées],ARS Bretagne,Directeur-adjoint [Données non publiées],
+e42ea750-6829-4523-a7c0-7849cfcee1f4,[Données non publiées],PRO SERVICES,Technicien de stand,
+e430f96e-f03e-4ea4-ad7a-00f2c4e58daa,[Données non publiées],[Données non publiées],retraitée,[Données non publiées]
+e4352474-703f-4180-acbd-5956aaec7fe3,[Données non publiées],Néant,Néant,Retraité [Données non publiées]
+e43e40b3-c214-4436-894a-f3bdb9b8765d,[Données non publiées],Drees&Sommer,Project Manager,
+e43f120a-3d4e-4a3a-93ac-4197db8be696,[Données non publiées],SCP Ciavaldini,Notaire,
+e44c93ae-338d-4228-8e70-bc976db4e968,[Données non publiées],Nespresso France,"Cadre commercial, responsable de secteur [Données non publiées] pour les établissements de débits de boissons, hôteliers et de restauration.",
+e450369a-2928-49b9-bf89-b8ee0fdd2a5c,[Données non publiées],Education nationale,Professeure de Mathématiques / Physique-Chimie en lycée professionnel,
+e45e542d-3895-4800-98a8-26a80301906a,[Données non publiées],neant,neant,
+e474985e-e1b2-4dec-a292-0dcff48386aa,[Données non publiées],SCEA [Données non publiées],Exploitant agricole [Données non publiées],[Données non publiées]
+e47be5a0-2b93-419f-a18e-cd22c94c2f33,[Données non publiées],kingfischer,Acheteuse bois [Données non publiées],
+e493d400-f2b2-4ddb-b24d-f6091e342a8f,[Données non publiées],SA [Données non publiées],"COMPTABLE, gestionnaire de paie.",
+e49511e6-c9e0-4a64-b425-399c1f3d9d1a,[Données non publiées],clinique vétérinaire Saint Roch,[Données non publiées],
+e49801f3-accf-4c89-bc44-99fa4363c930,[Données non publiées],BNP Paribas,"activités bancaires, coordinateur d'audit",[Données non publiées]
+e4af7e86-dccb-4797-8e77-cd2e9debebfc,[Données non publiées],cabinet comptable CGFE,SALARIEE SECRETARIAT,[Données non publiées]
+e4af7e86-dccb-4797-8e77-cd2e9debebfc,[Données non publiées],SCHNEIDER,AIDE MENAGERE,
+e4afd420-2526-47dd-a0d8-8c37efe677f3,[Données non publiées],Conseil départemental [Données non publiées],[Données non publiées] Service Informatique,
+e4c85429-5240-45e8-acd6-23ff19490711,[Données non publiées],Ministère des collectivités territoriales,Administratrice civile,
+e4ce05a0-0d8b-43a6-9608-bb6b3095847e,[Données non publiées],LUNETTES GRASSET,CHEF DE PRODUITS LUNETTERIE,
+e4cf8c9b-36db-460e-99ae-b592295a0165,[Données non publiées],néant,néant,
+e4d2f5e1-3a69-4cb4-8bb8-69e88aad0ec3,[Données non publiées],[Données non publiées],Administrateur Réseau Systèmes d'information Finances,
+e4d5cecb-e29c-43cf-a607-ea304f17bf9a,[Données non publiées],Néant,Néant,
+e4da53be-bd3e-43a6-8d00-74a972b77808,[Données non publiées],Nantes Métropole,Conseillère municipale de Saint Sébastien sur LoireConseillère Métropole de Nantes,
+e4daf615-a026-4adf-9fa2-970665a89828,[Données non publiées],fromagerie [Données non publiées],commerciale,
+e4df54ad-577c-4691-a90b-b1f90d7dcb98,[Données non publiées],SANS PROFESSION,NEANT,[Données non publiées]
+e4ec83e4-2d79-45a7-9c36-60994ef28739,[Données non publiées],statut SARL,entrepreneur,
+e4ffaaac-e616-42ee-81b2-0f6043520db0,[Données non publiées],BIOROCK,COMMERCIAL,
+e50ade84-b2e8-4d6c-bd06-702770c28130,[Données non publiées],CPAM [Données non publiées],Chirurgien Dentiste,
+e50ade84-b2e8-4d6c-bd06-702770c28130,[Données non publiées],[Données non publiées],Gérante,
+e5124bde-0c65-4a61-a316-d6fa45f14fa2,[Données non publiées],SA JEAN FLOCH,RESPONSABLE [Données non publiées],
+e51754f2-b3a0-410a-b0a2-634dede6a81f,[Données non publiées],Retraitée,Secrétaire,
+e52ad988-17da-4f69-93a9-ec8f04b8274b,[Données non publiées],NEANT ( retraité),NEANT,[Données non publiées]
+e52d1411-9c92-49ef-94bb-e1705037d58c,[Données non publiées],Association diosesaine,Assistante de Service,
+e53a9168-9924-4fa5-8774-69053f303f1e,[Données non publiées],NEANT,NEANT,
+e53baefe-a8c3-4104-8558-1691e830e968,[Données non publiées],Néant,néant,actuellement sans emploi [Données non publiées]
+e5441100-b473-460c-903f-532e8a796414,[Données non publiées],CFAI [Données non publiées],Formateur Maths et Sciences Physiques,
+e548529f-6a62-40e2-bbf5-194f02c8fc47,[Données non publiées],A.I.D.E (association Intermédiaire,servises à la personne et aide domicile,[Données non publiées]
+e56a86cf-0a76-476f-8475-908e0890fc0a,[Données non publiées],TECNIMODERN,[Données non publiées],
+e5785494-dc58-4f4e-943c-6f9b748d58b5,[Données non publiées],Retraitée,Néant,
+e58af92e-5df6-4e41-86b9-d1d0a5019c71,[Données non publiées],Vice Rectorat de la Polynésie Française,Gestionnaire financier,[Données non publiées]
+e5a36c35-3899-4ade-ad05-d72f5e706c0b,[Données non publiées],Néant,Néant,[Données non publiées]
+e5a3c698-9e31-47fc-a9ff-b726c3b295c2,[Données non publiées],néant,retraité,
+e5a66ce7-d6e5-43f5-bca8-398103f0e3cf,[Données non publiées],Éducation nationale,"Professeur des écoles, Directrice d’école",[Données non publiées]
+e5a6846b-d72c-471b-843c-a41a3c5eff9c,[Données non publiées],SUEZ,[Données non publiées],
+e5a7373c-a617-4b62-88b9-3155dbc69e11,[Données non publiées],Crédit Agricole du Morbihan,Cadre,
+e5b11275-8be1-47de-8fa8-13efa5408b1e,[Données non publiées],THÉÉTÈTE CONCEPT SASU,Enseignement et formation [Données non publiées],
+e5c78ea9-f9bc-4a97-850d-a8041dafcedb,[Données non publiées],CNAV,RESPONSABLE PROJETS [Données non publiées],
+e5ca3330-ce71-4813-9bd2-e0acd2b60b01,[Données non publiées],Panthera technologies Chambéry,Chargé d'affaires,
+e5e8b3e4-18d4-4730-952e-a333be5baec7,[Données non publiées],El One Production,Gérante,
+e5ee04f1-9af0-410d-8b6b-297a0ac0a158,[Données non publiées],SNCF,[Données non publiées],
+e5f7125c-a04f-464b-8e9e-02d47e661b2f,[Données non publiées],néant,retraité,
+e60f6f43-ba95-44b8-9f35-ab6ba596b188,[Données non publiées],Retraitée,Retraitée,
+e6169647-8cc1-45fb-b818-8d35bb0e14d7,[Données non publiées],Néant,Néant,[Données non publiées]
+e616cd65-8aa5-433d-be82-c782eedcbacc,[Données non publiées],Association France Handicap APF,psychologue [Données non publiées],
+e616cd65-8aa5-433d-be82-c782eedcbacc,[Données non publiées],auto-entrepreneur,psychologue clinicienne libérale [Données non publiées],
+e6218f76-89d2-4800-8864-602b4fc2a53c,[Données non publiées],[Données non publiées],Chef d'entreprise Salon de coiffure,[Données non publiées]
+e6220f20-404d-4ec8-af69-11bba50f7523,[Données non publiées],Education Nationale,Enseignant en collège,
+e62b65d0-a22c-4912-b0ad-7ea05043f6ea,[Données non publiées],CHU [Données non publiées],Ingénieur,
+e64035d9-0fcb-4805-a3ad-7971a75a93dd,[Données non publiées],CGT,Administrative,
+e6411ef5-4136-499d-9f1b-d440f2bfa0f0,[Données non publiées],Éducation nationale,"Professeur des écoles, Directrice d’école",[Données non publiées]
+e64bf894-eca0-491b-afa3-5c53c1688bef,[Données non publiées],NEANT,[Données non publiées],
+e656369a-527c-4531-a034-84a09382e32c,[Données non publiées],conseil départemental 35,Chargée de missions [Données non publiées],
+e6579610-3243-4327-a614-1214042dbc83,[Données non publiées],SAS Quali Investissements,Comptable,
+e663e75d-1ada-4e86-9ef1-f2565cf11292,[Données non publiées],Divers,Intermittente du spectacle.,
+e673499e-64f3-4b2c-b549-8ef9bbaa328c,[Données non publiées],Fédération,Graphiste,
+e67b58a1-4189-4562-8b6a-545d56f2338d,[Données non publiées],CONSEIL DEPARTEMENTAL DE L'ARIEGE,ASISTANTE FAMILIALE,
+e6814fe1-b7d3-4d0b-af7f-e9ea8c860f9a,[Données non publiées],SARL Pulvéric,[Données non publiées],
+e685ffd6-6a7e-4ddf-b3fd-e19d299abe06,[Données non publiées],profession libérale,Agent d'assurance,
+e68b729b-1c59-4368-bfa4-68f1b43b0f7a,[Données non publiées],GCSMS INTEGRATION,Pilote MAIA,
+e69803a4-0a3e-481a-8c67-cb63a41bcc3b,[Données non publiées],néant,néant,[Données non publiées]
+e69b9eb2-aef6-4a71-b2fa-5ae4da5dfd33,[Données non publiées],MAGASIN MARIELLE,COMMERCE,
+e69b9eb2-aef6-4a71-b2fa-5ae4da5dfd33,[Données non publiées],SARL MARIELLE MAIRE,COMMERCE,
+e6a183a5-6758-4d85-a1db-809db0deb16b,[Données non publiées],CDOS 59,Secrétaire,
+e6a270cc-8958-4cc2-b3d5-a1f0717686c6,[Données non publiées],Metropole,[Données non publiées],[Données non publiées]
+e6ae180e-4750-450d-b2fb-df5ff727a527,[Données non publiées],DIRECTION INTER REGIONALE DE LA MER,Technicien [Données non publiées],
+e6af77e5-c26a-4eed-afb1-9143fffbe608,[Données non publiées],AS NORMANDIE,[Données non publiées],
+e6c787da-06eb-409d-be25-cc0524cffc34,[Données non publiées],Groupe CISN,[Données non publiées],[Données non publiées]
+e6ce5804-e0f0-4aa6-8ae8-3849d02da1e7,[Données non publiées],[Données non publiées],COMPTABLE,
+e6d73984-4bab-4e8e-bdc7-8f636083b993,[Données non publiées],MAJ - ELIS [Données non publiées],ASSISTANTE COMMERCIALE,
+e6d87606-e523-470e-b50c-be8009515b46,[Données non publiées],EDUCATION NATIONALE,PROFESSEUR DES ECOLES,
+e6ef35d1-07dd-4300-9b24-74e89577d548,[Données non publiées],Montaz,Conseiller technique vente magasin de sport,
+e6f30b61-9725-44ba-865c-e5d74f81a4d7,[Données non publiées],[Données non publiées],GERANTE SOCIETE,
+e706f49e-c989-49ee-82a3-ec5854fc5dbb,[Données non publiées],NÉANT,NÉANT,
+e708bb56-35d7-4146-b7f7-63daeaefa1c6,[Données non publiées],Ministère de la Défense [Données non publiées],Ingénieur des études et techniques d'armement,
+e70aa316-3bbc-4efc-b2f0-58b8cd20b85a,[Données non publiées],Association [Données non publiées],Co-directrice,
+e70ada25-02d0-456b-b5d9-5425500a2a06,[Données non publiées],Communauté d'agglomération Grand Angoulême,Professeur [Données non publiées] Conservatoire Grand Angoulême,
+e70ada25-02d0-456b-b5d9-5425500a2a06,[Données non publiées],Orchestre Chambre Nouvelle Aquitaine,[Données non publiées],
+e70c7f9d-0348-4993-8306-2bf1659c4781,[Données non publiées],auto entrepreneur,Achats ventes antiquités brocante,
+e71db4b2-b2a9-479e-9eea-ebd418742dab,[Données non publiées],CLEMESSY,CHEF DE PROJET,
+e7221d32-94a9-4518-983f-0beb8d1544f0,[Données non publiées],[Données non publiées],Retraité,
+e730098e-e57e-48ef-ad7e-30509df4a4c5,[Données non publiées],Education Nationale,Professeur de collègeArts Plastiques,
+e73b2ae7-f558-4175-a0b8-e1c7c626b727,[Données non publiées],conseil départemental de l'Aude,[Données non publiées],
+e7400914-f248-4ff0-a494-79ebf6a4810f,[Données non publiées],Education Nationale,Professeur de Lettres,
+e753ccf0-7a15-4dca-ab04-492e950a9e3d,[Données non publiées],MDPH 976,Responsable p [Données non publiées],[Données non publiées]
+e768654c-1bc3-4789-8ce8-a225b37a5b54,[Données non publiées],earl [Données non publiées],associée exploitante sur earl [Données non publiées],pas de rémunération
+e768bae1-5913-4bdc-97e9-74a5eb9db1eb,[Données non publiées],KPMG,"Manager, salariée",
+e76d0eea-1293-4803-b0b2-a6a9ba5769db,[Données non publiées],[Données non publiées],RETRAITEE FONCTION PUBLIQUE,[Données non publiées]
+e77b6cf7-0430-43c1-8059-366e3a057603,[Données non publiées],Néant,RETRAITE,
+e7846be0-f5b1-4054-a418-dca3ebce268c,[Données non publiées],SITREVA (Syndicat Intercommunal pour le Traitement et la Valorisation des Déchets),Assistante de Direction [Données non publiées],
+e788eb55-4bb4-44be-9d66-177b12ae4a53,[Données non publiées],Gérant earl [Données non publiées],Exploitant agricole,
+e788eb55-4bb4-44be-9d66-177b12ae4a53,[Données non publiées],MAIRIE,MAIRE DE LASSE,
+e78eb0a0-d3f8-4f13-922a-533ac140e2ab,[Données non publiées],SAS SEBADIS,[Données non publiées],
+e79a507d-40eb-4b92-a5f0-a0f688de3510,[Données non publiées],pole emploi,conseillere emploi,
+e79f30df-d357-46f1-b807-71eae91e51be,[Données non publiées],neant,neant,[Données non publiées]
+e7c49c27-f9bc-46d8-91fe-f22920bd0c4c,[Données non publiées],Néant,Médecin libéral,
+e7c8019c-0425-455c-925f-cc09d0a60c79,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+e7c8ffad-a593-43ce-ae45-97ce2d0c065d,[Données non publiées],SIZIAF,[Données non publiées],
+e7c8ffad-a593-43ce-ae45-97ce2d0c065d,[Données non publiées],AESIO,[Données non publiées],
+e7c98c72-db9e-4d88-bf96-097c6acfc3ab,[Données non publiées],TANDEM,SECRETAIRE [Données non publiées],
+e7ca3fd9-6926-4337-bfe1-8d1ccc0bc638,[Données non publiées],CO GERANT,AGRICULTEUR en GAEC,
+e7d283c9-1ebb-43a7-bca9-4cab3950d56c,[Données non publiées],[Données non publiées],[Données non publiées],retraite [Données non publiées]
+e7dd75b8-60e8-426d-b831-a516bc1add67,[Données non publiées],Mairie de Marignane,[Données non publiées],
+e7f71c73-5002-4c3f-b049-b3b657b56f78,[Données non publiées],Direction générale de l'aviation civile,Ingénieure [Données non publiées],
+e7f79572-8078-404d-8534-c839b9ade2ca,[Données non publiées],Education nationale,Professeur des écoles,
+e7fba2ff-f39d-42ca-bbc2-556d004ee238,[Données non publiées],néant,néant,
+e80249c7-a8a9-47ad-990a-0685954cea5a,[Données non publiées],Mini World Lyon,[Données non publiées],
+e805e20c-02ab-4ba7-beec-2394cc6cd556,[Données non publiées],[Données non publiées],Directrice Générale,[Données non publiées]
+e8187330-5865-46c7-b6df-578bd774abb0,[Données non publiées],Ecole de Musique Danse et Théâtre [Données non publiées],Enseignante [Données non publiées],
+e8187330-5865-46c7-b6df-578bd774abb0,[Données non publiées],Ecole de Musique [Données non publiées],Enseignante [Données non publiées],
+e8238ec2-7f34-4ad2-83c6-94d5e217e9f4,[Données non publiées],Activité libérale,Orthophoniste en libéral et à l’hôpital [Données non publiées],
+e8268245-e74f-4eb3-896c-3e43917d78a3,[Données non publiées],NEANT,RETRAITE,
+e828b124-f68f-48b7-b689-10b08dddcb72,[Données non publiées],Directeur commercial de la société [Données non publiées],"vente de récompenses sportives (trophées, médailles...)",
+e828d74f-e552-4e95-9d8b-3e78eb205035,[Données non publiées],KERSCA [Données non publiées],Gestionnaire de stock salarié [Données non publiées],
+e82c5604-140b-4be2-b2d6-3150cb537a6d,[Données non publiées],Education nationale,Professeur des écoles,
+e82dfd53-89c4-4cbc-baa3-0d67cab5bdef,[Données non publiées],PST médecine au travail [Données non publiées],Secrétaire médicale,[Données non publiées]
+e835517b-a4ce-4a65-8371-fa6cbea6a7ab,[Données non publiées],[Données non publiées],Clerc de notaire,
+e8374e08-5d13-46b3-81de-5455dad516c4,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+e8374e08-5d13-46b3-81de-5455dad516c4,[Données non publiées],Auto entrepreneur,Conseil en relations publiques,[Données non publiées]
+e838ffe8-1a54-4c3f-b758-ea7aa6927251,[Données non publiées],[Données non publiées],pharmacien,
+e84252b7-71b2-4887-8284-d5a106d4f81c,[Données non publiées],Caisse des dépôts et consignations,Directrice [Données non publiées] adjointe,
+e84acf6c-1183-4255-aea7-c2931033b76d,[Données non publiées],Groupe EVALIS,DGA [Données non publiées],
+e84ed120-f40e-409c-aff8-e0ef48f322d6,[Données non publiées],auto entrepreneur,négociatrice immobilier,
+e8534938-d594-4fed-aea6-3d22e9f2ee57,[Données non publiées],Decathlon France,Directeur [Données non publiées],Cadre dirigeant
+e8588ef5-ba38-4eea-b7a8-d0b117b50eaa,[Données non publiées],Saint Pierre Chanel,Employé de restauration collective,
+e85c2d9e-542c-4af1-bced-b3761f549f87,[Données non publiées],neant,Retraitée de l'Enseignement,[Données non publiées]
+e85e4ff3-da8c-44cb-b29f-a4ce875042ea,[Données non publiées],[Données non publiées],ESTHÉTICIENNE A DOMICILE,[Données non publiées]
+e862a6a2-5239-487c-998e-f55f5cc607ee,[Données non publiées],[Données non publiées],néant,
+e881e7f9-888a-41eb-a773-19334a2c9f25,[Données non publiées],Education nationale,Professeur certifié de physique et chimie,
+e888b06b-e57e-439e-9ff9-a903eb49bae4,[Données non publiées],néant,étudiante à l'université Paris-Nanterre,
+e88c45ed-0a44-4145-afb3-cbbba9ce950d,[Données non publiées],Département du Puy-de-dôme,Conseillère juridique,
+e89ee71c-3f42-45dc-b906-c35f0eddda40,[Données non publiées],LE ROUGE,Responsable [Données non publiées],
+e89fc6ff-3ce1-440c-99f8-34c5defbf047,[Données non publiées],Néant,étudiant,Banqueassurance
+e8aa1a4f-ea6d-4187-bf86-6fd47e50b485,[Données non publiées],Innothera,Directrice [Données non publiées],
+e8c3514e-0ef8-4d02-a743-5535154c9d12,[Données non publiées],[Données non publiées],directrice de cabinet,
+e8d2a077-2ebe-4077-b4ad-c6869b601d31,[Données non publiées],SANS,AUCUNE,[Données non publiées]
+e8dce6c1-cc47-464f-afa4-2380923522e7,[Données non publiées],Communauté d'Agglomération Etampois Sud Essonne,Directrice de la politique de la Ville,[Données non publiées]
+e8e8f3f0-3b77-4745-b987-17f9179d5a58,[Données non publiées],DANONE,[Données non publiées] manager [Données non publiées],
+e8eaee98-cc76-4266-b0fc-588c3e872437,[Données non publiées],[Données non publiées],Notaire associé,
+e8eb4e2c-73c3-44d9-b1b4-e41806df763e,[Données non publiées],Retraitée,Sans,
+e8eb526a-7b72-48cf-8a13-1fb37d290fd0,[Données non publiées],néant,[Données non publiées],
+e8f3e218-1f4b-4aab-9b58-433e7e3f36df,[Données non publiées],Cabinet anesthésie [Données non publiées],secrétaire médicale,
+e8f6127e-fa10-479d-b2b6-a96c1d53ffc3,[Données non publiées],Des-Ca EURL,[Données non publiées],
+e8f6127e-fa10-479d-b2b6-a96c1d53ffc3,[Données non publiées],Région Réunion,Fonctionnaire Territorial / Agent Technique,
+e8fb6bc5-302f-4652-ba6b-f8b107dbdeb7,[Données non publiées],AFCCRE,Cadre au sein d'une association de collectivités territoriales spécialisée dans les affaires européennes et la coopération internationale,
+e8fea4e3-36b6-4bd3-bc76-4835daca34a9,[Données non publiées],[Données non publiées],"Ingénieur RD, chef de projet",
+e9126cb2-134c-4ccf-8131-e17f43e6658c,[Données non publiées],LIVCER,[Données non publiées] Expert de l'impression en continu pour l'industrie,
+e915b772-4928-42f3-a96e-a6ffae8394a0,[Données non publiées],Altarea Cogedim,[Données non publiées],
+e916a591-212b-4593-9b32-46f1232508d7,[Données non publiées],Ministère de l'Agriculture,Directeur régional [Données non publiées],
+e9235e15-44ad-4817-8c07-b664ccb6baf5,[Données non publiées],Conseil départemental,Agent Maison Départementale des Personnes Handicapées (MDPH),
+e92e318d-3613-4904-a962-4cd3767612af,[Données non publiées],[Données non publiées],Agriculteur,[Données non publiées]
+e92ed323-4528-40aa-b532-b86b9bcfabb4,[Données non publiées],[Données non publiées],[Données non publiées],
+e92ed323-4528-40aa-b532-b86b9bcfabb4,[Données non publiées],SAS LE VAUBAN,Présidente de la société commerciale d'activités hôtelières et para-hôtelières.,
+e93626a4-29ef-4145-a2d5-c72fe98f0d64,[Données non publiées],[Données non publiées],ENSEIGNANT,[Données non publiées] Maire de la commune de Villetaneuse
+e9456bfd-bded-44e8-9eed-3bbc80e1fb07,[Données non publiées],Education nationale,Professeur,
+e94fab90-e6d4-4a96-9d8c-649fc22fa00f,[Données non publiées],SA Massebeuf Textiles,Activité industrielle de production de fils,[Données non publiées]
+e964f1c6-8b6b-44d9-bd66-b52fa4361c65,[Données non publiées],Profession libérale,Avocate,
+e964f1c6-8b6b-44d9-bd66-b52fa4361c65,[Données non publiées],SASP Basket Landes,Présidente,
+e966c86e-48f8-4540-9d19-e5bd466240d9,[Données non publiées],Mickael Page Interim,Manager de transition,
+e96781cf-94cc-4404-809c-06cbdc0b25c5,[Données non publiées],CNR Compagnie Nationale du Rhône,[Données non publiées],
+e9696f9e-6ecf-40d7-9a61-0b8a3ea0872d,[Données non publiées],Néant,Agence de communication,Créatrice d’entreprise [Données non publiées]
+e972c7ec-c3a8-44d5-804c-533943c78ae8,[Données non publiées],Région Grand Est,[Données non publiées] [Données non publiées],
+e97a109f-54d7-4de1-bb23-53df928bbfa1,[Données non publiées],Education nationale,Enseignant second degré,
+e9878422-cd10-4988-8c04-7d236a59e9e4,[Données non publiées],Centre hospitalier [Données non publiées],Cadre supérieur,
+e98e69e4-5327-4310-b821-2dce9f88d95d,[Données non publiées],Retraité,Néant,
+e996c0f4-cd64-443d-9eed-5d5a0ac1d6ec,[Données non publiées],EDUCATION NATIONALE,RETRAITE EPS,
+e998ae52-56cd-4d63-9e04-2a74b85d955a,[Données non publiées],Auto boulevard,Mécanicien automobile,
+e99bffbb-cf2c-429e-bd1e-4c277dde6410,[Données non publiées],CFAI [Données non publiées],Formateur Maths et Sciences Physiques,
+e99de1b4-affb-4e28-b06c-8061dcc0fd99,[Données non publiées],MINISTERE DE LA JUSTICE,[Données non publiées],
+e99f940f-9ff2-4ff6-b635-11c2cbff25e2,[Données non publiées],SOLVAY,[Données non publiées],
+e9a11ee6-d593-42c8-9386-ac209097fec3,[Données non publiées],SEGAT,Conseil et accompagnement des acteurs de l’aménagement et de l’immobilier,
+e9cd6b92-391b-48a6-bcdb-15000e80a1a1,[Données non publiées],RETRAITE,NEANT,
+e9dee737-103f-405c-8634-2780a8852875,[Données non publiées],Toulouse School of Economics,Doctorat [Données non publiées],
+e9e24019-782a-417c-aa67-c80f2bb365ba,[Données non publiées],Chambre de Commerce et d'Industrie des Deux-Sèvres,[Données non publiées],
+e9e67fe8-d187-4021-821b-19d6dc5b7ca4,[Données non publiées],clinique [Données non publiées],lingére,
+e9f0d273-eec9-45cf-a6c3-664226a54114,[Données non publiées],NEANT,NEANT,[Données non publiées]
+e9f7436c-8687-4a3c-be8d-da6c6c2650b9,[Données non publiées],Hôpital Yves Le Foll,Psychologue,
+e9f7881a-280d-4914-8acb-b0e1d48a91b8,[Données non publiées],Fédération des élus des entreprises publiques locales,Responsable département [Données non publiées],
+e9f9ed84-d19a-432f-9848-5028fb77705a,[Données non publiées],BACCARAT SA,[Données non publiées],[Données non publiées]
+ea0c86f3-4cb1-46b0-93ca-1f79560a2ace,[Données non publiées],NEANT,NEANT,
+ea101669-3cec-419b-959d-76da96505a17,[Données non publiées],[Données non publiées],Secrétaire médicale,[Données non publiées]
+ea1dc20e-263e-46ad-97f3-9f8cb9c73e54,[Données non publiées],néant,néant,
+ea1f7700-e1ae-408d-89ba-2d3a0f829431,[Données non publiées],AXIOME NOTAIRES,Notaire associé [Données non publiées],
+ea1fbfdc-25be-4804-b2e9-b87e74db3163,[Données non publiées],Hopital,Medecin,villeneuve-sur-lot
+ea31b1d4-8d3a-49ad-aaa5-0f12557140c0,[Données non publiées],[Données non publiées],Assistante vétérinaire,
+ea35e79f-4fb1-45f7-a27f-ee15fde151b5,[Données non publiées],education nationale,prof de lycée pro,
+ea482ff2-af5d-4d7b-8f6f-60342adbcf2e,[Données non publiées],Gérant SARL [Données non publiées],Consultant en sécurité des systèmes d'information,
+ea55c285-d8e7-42e9-bcfe-bc17fb1c9a3b,[Données non publiées],Education Nationale,Professeur des Ecoles,
+ea566d97-c3b3-4399-8cec-8f50bb727e6d,[Données non publiées],Intérimaire,Missions d'intérim,
+ea5b7da7-ab46-46b5-bb11-555adf8edd7e,[Données non publiées],EDUCATION NATIONALE,Enseignant,
+ea5b7da7-ab46-46b5-bb11-555adf8edd7e,[Données non publiées],MEMBRE DU CA HARMONIMES EN SCENE,[Données non publiées],Activité bénévole
+ea5fef73-086a-4038-a5e1-754c20800328,[Données non publiées],LIEBHERR FRANCE [Données non publiées],[Données non publiées],
+ea6185ba-26f8-4197-a500-07bb3cf2a5f9,[Données non publiées],Education nationale,Assistant d'éducation,
+ea7d412b-ec7c-4f49-9415-d82a5276a6ae,[Données non publiées],neant,neant,[Données non publiées]
+ea803415-3c91-4e4f-8671-53adf7c132e0,[Données non publiées],OGC SAINT ANDRE,INTERVENANTE [Données non publiées],
+ea803415-3c91-4e4f-8671-53adf7c132e0,[Données non publiées],CRECHE KOKIRI,INTRVENANTE [Données non publiées],
+ea8b1933-b8c1-47e8-87c0-5b951d63eff1,[Données non publiées],Viltaïs,Directrice Générale Adjointe,
+ea8ce20e-e01d-428d-9b58-d230206fa0ef,[Données non publiées],retraité,[Données non publiées],
+ea8df619-955c-44c2-b3a8-bc1ddd4ed45d,[Données non publiées],Retraité,Retraité de la fonction publique territoriale,[Données non publiées]
+ea8df619-955c-44c2-b3a8-bc1ddd4ed45d,[Données non publiées],SAS CAMPET Entreprise,Ouvrier niveau II [Données non publiées],
+ea9da3ad-06f3-41d7-b3dd-ff8c3e0e1121,[Données non publiées],Semences de France,responsable [Données non publiées],
+eaa66db7-4aae-46fe-b9ef-5c3918ae08a3,[Données non publiées],[Données non publiées],Enseignante,
+eabcbe39-3b5a-4858-9ba7-072c97435149,[Données non publiées],Néant,Retraitée,[Données non publiées]
+eac37ef0-25a3-4be6-8e67-fea9ee8ef218,[Données non publiées],CASDEN,Ingénieur informatique,
+eac7e30d-2336-4da6-8ed1-23b6a5c31c33,[Données non publiées],exploitante agricole,viticultrice,
+ead77aa7-2f03-412b-9d49-79308b705152,[Données non publiées],néant,néant,[Données non publiées]
+ead8c35a-a1a4-4c73-aa92-71cf9e8de283,[Données non publiées],Néant,Néant,[Données non publiées] à la retraite [Données non publiées]
+eae6cfc0-6676-45c8-9d50-a23de6a74851,[Données non publiées],DREAL [Données non publiées],[Données non publiées],
+eae6cfc0-6676-45c8-9d50-a23de6a74851,[Données non publiées],[Données non publiées],réalisation d'évaluations et d'audits en tant qu'auto entrepreneur,
+eaeac41a-7715-4898-b753-41ba3dc2a0b1,[Données non publiées],FAURECIA,Responsable [Données non publiées],
+eaf09a7c-1407-4c32-a227-eb2778aa7610,[Données non publiées],Auto-entrepreneur,Technicienne du sommeil indépendante.,
+eb07f901-e207-435a-b1eb-6cace4d35b97,[Données non publiées],néant,retraitée,
+eb1d648a-d231-4504-a483-9b90b3c10b21,[Données non publiées],Groupe France Télévision,journaliste,
+eb22d274-ad4c-4947-ab82-96ff7f460f4f,[Données non publiées],France Télévision,Journaliste,
+eb2a0c2d-4020-4ad7-a10a-79c309734a62,[Données non publiées],CNFPT,Rédacteur principal [Données non publiées],[Données non publiées]
+eb2a6e17-8098-49c2-a304-3d890c4ea573,[Données non publiées],Néant,Néant,
+eb2e226d-5fd0-47d5-b042-58f1dec0e0fb,[Données non publiées],RETRAITE,RETRAITE,
+eb2f670a-c589-4917-bcb9-d20e970e8d94,[Données non publiées],Alliance Networks,Gérant.,
+eb34a1b3-34ba-4f28-986e-6f22e5a98a5e,[Données non publiées],WESER,Assistante direction [Données non publiées],[Données non publiées]
+eb37bcd3-c4ff-4b80-af77-9ac73df91228,[Données non publiées],BMI Group,Directeur Maintenance - Cadre,
+eb38d2af-0902-463c-8354-12a87acb0eb5,[Données non publiées],Intermittent du spectacle,Artiste de spectacle vivant (magicien)Comédien,
+eb3aeeea-efa1-43e8-860d-ea968d43812a,[Données non publiées],AFLD Paris,[Données non publiées],Infirmier préleveur
+eb4902a2-0d8c-4850-9992-ab46a5ba57c7,[Données non publiées],SAFIGEC,juriste [Données non publiées],
+eb4f0ac0-580c-4bf9-9e1b-42fe8a442b8e,[Données non publiées],EARL [Données non publiées],Agricole,
+eb574b8e-d848-49bd-870e-dd70a206be1f,[Données non publiées],Société Les Petits Poulbots,[Données non publiées] vendeuse [Données non publiées],
+eb635ccc-ce0c-4ec0-bc04-02530e10d273,[Données non publiées],Entreprise de travaux forestiers [Données non publiées],Secrétaire,
+eb68448a-f925-48bd-854f-b1b1faea83d2,[Données non publiées],néant,Retraité,
+eb6bd140-6b71-4e1b-8ca3-6c7d66af3c81,[Données non publiées],Fonctionnaire,Juriste,
+eb70a547-2a1f-4125-a8ca-3100e892f24d,[Données non publiées],SARL [Données non publiées],GERANTE,
+eb7321d2-edf1-424e-b08c-26f3a623cffc,[Données non publiées],[Données non publiées],[Données non publiées],A la retraite [Données non publiées]
+eb795da9-cf89-4cf1-93f6-7b70e5fd2bf7,[Données non publiées],néant,néant,[Données non publiées]
+eb896625-e1cd-48b5-8836-4863c12e112f,[Données non publiées],[Données non publiées],Développeur informatique,
+eb8a9046-3c36-4cd1-8383-a391191915a3,[Données non publiées],RETRAITEE,RETRAITEE,
+eb8f0ce1-8bd2-4ddb-8bd0-8474a4f95c9d,[Données non publiées],[Données non publiées],Gérant d'un commerce de bouche/bar,Activité qui a pris fin en date du 1er septembre 2020
+eb95b308-bdd9-4727-918f-36e5499f7905,[Données non publiées],STANHOME,VRP,
+eb9cbef7-f383-476b-ba9d-e785eeb127ef,[Données non publiées],CourdesComptes,conseillèremaitre,
+ebae6eda-3ff9-44dd-962c-2348bc3573fa,[Données non publiées],MINISTERE DE L'EDUCTATION,PROFESSEURE DES ECOLES,
+ebb8622e-06d5-47c6-99e6-91928a1aba2f,[Données non publiées],"Ministère de l'Enseignement Supérieur, de la Recherche et de l'Innovation",Chargé de mission,
+ebc18580-5c4e-4334-8031-00618f5989ca,[Données non publiées],Hopital POMPIDOU,Médecin,
+ebd1ae55-450b-4110-bf3d-1bad901d9543,[Données non publiées],Education Nationale,Enseignante,
+ebe44f93-f383-4fd0-a668-f3840734a985,[Données non publiées],Avocat,Avocat,Profession libérale
+ebe749da-c7e3-4087-8d11-862f07ae621c,[Données non publiées],HATVP,Chargée de mission [Données non publiées],
+ebe8127a-b879-4881-a27a-71f4e79fac3b,[Données non publiées],CHU Rouen,retraité,
+ebef312e-a399-4fc8-b2f6-54c9397e6bbe,[Données non publiées],retraitée,retraitée,
+ebf04afe-c5c5-4a1d-a077-c11134b83da5,[Données non publiées],SELARL [Données non publiées],Médecin Radiologue,
+ec0b17e4-35f8-4d39-bb4c-1160a1936fa6,[Données non publiées],Travailleur indépendant,conseil en communication scientifique et journaliste,
+ec0dcad5-8a56-4c9e-b554-8e6eb3332b36,[Données non publiées],neant,neant,
+ec0ebea5-ebbb-47e8-9c8d-c8681e915421,[Données non publiées],Néant,Néant,En retraite [Données non publiées]
+ec160900-0d68-4b34-93fe-b5b23e0e2770,[Données non publiées],Entreprise Lafitte TP [Données non publiées],secrétaire,
+ec204f9c-3bd8-48e0-b34f-e2c19eb30afc,[Données non publiées],[Données non publiées],co-gérante,
+ec243ff2-2a8c-4941-8a73-4362f9a58d29,[Données non publiées],Caisse d'Allocations Familiales,Assistante Sociale,
+ec29cb15-aac5-44d2-bbfb-17bab22e86c5,[Données non publiées],BNP,CHARGEE D AFFAIRE PROFESSIONNEL,
+ec2d7476-8800-428f-86cc-566301453d18,[Données non publiées],Ministère de l'Education Nationale,IA-IPR [Données non publiées],
+ec2ff9ba-4648-4f28-88cf-bb72ee656c2a,[Données non publiées],retraitée,retraitée,
+ec34c1d6-ab5b-4439-8643-16c9c0efdbd2,[Données non publiées],Mairie de dijon,[Données non publiées],
+ec3c5a69-eed3-4c5b-bb38-8e7ca2c7625b,[Données non publiées],Mairie de Beauchamp,Assistante de direction,[Données non publiées]
+ec493381-c318-466b-be90-e8dbca08d706,[Données non publiées],Architecte Libéral à [Données non publiées],architecture : conception d'immeubles divers et suivi des travaux,[Données non publiées] retraite [Données non publiées]
+ec4aaccc-e466-4afe-93bc-a8b2c53f5ab8,[Données non publiées],Ministère Education nationale,Professeur,
+ec5bd06f-a086-4689-8ab6-3f3abb885295,[Données non publiées],cgfi,CONSEILLER FINANCIER,
+ec5be167-fefa-44d8-aa47-9ac04da4eeaa,[Données non publiées],KERSCA Société [Données non publiées] [Données non publiées] [Données non publiées],Gestionnaire de stock salarié [Données non publiées],
+ec5c8a03-c953-4cde-a46e-0d4c2451e59f,[Données non publiées],EURL [Données non publiées],gérant majoritaire d'une société de lavages automobiles,
+ec61747b-64ed-4a66-b8ae-cb450e34f930,[Données non publiées],[Données non publiées],COMPTABLE ACTIVITÉ : Céréales du petit déjeuner en BIO,[Données non publiées]
+ec76769a-6753-4be7-a35b-d98d74d68c75,[Données non publiées],SCEA [Données non publiées],Exploitante agricole,Associée exploitante sur l'exploitation familiale [Données non publiées]
+ec76769a-6753-4be7-a35b-d98d74d68c75,[Données non publiées],SCEA [Données non publiées],Cogérante,Cogérante sur l'exploitation SCEA [Données non publiées]
+ec776410-c078-433e-8609-8cc41f41ba45,[Données non publiées],Ministère de l'Education Nationale,Professeur des écoles,
+ec7c7122-c73f-43a0-89ff-4c520e414179,[Données non publiées],"Professeur certifié, [Données non publiées]",[Données non publiées],
+ec7fb8b9-f729-4647-8bdc-6084e41b5f42,[Données non publiées],Office du tourisme [Données non publiées],Attaché de presse,
+ec8c6782-652d-451d-8248-85d6d8faedfc,[Données non publiées],retraitée éducation nationale,Retraitée,[Données non publiées]
+ec9175bb-8cd2-4fca-94d3-8ccf33523d93,[Données non publiées],Mairie de Paris,[Données non publiées] cabinet,
+ec934de5-47e9-4127-9749-60ceebef607d,[Données non publiées],Fonctionnaire Etat,Sous Préfet,
+ec94136f-e73d-42ac-9ad4-781148932775,[Données non publiées],État (éducation nationale),Gestionnaire d'EPLE,
+eca60f36-70f0-40e0-9db7-ec6e489e42b0,[Données non publiées],Fund Channel S.A.,Juriste,
+ecac35ce-15b7-4bff-ab9b-26bf42320d09,[Données non publiées],Mairie,adjoint,[Données non publiées]
+ecb4d408-d095-4994-ac1f-ec6a9774d572,[Données non publiées],LA POSTE,Facteur,
+ecb67d83-d797-422c-bb7e-b7e751d3fdb0,[Données non publiées],SARL MAV,Salarié,
+ecbd544f-73f9-49a8-b1d0-0fabd52a769b,[Données non publiées],CARSAT,RETRAITE,
+ecbd544f-73f9-49a8-b1d0-0fabd52a769b,[Données non publiées],MAIRIE DE PORTES LES VALENCE,DELEGUE,
+ecbd544f-73f9-49a8-b1d0-0fabd52a769b,[Données non publiées],GARAGE PIETRI,DEPANNEUR,[Données non publiées]
+ecc2a732-fb00-4299-845c-ff41c79bd0c6,[Données non publiées],Auto entrepreneuse,Traductrice Psychothérapeute,[Données non publiées]
+ecc49d9d-b671-4b7b-a85a-4109549433f1,[Données non publiées],Boulangerie [Données non publiées],Vendeuse en boulangerie,
+ecc8df6c-c3d8-4b14-b6e6-26409c264667,[Données non publiées],Alisée,conseiller énergie,
+eccdd772-2f58-4389-b256-76d348011de2,[Données non publiées],Mairie de Paris,cadre administrative [Données non publiées],
+ecd86701-02b4-42a1-9cfd-f4af8231386e,[Données non publiées],EURA ENERGIE,Responsable de communication,
+ecd86701-02b4-42a1-9cfd-f4af8231386e,[Données non publiées],[Données non publiées],[Données non publiées],
+ece6c9dd-3cc4-4d0c-b789-a5e51f0848e4,[Données non publiées],Néant,Néant,
+ece94230-b0bc-4476-924f-0a8772bf36b7,[Données non publiées],COLLEGE [Données non publiées],Professeur de français [Données non publiées],[Données non publiées]
+ecf04603-649d-40c4-aaec-60ebe5e3a28e,[Données non publiées],Université Paul Valéry [Données non publiées],[Données non publiées],
+ecf15460-365f-4118-9dce-c3ced3499a6d,[Données non publiées],Université de Bordeaux -IUT,[Données non publiées],[Données non publiées]
+ecfb3b7c-34a4-48e2-ac44-32be998c6692,[Données non publiées],[Données non publiées],[Données non publiées],
+ecfce3ef-1bba-45b0-b74d-59b93bc212ad,[Données non publiées],NEANT,NEANT,[Données non publiées] élue [Données non publiées]
+ed143ee1-0da6-44e6-9159-8d0d5a484933,[Données non publiées],neant,retraitée,
+ed18f673-3dbe-448e-99d9-ac79e851b532,[Données non publiées],néant,néant,retraitée
+ed29b225-ff68-42a8-8a32-b8464357fca0,[Données non publiées],Activité Libérale,Architecte,[Données non publiées]
+ed393ded-c780-4cbf-b35e-f6926f11f551,[Données non publiées],pole emploi,conseillere emploi,
+ed3d7631-f651-40fa-a288-5d26478fde70,[Données non publiées],SELAS LPACGR,Avocat,
+ed4fad4c-fb43-4344-82b4-c90e68be8ab4,[Données non publiées],Néant,Néant,
+ed543ff6-aae9-4ba2-80eb-36cc822f59d2,[Données non publiées],Ministère de la santé et Ministère de l'enseignement supérieur et de la recherche,[Données non publiées] CHU de Caen. Praticien hospitalier [Données non publiées] Emploi à temps plein.,
+ed56ea30-ba2f-4d7e-bd51-77a2dcb440bd,[Données non publiées],SA [Données non publiées],directeur général / démolition automobile,
+ed66edd9-bc1d-439b-a619-cac0003cb869,[Données non publiées],[Données non publiées],[Données non publiées],RETRAITE
+ed7219fa-b580-46ea-b430-ceeb22c1f223,[Données non publiées],ACC,[Données non publiées],
+ed76bfb8-5dfe-47c6-a84b-12836e3db3d4,[Données non publiées],Université Grenoble Alpes,[Données non publiées],
+ed794dc7-380d-4907-9607-f0cbf6499997,[Données non publiées],Néant,Vacataire pour le théâtre de Brest. [Données non publiées],
+ed7dce3c-7348-45e5-bd5d-33efe21784a2,[Données non publiées],[Données non publiées],Participation,
+ed8876cf-354d-4d32-a6b1-ed6d239a2b8b,[Données non publiées],médecin,gynécologue,
+edac9920-014b-4ca1-8d04-05b97c1621ad,[Données non publiées],seac-pf,logistique,[Données non publiées]
+edac9920-014b-4ca1-8d04-05b97c1621ad,[Données non publiées],exploitant agricole,dans le domaine de la culture de la vanille,[Données non publiées]
+edac9920-014b-4ca1-8d04-05b97c1621ad,[Données non publiées],entreprise individuelle,"travaux de finition location de logement traduction interprétariat Photocopie, préparation de documents et autres activités spécialisées de soutien de bureau",
+edb13458-9b8f-4909-96f1-c31ebeae30cd,[Données non publiées],Conseil départemental [Données non publiées],Fonctionnaire,
+edb7beac-dee7-4b83-8f4b-dd5830b42d87,[Données non publiées],La Vitrine Française,opérateur Commande Numérique.,[Données non publiées] Son nouvel employeur : Calme Intérieur avec une activité équivalente.
+edb887ff-912a-49f1-afd7-30d7f83ab829,[Données non publiées],Retraitée Education Nationale,Retraitée,
+edc0f2f0-b353-4600-a271-b014c42d5854,[Données non publiées],SA [Données non publiées],"COMPTABLE, gestionnaire de paie.",
+edd02fc3-9234-4ef4-b7c0-78a81959a565,[Données non publiées],retraité,retraité,[Données non publiées]
+eddc3346-3173-4f8f-a271-62b3a1ce2f8b,[Données non publiées],Education nationale,Professeur des écoles,
+eddfa2da-6d76-4457-b6b5-e68afd2943d6,[Données non publiées],EDUCATION NATIONALE,Professeure des écoles,
+edff1733-9c3c-4728-82be-953638f63e08,[Données non publiées],LEGRAND,Business développeur,
+ee0ade64-f77f-4ba4-ad90-8c1e243392ce,[Données non publiées],EBEN,[Données non publiées],
+ee0c0e4c-d8c7-4ef0-81c7-4d24cc364de2,[Données non publiées],Libéral à son compte,Chirurgien Dentiste,
+ee12b43e-2310-4806-affe-56af4868c80f,[Données non publiées],Mairie de Foug,Bibliothécaire,
+ee1bc530-f5bc-41a1-bab4-47c26c4e7c2e,[Données non publiées],COVEA (assurance MMA),gestionnaire de sinistres,
+ee3f6706-f51e-4323-8436-b99f027871a1,[Données non publiées],[Données non publiées],Clerc de notaire,
+ee430316-4ad6-4bfc-a87f-fb7e9e54edd5,[Données non publiées],Retraitée,[Données non publiées],
+ee4baf5a-ac87-4649-ba2c-a18c37a8ac39,[Données non publiées],EIFFAGE,Directeur technique,
+ee4f44c5-c198-4104-8d85-0718f2631323,[Données non publiées],Hutchinson France,Support IT,
+ee580e54-5d16-4d73-ae2b-0f39d3e8d43a,[Données non publiées],[Données non publiées],Médecin Généraliste,
+ee5d03a6-3666-4232-afe7-b7b99ad9e9dd,[Données non publiées],Crédit Agricole Assurances - SIRCA,Juriste Gestion de sinistres protection juridique,[Données non publiées]
+ee5d03a6-3666-4232-afe7-b7b99ad9e9dd,[Données non publiées],Mairie de Noyal Chatillon Sur Seiche,[Données non publiées],
+ee693422-8c12-48a5-939e-d9f1cff7fc4d,[Données non publiées],Néant,Néant,
+ee77f823-baee-48b4-8e54-13dd4fe20597,[Données non publiées],CIST [Données non publiées],Médecin de travail,
+ee77f823-baee-48b4-8e54-13dd4fe20597,[Données non publiées],AGESTRA [Données non publiées],medecin du travail,[Données non publiées]
+ee78c05a-58f1-4e91-a2d3-6c9eac81ecc9,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+ee7c78b7-0022-4742-a02b-fde6cfc699be,[Données non publiées],Ministère de l'Education Nationale,Institutrice,
+ee801bb8-8ea3-484c-98a3-dac93465d25f,[Données non publiées],EDUCATION NATIONALE,Retraité,
+ee81a22b-e061-4b68-b385-d16f433b5a4f,[Données non publiées],Gouvernement de la Polynésie française,Conseillère technique,
+ee82d036-84f5-47f8-a7d1-d37331e3df23,[Données non publiées],Conseil départemental,[Données non publiées],
+ee877be8-18eb-4249-9e77-7d76cd9783cc,[Données non publiées],[Données non publiées],SECRETAIRE,
+ee89362f-5782-4e99-99c6-33130b311164,[Données non publiées],Retraité,Néant,
+ee91f9fb-7634-465b-9395-0bafde714cd9,[Données non publiées],Assemblée de la Polynésie Française,Représentant,
+ee91f9fb-7634-465b-9395-0bafde714cd9,[Données non publiées],Sénat,Sénatrice,
+eea33e9e-6bc3-430b-bb82-f5df18278e64,[Données non publiées],Office National des Forêts,Ingénieur,
+eeae1c41-2413-4ca4-8d85-32f826211906,[Données non publiées],Véro coiffure,[Données non publiées],
+eeca0bf2-9b1c-47e8-b979-e49311ef47ff,[Données non publiées],SNCF Réseau,Responsable unité juridique environnement,
+eecfe89c-97b7-48ed-b55e-22c6a559827f,[Données non publiées],Bat' expert,gérant de la Société de bureau d'études dans le bâtiment,
+eedb3eba-9b38-405a-8d5f-c048771b3f54,[Données non publiées],Néant,Retraitée,[Données non publiées]
+eede4641-8c25-455b-922c-2cbb2abb0cf1,[Données non publiées],CGO (Comptabilité Gestion Océan) [Données non publiées],Juriste,
+eee87992-9daa-4640-986a-9d86d1fb7045,[Données non publiées],SARL IMMOBOX,[Données non publiées],
+eeee2117-60ee-4b2e-a77c-b636707506ed,[Données non publiées],Education Nationale,Professeur des écoles [Données non publiées],
+eef65227-d5b4-49d8-9808-37046e4c722b,[Données non publiées],Centre hospitalier [Données non publiées],auxiliaire de puériculture,
+ef080d77-f058-44a5-ab7a-f31bd46a426e,[Données non publiées],Département des Hautes-Alpes,Fonctionnaire territorial catégorie A Chef de Service,
+ef083b7e-9691-4f55-9a9d-c87a17554555,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+ef083b7e-9691-4f55-9a9d-c87a17554555,[Données non publiées],Autoentrepreneur,Développement informatique,[Données non publiées]
+ef0d54e2-f872-44c8-be78-d7f96bed306d,[Données non publiées],Assistance Publique - Hôpitaux de Paris,Interne [Données non publiées],
+ef0dcbc3-909d-4c98-94fc-f23c9c540bec,[Données non publiées],Enedis,Agent d'appui administratif,
+ef0dd58f-39cd-4e81-b6ad-da8fb70d01d6,[Données non publiées],Retraité,Retraité,[Données non publiées]
+ef0e7b8c-b370-44ce-9f59-430f65abe3bd,[Données non publiées],néant,néant,
+ef175b51-1c18-483f-8439-358ee0702f74,[Données non publiées],GAEC [Données non publiées],Agricultrice-conjointe-collaboratrice,
+ef1b7347-2ab2-4453-a05f-c233200a72f0,[Données non publiées],Conseil régional Grand Est,Directrice générale adjointe,
+ef1e7251-84f0-4172-8c60-98d155534d1e,[Données non publiées],Association [Données non publiées],[Données non publiées],activité de crèche parentale associative
+ef20370e-f7f8-433d-afa9-1e4e77d9ffa7,[Données non publiées],activité libérale,médecin généraliste,
+ef21405a-a23e-426c-9a0b-78c431ccc7ad,[Données non publiées],Éducation nationale,Professeur certifié d’Histoire- Géographie,
+ef22aa2a-7d64-4343-8600-27fd41fd41db,[Données non publiées],Mairie de Cannes,dgs,
+ef29ca06-00bd-46dd-853d-48de5749341f,[Données non publiées],Association Léonard de Vinci / IIM,Chargée de mission,
+ef4336a5-02d2-4ffe-9d7e-d024dc7c2079,[Données non publiées],[Données non publiées],personnel de direction éducation nationale,
+ef4dd0ac-5aa4-4f66-b7ff-9a394382d2b5,[Données non publiées],CCAS [Données non publiées],directrice de la pouponnière [Données non publiées],[Données non publiées]
+ef6c2342-514d-439a-b60a-660ff67b6034,[Données non publiées],EPCI,Attachée territoriale,
+ef6caf58-2d5f-4788-a62c-585f85510983,[Données non publiées],[Données non publiées],Avocate [Données non publiées] [Données non publiées],[Données non publiées]
+ef734d39-50d2-423b-b689-6ed9442eff1a,[Données non publiées],BNPrealestate,DGA,
+ef7d89c1-71bb-4c1a-b2d1-adfa3868aea7,[Données non publiées],General Electric,Senior Vice President [Données non publiées],
+ef8b0f2e-79ed-485f-a3f2-5f171dd64e40,[Données non publiées],education nationale,professeur des écoles,
+ef8c987d-a198-4c10-9821-2b2a0a438e43,[Données non publiées],BNP Paribas,"activités bancaires, coordinateur d'audit",[Données non publiées]
+ef98f0a1-37c2-49bc-89da-47bb648d159d,[Données non publiées],SARL JAG HAUT VERDON VOYGES,GERANT,
+ef9d32a7-5489-4591-ad33-904dfad41ba7,[Données non publiées],Ministère de l'éducation,Professeur des écoles,[Données non publiées]
+efac167b-bba3-48a4-ac71-bbfec8aa1849,[Données non publiées],Education Nationale [Données non publiées],Enseignante,
+efad0647-fa11-4181-bd6a-d666862673e9,[Données non publiées],CNRS,Chargé de recherche puis directrice de recherche,[Données non publiées]
+efbe3284-cae7-4036-b1c1-9667e9733831,[Données non publiées],Crédit Agricole,Chargée de clientèle professionnelle,
+efbfdcca-eed9-4e3e-baae-8faed0109eda,[Données non publiées],EDF [Données non publiées],RESPONSABLE D EQUIPE,
+efc44208-77df-4d89-80fb-7cb8eccd0879,[Données non publiées],Ville de Vaires sur Marne 77,Directrice Générale des Services,
+efc9d0d9-4172-45eb-be65-f56d275abecc,[Données non publiées],VEOLYS,Assistante de Développement Informatique,
+efca6a02-649c-4fdc-a7ce-5cb3d89cb894,[Données non publiées],SAS ACTENSEINE,SOCIETE DETENANT DEUX OFFICES NOTARIAUX,[Données non publiées] Notaire dirigeant de cette société [Données non publiées]
+efde5f8c-8298-4345-a512-ba1091d31b3e,[Données non publiées],Métropole de Lyon,Responsable du service [Données non publiées],
+efeab96e-9852-4acd-ba96-2a8a8574698e,[Données non publiées],Éducation Nationale,Professeur des Écoles,
+eff76122-eab6-4687-b474-7af8eb847bcd,[Données non publiées],BPCE,Chargée de communication,
+eff9e9c5-629c-4405-ae6c-2603248710a7,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées] retraite [Données non publiées]
+f0016671-f6f4-4989-a49a-a52d742413b6,[Données non publiées],Ballot,Fabricationdeproduitcosmétiques,
+f009d5c1-0140-46b5-ab12-7c83f93b2d8d,[Données non publiées],Sénateur de la Sarthe [Données non publiées],[Données non publiées],[Données non publiées]
+f009d5c1-0140-46b5-ab12-7c83f93b2d8d,[Données non publiées],Conseil Départemental de la Sarthe,Conseillère Départementale de la Sarthe,
+f00b02af-6250-4c22-bcfb-9bd7bc789981,[Données non publiées],Indépendante,Kinésithérapeute,
+f011da80-4475-4d16-888e-b76950a4a5cc,[Données non publiées],COMMUNE DE CASTELCULIER,DGS,
+f01bf627-4d50-4de5-9340-d6fc01787955,[Données non publiées],SCP [Données non publiées],Salariée cabinet d'avocat,
+f01eb24c-b4ad-4706-b962-a7c9b72809e3,[Données non publiées],Nantes Métropole,[Données non publiées],
+f035d7d8-8920-4de8-a544-0b43735cc7c8,[Données non publiées],SARL PLUS 6,Communication publicité,[Données non publiées]
+f03d8b97-70be-408c-a93c-e4c0158eb5a7,[Données non publiées],AXA FRANCE IARD / VIE-AFI,chargé de clientèle,[Données non publiées]
+f05d95ba-1929-46a4-93c4-85bd2bf69113,[Données non publiées],Micro-Entrepreneur,Agent Commercial dans l'immobilier.,
+f0670351-cd88-4962-bc07-a7b6cb5dfdcb,[Données non publiées],[Données non publiées],DGS du département,
+f0673fce-55d7-473b-8680-4d6274e74d40,[Données non publiées],BIOROCK,COMMERCIAL,
+f07579f2-8d3c-44e4-9a7c-5e5f07b37bfb,[Données non publiées],néant,neant,
+f077b58e-837f-4c73-bbbd-d20d877e32ac,[Données non publiées],néant,néant,
+f0831d35-b8d2-43a8-b808-aaa92c1a4fea,[Données non publiées],Education Nationale,Professeur des écoles,
+f08587f9-fbd3-4849-9276-72ec73f6c0f0,[Données non publiées],Rectorat enseignement privé [Données non publiées],Enseignant,
+f08ecbf0-f95d-4a05-b162-15c73ea41265,[Données non publiées],Conseil de l’Ordre des médecins,[Données non publiées],Retraitée active [Données non publiées]
+f0aa7bfd-dd80-461a-9663-3f3ccd23d8c0,[Données non publiées],[Données non publiées],retraitée,
+f0b21233-61e1-4105-9f1b-ed2a9f032ab8,[Données non publiées],les Talens lyriques,[Données non publiées],
+f0b572b8-b2b8-4289-b3a3-eae0675a0498,[Données non publiées],CLS_EVENT,COMMERCIALE,
+f0db53cf-4143-4434-bdfb-b89c813dfc50,[Données non publiées],EPLEFPA [Données non publiées],animateur financier,
+f0dbef4f-6591-4668-96ee-c9baf66cfe79,[Données non publiées],Mairie de FAA'A,Agent municipal [Données non publiées],
+f0dce9cc-e1b7-4158-957b-46e85bd629c0,[Données non publiées],MAERSK FRANCE,EMPLOYE DE CONSIGNATION,
+f0e459c8-9981-4516-aa1d-105d6359d2da,[Données non publiées],[Données non publiées],"Etiopathe, activité libérale",début de l'activité en juin 2021
+f0e70a86-3de0-47d0-886c-d198af59187d,[Données non publiées],[Données non publiées],Collaboratrice parlementaire,
+f103e7fc-e6ed-492e-8ead-0136fdfaea72,[Données non publiées],retraitée,aucune,[Données non publiées]
+f10bee2c-2b40-4957-959d-725899d7e7ab,[Données non publiées],activité libérale,médecin généraliste,
+f1101e3d-f3c7-4aa9-99cc-0ba27e5c0f07,[Données non publiées],Néant,Néant,
+f1114334-17bd-4b2d-bfc8-3ea9ecb758e1,[Données non publiées],Etat,Retraitée,
+f113c911-d27b-4f31-a073-8a2ac4d4ba8c,[Données non publiées],Avocate/ Centre de Formation,AvocateEnseignante,
+f11439d9-3acf-4d47-be48-298becbe045a,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+f11788c0-f3ad-4d41-81c0-ab16855ddb5f,[Données non publiées],SDIS 35,[Données non publiées],[Données non publiées]
+f118f70f-4463-4aba-9c68-c84a749f88dd,[Données non publiées],A titre libéral,Kinésithérapeute,
+f11bbcf9-4df0-4097-af6c-5276c73a76c9,[Données non publiées],France Travail,Conseillère en Gestion de Droits,[Données non publiées]
+f124eaea-7681-43b5-9a6c-e1b700b794f4,[Données non publiées],SARL SOLUTEC,[Données non publiées],
+f124eaea-7681-43b5-9a6c-e1b700b794f4,[Données non publiées],GMO,[Données non publiées],
+f13ed3e7-3d2f-44a8-a15d-f690fc0c57cd,[Données non publiées],Action Logement,Directrice générale [Données non publiées],
+f13ed3e7-3d2f-44a8-a15d-f690fc0c57cd,[Données non publiées],Conseil Régional Grand-Est,Vice-Présidente,
+f1401c69-6097-485b-ada5-1362d415cec6,[Données non publiées],néant,néant,retraitée
+f150af7e-997a-4ae9-9b5d-b3a3fdc90bd4,[Données non publiées],néant,retraitée,
+f1529d59-44cf-4e81-abc7-e45a670c7859,[Données non publiées],Société Générale,Cadre supérieur [Données non publiées],
+f15d1849-2e08-4017-8362-7dc7766c93e4,[Données non publiées],PHARMACIEN,GERANT DE PHARMACIE SELARL DU MARAIS,
+f15f21c1-8e91-467b-a587-2fde10ae89f0,[Données non publiées],VEOLYS,Assistante de Développement Informatique,
+f160eb51-740d-4f8e-902e-e8ccd9fd1ca5,[Données non publiées],auto-entrepreneur,chauffeur-taxi,
+f1659d11-db0a-4ebe-8f56-138dc37937cf,[Données non publiées],VEOLYS,Assistante de Développement Informatique,
+f1670298-40fe-4444-9b75-a0fe7fd53223,[Données non publiées],EFS [Données non publiées],Opérateur PAO,
+f1757911-70ff-4e2f-92f8-b138dd3178d5,[Données non publiées],SELARL D INTORNI MESNIL CHARPAIL,gérant société avocat,
+f179d226-360a-40c6-bf68-339db8e380f6,[Données non publiées],Conseil départemental de la Haute-Loire,Médecin [Données non publiées],
+f180eaa5-fa62-4eea-9497-307250ea0f41,[Données non publiées],ministère de la justice,Juge,
+f1827f34-bc58-44d4-b646-b084a8dcf159,[Données non publiées],Néant,Néant,
+f1849039-e3a2-44eb-bc3d-ee8a8c27c9af,[Données non publiées],Néant,Néant,
+f1880c8b-6c1b-443f-9a96-e576ffe2973c,[Données non publiées],Libérale,Infirmière libérale,
+f18f1e23-0a28-4f05-88aa-96317be43ea4,[Données non publiées],Ministère de l'Education Nationale,Professeur des écoles,
+f190460b-d87d-4b5d-982d-70ec52cc39e9,[Données non publiées],Éducation Nationale,Principale-Adjointe [Données non publiées],
+f19110d1-1f86-4b56-93ba-238f3fae4d87,[Données non publiées],CHU [Données non publiées],Infirmier Diplômé d'Etat,
+f1919345-5fde-403c-aeba-c74c6c5d61f6,[Données non publiées],Groupe Lamotte,[Données non publiées],
+f19195d7-9770-4ccb-86dd-248db560b909,[Données non publiées],SELARL D INTORNI MESNIL CHARPAIL,gérant société avocat,
+f19807fb-9e9d-4a23-a31c-df34e6240d17,[Données non publiées],Crédit Mutuel Arkéa,Responsable de service [Données non publiées],
+f1a34087-381b-4f83-a1cc-c995e634b3dd,[Données non publiées],[Données non publiées],[Données non publiées] retraite,
+f1ac9e54-0f94-4924-9d31-c20a91918ac3,[Données non publiées],Sans emploi,[Données non publiées] [Données non publiées],
+f1b1796c-e6c6-4f7e-823f-f3b7f259522d,[Données non publiées],Néant,Néant,Néant
+f1b1c095-bad8-43df-a352-c9d6bce24157,[Données non publiées],Education nationale,Professeur des écoles,
+f1b7e7a3-73c8-4d71-8e13-f20cf2a2fc9a,[Données non publiées],[Données non publiées],Imprimerie,
+f1bb7a28-ac1b-4957-bdb8-fb27051365ad,[Données non publiées],AFD,Directeur exécutif adjoint,
+f1c226f5-f0fc-41cc-bd2c-15fc8f68e1e9,[Données non publiées],Association [Données non publiées],Cadre RH,
+f1cc58bb-64cb-49fb-a880-409b0268c04c,[Données non publiées],Design Concept [Données non publiées],Agencement d'intérieur,[Données non publiées]
+f1cdd924-43a6-4ab9-9995-342cc3763c89,[Données non publiées],[Données non publiées],[Données non publiées] [Données non publiées] Retraité de l'éducation nationale.,[Données non publiées]
+f1dd05d2-a756-4498-b663-f584dc696cbd,[Données non publiées],neant,exploitante agricole,
+f1dd05d2-a756-4498-b663-f584dc696cbd,[Données non publiées],neant,exploitante agricole,
+f1e4cc04-b05a-43bf-b0d4-cd2906cae607,[Données non publiées],SMDIS,[Données non publiées],
+f1e565e8-9464-405a-8c73-ecb599cc1e9e,[Données non publiées],éducation nationale,professeur des écoles,[Données non publiées]
+f1e59210-5609-46c7-a168-89a0d3cb748d,[Données non publiées],mairie [Données non publiées],DGA,
+f1fcfc4f-9d27-43f2-9261-c44993b7cbce,[Données non publiées],FMI,Responsable qualité,
+f1ff49a6-8435-4bd4-b675-1ef0e2cf1dea,[Données non publiées],MAIRIEdeDRAGUIGNAN,[Données non publiées],
+f205f9f4-9bd2-4495-b723-3e5b063ad8ba,[Données non publiées],Initiative Terres d'Azur,Directrice.,
+f214691c-61bb-4e6e-870e-c5de960bde56,[Données non publiées],LABORATOIR [Données non publiées],Technicienne de laboratoire d'analyses médicales,
+f217feb6-3b24-4b5f-bfbd-0fa288ad8d79,[Données non publiées],ministère des armées,Commissaire des armées,
+f21db9ed-f17d-4c6d-9b62-b2adf8e2e812,[Données non publiées],S.C.M.S,Assistante [Données non publiées],
+f223da9b-00f9-4f3b-90e1-7b84cb297415,[Données non publiées],aucun,retraitée,retraitée
+f2272bef-2894-4511-b3f8-9177deff7992,[Données non publiées],gims,med du travail,
+f228673c-e241-407a-867e-257c3d8ddbfa,[Données non publiées],Maison de la Jeunesse et de la Culture [Données non publiées],[Données non publiées],[Données non publiées]
+f2299574-e4f0-4cc2-82fb-9bc2b4d884a7,[Données non publiées],[Données non publiées],Gérant de la SARL,
+f22f7a18-d44f-4a95-951b-a6aa85c5d69d,[Données non publiées],NEANT,NEANT,
+f2333935-679d-40ea-93bb-683b8d28aac1,[Données non publiées],BOUCHERIE [Données non publiées],SALARIÉE DEPUIS 2005 PUIS COGÉRANTE DEPUIS LE 1ER MARS 2021.,
+f234fbff-bb0e-4309-8d85-eb1053c5a2ce,[Données non publiées],NORAUTO,VENDEUSE,
+f23e5d96-3e53-414b-bfa1-5d904b5cf298,[Données non publiées],Lycée professionnel agricole [Données non publiées],Professeur,
+f250a2e7-ee58-4a4d-8ceb-3c804bca600f,[Données non publiées],HATVP,Chargée de mission [Données non publiées],
+f255bc33-e1f9-4728-9553-17edf9ef2e04,[Données non publiées],ENTREPRENEUR INDIVIDUEL,PSYCHOLOGUE CLINICIENNE,
+f2636f13-b946-4226-a965-a4ba1d72257d,[Données non publiées],Néant,Néant,
+f268ec77-e711-4162-8b62-0743af05c5e7,[Données non publiées],[Données non publiées],journaliste sportive,
+f279361f-0a95-405b-8889-72b6a1f08d19,[Données non publiées],NEANT,NEANT,[Données non publiées]
+f27c519e-5a02-4901-9638-cf930fa52923,[Données non publiées],[Données non publiées] [Données non publiées],USINE PATE A PAPIER,
+f27f3eec-292a-4145-b1d8-bd1f9386c2c5,[Données non publiées],Néant,Néant,
+f2893a91-0b56-4bb0-bd59-a1a4758a386c,[Données non publiées],Allianz Finance Conseil,Conseiller en Gestion de Patrimoine Certifié,
+f293767c-9ead-4496-b7da-1192db7611b1,[Données non publiées],retraité,retraité,
+f293767c-9ead-4496-b7da-1192db7611b1,[Données non publiées],retraité,retraité,
+f294f21f-8516-42e0-a6c3-9b0abb75bbf6,[Données non publiées],NEANT,NEANT,CO GERANTE [Données non publiées] DE 2018-2020
+f2975adc-1c8a-4c91-9938-da12d8eacd13,[Données non publiées],mairie [Données non publiées],adjoint technique [Données non publiées],
+f2a1530c-63d3-48c3-bda0-5baae71e7d2e,[Données non publiées],NEANT,NEANT,[Données non publiées]
+f2a46393-6220-465c-8be5-f68886a4e827,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+f2ad6ff0-88d7-402f-98a2-48bc0ae83ec4,[Données non publiées],Maria Farinha Films,Production cinématographique,
+f2b31cc4-9380-41d6-bfc2-febe8aff3357,[Données non publiées],COALIA,[Données non publiées],
+f2bade5f-3ba1-4900-89ba-f8b99069f3e7,[Données non publiées],[Données non publiées],CHARGÉE DE MISSION RH [Données non publiées],
+f2bed167-d67f-42f9-8d6c-c33e4fc1df69,[Données non publiées],SARL [Données non publiées],Assistante de direction,
+f2c87ffa-3139-498d-b0fe-b9992a25d53f,[Données non publiées],département du nord,responsable [Données non publiées],
+f2cac6da-740c-4864-85af-209438682750,[Données non publiées],[Données non publiées],Huissier de Justice,
+f2cb614d-9cca-4ac8-a73b-f5c988b5a656,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+f2cb614d-9cca-4ac8-a73b-f5c988b5a656,[Données non publiées],SASU ACITI,Présidente [Données non publiées],[Données non publiées]
+f2d9f470-083b-42fa-b207-6d50bccf0b6a,[Données non publiées],Université [Données non publiées],professeur,
+f2e3301b-a4ed-429f-8903-69821e0e2a6b,[Données non publiées],Innothera,Directrice [Données non publiées],
+f2e3ea30-f980-4a37-9dc1-c5005ff1300e,[Données non publiées],[Données non publiées] [Données non publiées],CLERC DE NOTAIRE,
+f2f511e2-8af7-4d11-b1ae-d21a5d02854b,[Données non publiées],Independant,Kinésitherapeute,
+f2f8dd94-5a76-4dc1-ac28-70d7f8ced405,[Données non publiées],Ville de Forbach,Directrice de la Communication,
+f3031d67-76bd-43cb-bca2-4f5773b78e13,[Données non publiées],Airbus defence and Space,Directeur [Données non publiées],
+f31f0bf4-6b32-461e-8f1f-c4002673e350,[Données non publiées],snc [Données non publiées],gerante bar tabac,
+f331b558-cad5-4604-ac77-b8b9d20cedff,[Données non publiées],Retraitée,Retraitée,
+f33917f9-2898-4a89-9c8c-d2d9e5f7099d,[Données non publiées],CCAS [Données non publiées],Directeur de crèche,
+f3498da4-61bb-47a9-a114-3a8cf50202eb,[Données non publiées],[Données non publiées],Architecte,
+f3552949-7ed5-41b4-9a94-5b4b7d3a7ffe,[Données non publiées],Mairie de Pont-Sainte-Marie,Fonctionnaire,
+f3560552-ed55-4707-ab09-5aff7e5680d9,[Données non publiées],General Electric,Senior Vice President [Données non publiées],
+f363808a-cf3f-4265-9542-83023c4f6c7f,[Données non publiées],[Données non publiées],Directeur de la Société,
+f363808a-cf3f-4265-9542-83023c4f6c7f,[Données non publiées],[Données non publiées],Membre du comité des actionnaires,
+f363808a-cf3f-4265-9542-83023c4f6c7f,[Données non publiées],[Données non publiées],Membre du comité stratégique,
+f363808a-cf3f-4265-9542-83023c4f6c7f,[Données non publiées],[Données non publiées],Membre du comité des actionnaires,
+f363808a-cf3f-4265-9542-83023c4f6c7f,[Données non publiées],[Données non publiées],Représentant,
+f363808a-cf3f-4265-9542-83023c4f6c7f,[Données non publiées],[Données non publiées],Membre du Comité de sélection,
+f363808a-cf3f-4265-9542-83023c4f6c7f,[Données non publiées],[Données non publiées],Actionnaire,
+f363808a-cf3f-4265-9542-83023c4f6c7f,[Données non publiées],[Données non publiées],Actionnaire,
+f3661d66-22a2-406d-96d2-e46add1b0e02,[Données non publiées],Mairie de FAUCON [Données non publiées],Secrétaire générale,[Données non publiées]
+f368a246-9919-4d52-b686-1cc6f62ee939,[Données non publiées],[Données non publiées],Gérant de la société,
+f368fe2d-01d6-4c10-a8dd-ecd1bc5d7d07,[Données non publiées],[Données non publiées],COURTIER EN PRET IMMOBILIER,AUTO ENTREPRENEUR
+f375573e-7907-48d1-936b-dc6488e12ed3,[Données non publiées],SCEA [Données non publiées],Exploitante agricole,Associée exploitante sur l'exploitation [Données non publiées]
+f375573e-7907-48d1-936b-dc6488e12ed3,[Données non publiées],SCEA [Données non publiées],Cogérante,Cogérante sur l'exploitation SCEA [Données non publiées]
+f37af085-a407-49fa-9bb6-8a2e71dc151d,[Données non publiées],Département_de_l'Essonne,[Données non publiées],
+f38337e5-79b3-4a51-bec6-acb04703b5d5,[Données non publiées],[Données non publiées] société CEBORG,Commerçante dans l'habillement,
+f384150f-0bb2-4e9e-81f6-fcf92b7ff41f,[Données non publiées],CHU GUADELOUPE,[Données non publiées],
+f387b65d-2c87-4d5a-93f3-297ac1dc2af4,[Données non publiées],earl [Données non publiées],agriculture,[Données non publiées]
+f38c3559-2217-4009-b12b-f7aeea79590f,[Données non publiées],Polyclinique Navarre,Infirmière,
+f3903f06-51e7-4bf6-a671-35548d3d1a5c,[Données non publiées],EARL [Données non publiées],co gérante,
+f3ac08f4-087a-489d-9d47-189de514cc42,[Données non publiées],ANSES,[Données non publiées] Membre du comité exécutif de l'ANSES,
+f3b2fae8-a390-4148-829a-e43f51ff899e,[Données non publiées],Neant,Artisan jardinier,ARRET DE L ACTIVITE [Données non publiées]
+f3bab46f-ada3-4a8b-a591-028f34878b70,[Données non publiées],cr occitanie puis cd 31,[Données non publiées],[Données non publiées]
+f3c03dc8-646a-4b45-a3c2-e0b4ce509540,[Données non publiées],Ministère de l'Education Nationale et de la Jeunesse,Inspecteur [Données non publiées],
+f3c1eadc-bed1-4482-9616-14e9e5588d77,[Données non publiées],AHM,Dirigeant de l'entreprise [Données non publiées],
+f3c594e6-90d9-4e93-aebf-8e215aa0c330,[Données non publiées],SARL [Données non publiées],Assistante de direction,
+f3d2500b-9e85-44c1-a4e1-54c92f321044,[Données non publiées],Présidence de la Polynesie Française,Comptable,Fonctionnaire de la fonction publique territoriale Séparés
+f3d3bba4-3752-4928-8eef-7575e63b5c43,[Données non publiées],Transdev [Données non publiées],Directeur des Ressources Humaines,
+f3d6eefd-c60e-4897-9073-2107b19cb705,[Données non publiées],WILL&CIE,Evénementiel professionnel Accompagnement en stratégie de communication Formation en relations publiques,cessation d'activité au 30 juin 2021/ [Données non publiées]
+f3d6eefd-c60e-4897-9073-2107b19cb705,[Données non publiées],Dialogues et Solutions,salariée depuis le 1er avril 2021,
+f3dd297b-29dc-4399-b43c-485b8680b89f,[Données non publiées],FranceTV,[Données non publiées],
+f3f2a11a-317b-476c-9469-68cf566f2a2c,[Données non publiées],Retraitée Airbus Group,Néant,[Données non publiées]
+f3f512d0-671d-4d13-a112-e424d7eceee9,[Données non publiées],Retraité,Néant,
+f3f71b82-80a3-4b21-a3bc-b9dd6cd9bab1,[Données non publiées],Mairie de Draveil,Retraitée,
+f3f99ec0-58c5-435c-ac33-e72f02fd4d33,[Données non publiées],AKZO NOBEL DECORATIVE PAINTS FRANCE,Responsable [Données non publiées],
+f3fdf731-4936-4761-9507-1da62a705022,[Données non publiées],CNRS,Ingénieur d'études,
+f40993c6-d353-4165-8d0a-793a00e439b0,[Données non publiées],UDAF [Données non publiées],MANDATAIRE JUDICIAIRE A LA PROTECTION DES MAJEURS,[Données non publiées]
+f40eac36-59d2-4899-b173-3d5f3d508ee1,[Données non publiées],Education nationale,Enseignant,
+f4116edd-3d33-4b0f-96a3-9fb6689550e1,[Données non publiées],Nexans Power Accessories France,Product Line Manager : [Données non publiées],
+f41856fd-753a-4607-bc29-7376c44b063a,[Données non publiées],Assemblée de la Polynésie Française,Représentant,
+f41856fd-753a-4607-bc29-7376c44b063a,[Données non publiées],Sénat,Sénatrice,[Données non publiées]
+f41b1701-1c3c-43b3-961a-042fe5c84b32,[Données non publiées],SARL MAGASIN MAEVA,épicerie [Données non publiées],
+f41b1701-1c3c-43b3-961a-042fe5c84b32,[Données non publiées],PENSION [Données non publiées],Pension de famille,gérante et propriétaire
+f42049cd-b76d-44bc-8ee7-b501f5f09cca,[Données non publiées],Korian [Données non publiées],DIRECTRICE RÉGIONALE ADJOINTE [Données non publiées],
+f422d4db-ad56-4d9a-9fb6-15c1d9703ac0,[Données non publiées],RETRAITE,[Données non publiées],[Données non publiées]
+f422ecf9-1186-44ad-b09f-c165e486f479,[Données non publiées],Retraité,[Données non publiées],
+f428d45c-f5d2-40bd-9bff-74ae820bb0cc,[Données non publiées],Ecole d'Ingénieurs [Données non publiées],Enseignant - chercheur,
+f42a6d82-1364-4809-8966-380b28e323b3,[Données non publiées],kingfischer,Acheteuse bois [Données non publiées],
+f434a20f-d98b-450c-b31a-21400c7ca00b,[Données non publiées],Tout en Vélo Grenoble,Dirigeant,
+f4397aa0-fc26-40be-b46a-122556c3b0e7,[Données non publiées],Fédération française handisport,[Données non publiées],
+f4397aa0-fc26-40be-b46a-122556c3b0e7,[Données non publiées],Dirigeant,SASU [Données non publiées],[Données non publiées]
+f43acc6e-23e2-4a59-9270-f606d8ab773a,[Données non publiées],SAS [Données non publiées],MANDATAIRE immobilier,mandataire
+f4469c9d-cb9c-4403-812c-19c9bd38c811,[Données non publiées],Education nationale,Professeur des écoles,
+f44feb79-c347-4482-99b6-dc39f3569034,[Données non publiées],Education Nationale,Enseignante,
+f450b883-5d01-40ba-870a-3ec2a1cb8674,[Données non publiées],Unec [Données non publiées],Secretaire générale,
+f451228b-3913-463a-8aa3-9d523ebb2b85,[Données non publiées],LIBERAL,MEDECIN GENERALISTE,
+f4567448-9e8d-4cf4-8c92-853e56976192,[Données non publiées],cabinet dentraire Mignot,Secrétaire médicale,[Données non publiées]
+f45e5e5f-60d2-4277-be28-941232ccc1db,[Données non publiées],RETRAITE,NEANT,
+f4644728-b16f-44ec-a670-f6e7bf0b43a6,[Données non publiées],EDUCATION NATIONALE,PROFESSEUR CERTIFIÉE STG BTS,[Données non publiées]
+f474f92c-635b-4d4e-9bf5-104d3d72189a,[Données non publiées],retraité,retraité,
+f478661e-55d1-4da1-a343-cee111aedd13,[Données non publiées],CCAS Ville de Paris,Attachée territoriale - Direction de la solidarité,
+f478e003-8469-4086-860c-375165d847c7,[Données non publiées],Néant,Retraitée,Retraitée
+f478e003-8469-4086-860c-375165d847c7,[Données non publiées],Neant,Retraitée,Retraitée
+f478fa4b-f95b-4338-8dd3-b92fd5dc52d6,[Données non publiées],agriculteur exploitant,AGRICULTURE BIOLOGIQUE,Pas de rémunération
+f47ada16-a238-4fd3-8b1e-dce901d6a1e4,[Données non publiées],[Données non publiées],"auto entrepreneur, conseil, vente",
+f4850b05-3b31-4e08-81cf-eb8a9059505f,[Données non publiées],SANS,AUCUNE,[Données non publiées]
+f48af7cc-8f70-4c20-ae47-01597be94c8b,[Données non publiées],Education Nationale,Professeur des écoles,
+f48db79a-6149-480e-a83c-db2a9f8b125b,[Données non publiées],Ministère de la Défense,Militaire de carrière,
+f4900a8f-491b-4ca5-94b5-129de6825219,[Données non publiées],AEP ND du Mont Carmel,Institutrice,[Données non publiées]
+f491c446-f945-49ca-882f-9ac722d25fae,[Données non publiées],BANQUE POPULAIRE DU SUD,CADRE DE BANQUE,
+f49399c1-ff88-405e-8aec-6b0dfe1b9d45,[Données non publiées],Assemblée Nationale,Député [Données non publiées],[Données non publiées]
+f4a59919-ad9b-4d29-9f73-84cabb7db4fd,[Données non publiées],Education nationale,Professeure des écoles,
+f4aa86d2-15f9-4b20-a1ac-538fbdab93a5,[Données non publiées],commerçante indépendante,Fabrication de pain et gâteaux bio et négoces de produits régionaux,
+f4b1941d-16dd-432e-9d79-6823869cb0c9,[Données non publiées],Néant,Néant,
+f4bc8aee-e55b-4d39-92e0-afea598e3396,[Données non publiées],AIES,directrice adjointe d'ESAT,
+f4d05200-b5a6-4577-bf80-9e00e95499b6,[Données non publiées],fromagerie [Données non publiées],commerciale,
+f4d44192-dfbe-4080-9be6-66bab9022c2e,[Données non publiées],[Données non publiées],néant,[Données non publiées]
+f4e0fba9-432e-436d-b121-b616aab9b762,[Données non publiées],ARKEMA,[Données non publiées],
+f4ed549c-f3dc-42e0-92f9-78f9c0f5f4e7,[Données non publiées],retraité,retraité [Données non publiées],
+f4f296a8-be32-43cd-816b-2199392f9ec6,[Données non publiées],HYPER SOREDECO SA [Données non publiées],EMPLOYEE DE COMMERCE,[Données non publiées]
+f4f5b807-0694-4b8a-b13b-5101f20ff7ae,[Données non publiées],[Données non publiées],magasin de vetements,responsable salariee
+f4ff0240-910c-4f33-9228-7b54f40c2f5a,[Données non publiées],CYCLIFE France SA,CHARGE D'AFFAIRE MAINTENANCE,
+f5019216-9d87-4609-b9d9-0209e2f0a9be,[Données non publiées],sasRemi,technicien,
+f507700f-c329-4bab-b629-c1a0e8cae2ec,[Données non publiées],[Données non publiées],RAS,RAS
+f50c075b-62f8-48ef-89ae-fa5db471fecb,[Données non publiées],[Données non publiées],Artiste,
+f51168e4-b22a-46d1-b4f0-cbb6edaaee9a,[Données non publiées],CPAM [Données non publiées],[Données non publiées],
+f5185004-cd16-4fe8-a1de-bf38aa4cf40a,[Données non publiées],[Données non publiées],[Données non publiées],En retraite [Données non publiées]
+f51c8c5e-ee89-4870-a039-274347dfe33a,[Données non publiées],CPAM de l'Eure,[Données non publiées],
+f52f7dac-3f68-4ce4-b37d-c73c96d8481d,[Données non publiées],néant,néant,
+f5359eba-d719-4272-aaaa-8e125e9f1e7e,[Données non publiées],Néant,Retraitée,
+f53d545d-37f7-470f-94da-42ed4a668683,[Données non publiées],Néant,Néant,
+f53db226-a67c-4ab0-a352-cef10e84630b,[Données non publiées],RETRAITEE,Néant,
+f53e7828-ea06-4928-850b-e321a5206045,[Données non publiées],SYCTOM,Chargé de mission,
+f5442b2f-c151-4071-afa1-3fc4ecc3d268,[Données non publiées],[Données non publiées],technicienne de laboratoire,
+f55ab453-6093-4792-a15a-f0b0937c69d6,[Données non publiées],France Télévision,Journaliste,
+f55b91c5-5790-4ea4-856b-0324e922684b,[Données non publiées],Néant,Néant,Retraité
+f57da4b7-4ef2-4252-94a1-df52e1d2f890,[Données non publiées],Etat,Retraitée professeur des écoles,
+f57f4e75-ef26-4654-b13d-b9c237012f6e,[Données non publiées],Néant,Retraité,
+f5831663-2320-40f8-87d8-4e69c6c25585,[Données non publiées],Conseil Départemental du Pas de Calais,[Données non publiées],
+f5831663-2320-40f8-87d8-4e69c6c25585,[Données non publiées],[Données non publiées],RETRAITEE,[Données non publiées]
+f586a2b6-49cb-415e-9641-f2d5e9c7877b,[Données non publiées],néant,néant,
+f58aa9bd-fd3a-447e-a39a-00028c6bf850,[Données non publiées],Ministère des Armées,Chargé d'études documentaires,[Données non publiées]
+f58e88f3-cb01-499e-a80e-87165b51ef7b,[Données non publiées],Universite [Données non publiées],Maitredeconférences,
+f59b9806-8c6d-4baf-acaf-245eaa65286a,[Données non publiées],neant,neant,
+f5b2dbec-05ae-46e6-9132-bcb55db947e2,[Données non publiées],[Données non publiées],retraitée,[Données non publiées]
+f5ba405c-2ffe-4744-8531-8a3a887083eb,[Données non publiées],[Données non publiées],Gérant de la société,
+f5bad976-688d-41b4-959b-cb6e13f8107a,[Données non publiées],ADI KALFA,Mécanique de précision chargé d etablir les prix des pièces à usine,[Données non publiées]
+f5bb0347-c3b6-48ea-b9cd-f5701259cdd5,[Données non publiées],Métropole de Lyon,Responsable du service [Données non publiées],
+f5c436bd-e187-40df-916b-8ff91bdc8727,[Données non publiées],SA [Données non publiées],DIRECTEUR GENERAL,
+f5c7da28-4900-4314-96f1-6adceb032e29,[Données non publiées],CPAM,Responsable d'un Centre de Prévention et d'Examens de Santé,
+f5cb3b5c-da5e-4029-b80d-f2bcdd612339,[Données non publiées],néant,retraité,
+f5cb8569-4120-4e83-aadb-030cf8eb6100,[Données non publiées],[Données non publiées],emploi familial,
+f5cb8569-4120-4e83-aadb-030cf8eb6100,[Données non publiées],[Données non publiées],emploi familial,
+f5cb8569-4120-4e83-aadb-030cf8eb6100,[Données non publiées],[Données non publiées],emploi familial,
+f5cb8569-4120-4e83-aadb-030cf8eb6100,[Données non publiées],[Données non publiées],emploi familial,
+f5cbadd3-753d-49a3-8e3b-4b18c8c57c9a,[Données non publiées],Education nationale,Professeur certifié d'histoire géographie,
+f5ccc189-27e6-4f29-ba3c-e64229a85462,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+f5d4351f-ab95-4df3-a844-8e16b2c9cdda,[Données non publiées],CROIX ROUGE,[Données non publiées],
+f5d61607-2d2b-4dea-b273-7301c7e5bb0e,[Données non publiées],SARL FAMILLE HAULLER,commerce de vins,secrétaire comptable
+f5d96801-a888-4100-85d1-fb191abf24af,[Données non publiées],PGA Associés,[Données non publiées],
+f5e7cf2a-5e63-48cf-a204-195b2c7fc4ce,[Données non publiées],scp infirmieres,infirmiere liberale,
+f5ef43b4-b4b0-4d60-a8fa-331b2c22743a,[Données non publiées],Caisse d'Allocations Familiales,Assistante Sociale,
+f5f52e19-4c23-4044-aa1f-b3f927b1674a,[Données non publiées],VILLE DE LYON,Fonctionnaire territoriale [Données non publiées],[Données non publiées]
+f5f59291-5d9b-403f-bf28-504123812dce,[Données non publiées],FCSM,[Données non publiées],
+f5f8031a-536a-4954-ab56-bbc79db77e9e,[Données non publiées],Travailleur indépendant,conseil en communication scientifique et journaliste,
+f6055f5c-1245-44a9-beb5-aecb4d81047e,[Données non publiées],néant,néant,
+f60645b3-52cb-4bc6-9c41-b11bf17a755a,[Données non publiées],LINKT,Développeur informatique,
+f60bf93d-50d7-4a84-93fe-3f9919b98079,[Données non publiées],Nexans Power Accessories France,Product Line Manager : [Données non publiées],
+f60fbf9e-0b6e-4833-8a75-c25f6d4eae89,[Données non publiées],lui même,journaliste Président et directeur du journal Le petit mag Lens Liévin exploitant agricole [Données non publiées],[Données non publiées]
+f61177ad-e5cb-47e0-95dc-bd0bdc3f983d,[Données non publiées],EDUCATION NATIONALE,Professeur d'histoire et géographie,
+f61510bf-d3ba-49f8-a149-c14d11e6869d,[Données non publiées],Sciences Po Paris (enseignante) / Conseil régional Auvergne-Rhône-Alpes (Conseillère régionale) / Université [Données non publiées] de Marrakech (Professeure affiliée) / Raisons sociales (Cabinet de consultants Présidente fondatrice),[Données non publiées],
+f6258605-cddd-49b2-9566-edb8012edfd3,[Données non publiées],province nord,collaboratrice,
+f6281dd7-3575-48f1-a364-31ca16022638,[Données non publiées],GERANT,gérant d'une société dans la restauration (brasserie traditionnelle),
+f62bee91-1cf8-44dc-94ce-7793939a0901,[Données non publiées],ASSEMBLEE NATIONALE,DEPUTE [Données non publiées],
+f62bee91-1cf8-44dc-94ce-7793939a0901,[Données non publiées],SCEA [Données non publiées],GERANT,
+f6346c90-55a1-4bd9-b358-0f0f2b5ba1ba,[Données non publiées],Groupe CISN,[Données non publiées],[Données non publiées]
+f6382508-db3c-49ce-9183-521832990522,[Données non publiées],ministere de l'interieur,commandant de police,
+f642e4d0-b54a-498d-82a5-11b4d6e43fb2,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+f642eec8-2a90-4724-bd2d-c7a3c4f6f91c,[Données non publiées],Agentco,Agentcommercial,
+f659f126-e338-4031-9fc3-4e8ca016de14,[Données non publiées],Credit Agricole,Employée de banque,
+f66f1304-b2c3-48c3-9f2f-156945df6844,[Données non publiées],BPALC,[Données non publiées],
+f67e807f-8a45-4506-b3cd-b4bf6c8660d8,[Données non publiées],KINE en liberal,masseur kinésithérapeute,
+f68075c0-4d3d-45ac-8fe6-f36de3e6ace1,[Données non publiées],Education nationale,Enseignante,
+f685ed75-607a-4195-a5b3-331b4847f282,[Données non publiées],entreprise individuelle,Courtier en assurances de personnes.Commerçant et assimilés.,
+f6949ff3-c77e-4dab-8d68-0b5501abbf5b,[Données non publiées],Mairie [Données non publiées],Employée communale,
+f698cdfc-44cb-405c-a152-1450fc58332e,[Données non publiées],SARL POC,nautisme (courtage / contrats de location et commercialisation de bateaux),
+f6998ead-23c1-4bd7-8641-9fa49b56dc18,[Données non publiées],lui même,journaliste Président et directeur du journal Le petit mag Lens Liévin exploitant agricole [Données non publiées],[Données non publiées]
+f69b34e3-1849-4ccf-9479-2d596f96b60f,[Données non publiées],Education Nationale,Enseignante,
+f6a1b4ff-ca0d-4074-b8e2-8ec2d7da0e04,[Données non publiées],Bordeaux Métropole,directrice [Données non publiées],
+f6a80d35-8572-4f0c-8003-e5fdf7130786,[Données non publiées],GROUPE IGS,[Données non publiées],
+f6aaddd7-765f-4b50-b305-90d3e6163cfb,[Données non publiées],Retraité,retraité,
+f6b2559a-1de4-4431-8aac-6fbccd19f12c,[Données non publiées],thomine,attachée administrative,
+f6bb9c92-1be8-4296-9343-bc40bf438302,[Données non publiées],palais des congrès,directrice [Données non publiées],
+f6c6a6d2-505f-4b0e-8acd-c081fe5ddf34,[Données non publiées],Orange,Responsable marketing [Données non publiées],
+f6c7e88d-50c4-4cf4-b9b9-d75a563bd3ce,[Données non publiées],Micro-Entrepreneur,Agent Commercial dans l'immobilier.,
+f6ceafe7-5a92-4f2d-a9d8-566989f7a9ee,[Données non publiées],Auto-entrepreneure,"Photographe, réalisatrice de documentaires, agence artistique [Données non publiées]",
+f6d1a7af-144a-4426-8d3f-1da84b962e95,[Données non publiées],Néant,Néant,
+f6dd1555-cde5-4016-9715-538c44b1d649,[Données non publiées],Co-Gérant SARL Holding MOUTON,Fabrication/Vente Alimentaire [Données non publiées],[Données non publiées]
+f6e20da3-f033-4fc7-a77c-ab498f4568bc,[Données non publiées],Education Nationale,Professeur en lycée technique,
+f6e9ac9e-e4ce-4760-8f5a-d79e2273dce8,[Données non publiées],Groupe EVALIS,DGA [Données non publiées],
+f6f9b5c9-046b-4725-9821-d08aa7240dc2,[Données non publiées],STAG - Villers Bretonneux,Assistante administrative,
+f6fa27d3-5c10-466b-9b89-31e676189308,[Données non publiées],Ginger Burgeap [Données non publiées],Stagiaire ingénieur d'études [Données non publiées],
+f6fe2a55-03c8-4dee-b847-2e686e8a8a98,[Données non publiées],[Données non publiées],[Données non publiées],RETRAITEE
+f703324f-785c-4a00-a060-f74c2f083a26,[Données non publiées],Mairie de Vals les Bains,[Données non publiées],
+f7052d68-444b-4a70-8ec0-f2551f946b37,[Données non publiées],Office National des Forêts,Ingénieur,
+f7069aff-2bca-4ab5-b448-45d7b92e7158,[Données non publiées],Ministère de l’interieur,Gardien de la paix,
+f72189e3-3412-465e-92c0-6d9f5e3fd607,[Données non publiées],Autoentrepreneur,Vente de matériels de loisir (mobiliers extérieurs et matériels sportifs),
+f738c978-51f2-4c54-bbb2-7eccaa347810,[Données non publiées],[Données non publiées] ENTREPRISE INDIVIDUELLE,EXPLOITANTE AGRICOLE DEPUIS LE 01/01/2024 ET VDI CHEZ VORWERK FRANCE,
+f73a6936-5a8e-4cf4-822f-4deb04b58275,[Données non publiées],Education Nationale,professeur des écoles,
+f73cac6e-3ec6-49cb-843d-df891cc89968,[Données non publiées],Arlim Prestige,[Données non publiées] [Données non publiées] agent immobilier [Données non publiées],
+f74e5521-58e8-4bca-8e46-7eef6aced660,[Données non publiées],groupe saint vincent,chauffeur poids lourd,[Données non publiées]
+f74ee81f-ce40-4a0e-adc4-d49df5371db7,[Données non publiées],Dillinger Hutte Saarstahl,Conducteur de concasseur,
+f74eeda9-12d3-46b6-a084-72d00bd9cfa3,[Données non publiées],TNS,Commercante,
+f74f8090-fcaf-4131-b2a6-f3cc46fb69e9,[Données non publiées],PROFESSION LIBERALE,MEDECIN,
+f75826d5-88ed-44d9-b232-7e553456e3c1,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+f75826d5-88ed-44d9-b232-7e553456e3c1,[Données non publiées],Autoentrepreneur,Développement informatique,[Données non publiées]
+f7655194-1f16-4385-8f5e-1e2335432227,[Données non publiées],Ville de Strasbourg,[Données non publiées],
+f76745ac-e891-4f1b-bcae-76c11e223275,[Données non publiées],Néant,Retraité,
+f76cc12d-cb04-44b0-af15-637969c590c7,[Données non publiées],SEMC,Graphiste,
+f779f404-0f8c-4b56-8362-f24e08487cc7,[Données non publiées],commune de Donnery,Adjoint technique,
+f77b7c3f-8f5c-4edb-a35e-fb8be3922aba,[Données non publiées],Éducation Nationale,Professeur des écoles,
+f78d9156-1cfe-450d-81b1-e9097f6cd807,[Données non publiées],[Données non publiées],Président de la SAS [Données non publiées] . Statut de commerçant (bar à vin).,
+f7940348-63d6-47df-a9bf-d92a5253d475,[Données non publiées],Néant,néant,[Données non publiées]
+f7953e72-f078-4c51-830b-a5a215773817,[Données non publiées],Mairie de Montereau-Fault-Yonne,[Données non publiées],
+f79bed29-d7a6-4757-a0c7-8c8c950a174a,[Données non publiées],BIZLINE,Responsable régional [Données non publiées],
+f79c4efa-534e-481e-89c6-80c58ccf26e8,[Données non publiées],Ville de Dijon,Direction des Musées [Données non publiées],
+f7a2ae0f-f620-41f1-9234-a024f562f939,[Données non publiées],[Données non publiées],Directeur de maison de retraite,
+f7a2ae0f-f620-41f1-9234-a024f562f939,[Données non publiées],[Données non publiées],Gérant,
+f7ad8ed4-762c-4021-83e3-4e32455069a9,[Données non publiées],CYCLELIFE,CHARGE D'AFFAIRE MAINTENANCE,
+f7b033da-c75a-4433-8977-bea09f738fa8,[Données non publiées],EDUCATION NATIONALE,RETRAITEE,
+f7b29060-05d4-4181-b635-1b36df27f76a,[Données non publiées],[Données non publiées],Loueur meublé non professionnel [Données non publiées],
+f7ba83f7-e2df-4cc5-8cc5-a157064c8b3d,[Données non publiées],SNCF Voyageurs,Opérateur assistance,[Données non publiées]
+f7be71a4-e330-4fcd-a79a-ec4daebc1b74,[Données non publiées],Groupe Majorité CD 45,Collaboratrice [Données non publiées] [Données non publiées],[Données non publiées]
+f7c15b88-223e-4eca-bcb2-b190934681c9,[Données non publiées],MINISTERE DE LA JUSTICE,[Données non publiées],
+f7c552a0-7d11-4102-b8dd-d53174cc6abd,[Données non publiées],Etat,contrôleur du trésor public,
+f7d30600-3402-4892-82b9-6609d74cacfd,[Données non publiées],education nationale,enseignante,
+f7dc03b0-c7dc-42a3-8eb1-a6ddffa05011,[Données non publiées],Fédération Agirc-Arrco,Responsable des instances [Données non publiées],
+f7dcf935-5153-44b6-9a39-a4ffd56cea1d,[Données non publiées],Mairie de Montereau-Fault-Yonne,[Données non publiées],
+f7e14eda-49fd-4fcc-b044-fae73ce9567a,[Données non publiées],libéral,médecin généraliste,
+f7e2bb6b-3acd-4ea3-bdda-aacaabd138c0,[Données non publiées],néant,retraitee,[Données non publiées]
+f7e2c09b-302e-489d-83aa-40b6507b25f9,[Données non publiées],Ingefi,Expert-Comptable associé,
+f7f2943d-217b-4c6f-9e8e-3d629a13c496,[Données non publiées],Néant,néant,retraitée
+f7f9df00-a42d-4904-b6b6-2b62ba45fb2e,[Données non publiées],SICOLY COPY,VENDEUSE,
+f8064e10-ed2d-459d-a6f6-7d6266466e7b,[Données non publiées],REPUBLIC TECHNOLOGIES,[Données non publiées],
+f80908a9-67dd-44ea-a691-10b4490396f3,[Données non publiées],hôpital de Ribérac,cadre de santé.,
+f8190f06-3144-40e8-8de3-5e4620dfe041,[Données non publiées],SCP [Données non publiées],AVOCAT,DROIT DE LA FAMILLE
+f840cb7e-2224-4369-9990-48d54cb71800,[Données non publiées],CFA des universités de Centre-Val-de-Loire,Directrice [Données non publiées],
+f85dbbf4-93cc-4a21-913f-dfe651c15660,[Données non publiées],[Données non publiées],[Données non publiées] RETRAITEE,
+f86319af-fe13-417f-bb54-28820e3e50d1,[Données non publiées],GITE DE FRANCE 25,DIRECTRICE,
+f86afe1d-e14c-4b0e-8425-9274531320ad,[Données non publiées],[Données non publiées],Retraitée de l'Education Nationale,
+f88d41aa-ec50-4538-809e-73f8e4cac085,[Données non publiées],Lee Hecht Harrison France,"Consultante senior, salariée",
+f88f7ca8-7d94-480c-8dbf-106bc1887516,[Données non publiées],FREKENCES,Chef de projet [Données non publiées],
+f895eb61-524b-4ba1-a298-376a96a6f63a,[Données non publiées],neant retraitée,néant retraitée,[Données non publiées]
+f89bbfbc-8518-4301-b87d-711603dc4ced,[Données non publiées],Retraitée,aucune activité,
+f89dc370-1679-4161-8cfe-00ca608f6e2e,[Données non publiées],SARL SOLUTEC,[Données non publiées],
+f8a279bd-84fb-4ba4-9714-f94b57562cd2,[Données non publiées],agriculteur exploitant,AGRICULTURE BIOLOGIQUE,Pas de rémunération
+f8a2e122-6a09-44af-a347-5d37adba43f8,[Données non publiées],Education national,Professeur,
+f8b51e1c-277f-430b-ad9b-9006aa747973,[Données non publiées],Union mutualiste Enfance Famille Handicap Soins,Formateur Informaticien [Données non publiées],
+f8b6c66f-53aa-41bd-9423-e9772e117930,[Données non publiées],Centre hospitalier [Données non publiées],Aide soignante [Données non publiées],
+f8b6d6dc-b23b-4f7c-ac69-f60f13ff6a4b,[Données non publiées],[Données non publiées],[Données non publiées],retraité
+f8b72eb9-8d37-42ae-9ea8-54e28837e6cf,[Données non publiées],Education nationale,Professeur des écoles,
+f8bc7519-8ac0-470a-99c9-c287c92f7842,[Données non publiées],EDUCATION NATIONALE,ENSEIGNEMENT,
+f8be307a-d1a1-47d2-943b-f32dbd6b2bc6,[Données non publiées],Saint Michel Education,Chef d'établissement [Données non publiées],
+f8e21a02-07da-4a5e-8c4a-af8a737df306,[Données non publiées],Paris School of Economics,Conseiller politique [Données non publiées],
+f8e3896f-6c89-4731-8d56-9972af5eec22,[Données non publiées],NEANT,RETRAITÉ,
+f8e81b00-df2a-4295-8a7f-64315275b825,[Données non publiées],KPMG,"Manager, salariée",
+f8e84801-cf6e-41e7-8cbb-52a4452ad210,[Données non publiées],General Electric,Senior Vice President [Données non publiées],
+f8e84801-cf6e-41e7-8cbb-52a4452ad210,[Données non publiées],JPCR Conseil SAS,"Prestations de conseil pour sociétés industrielles et d'investissement, principalement dans le secteur de l'énergie",[Données non publiées]
+f906e747-9ff4-43a4-b9e5-342213c3e840,[Données non publiées],COLLEGE [Données non publiées],Professeur de français [Données non publiées],[Données non publiées]
+f90975c5-95fd-4df2-bc6f-a810bb6c7b70,[Données non publiées],[Données non publiées],Consultant,[Données non publiées]
+f90c0da9-cf7a-4de0-9084-33fd66a2052e,[Données non publiées],CNRS,Ingénieur d'études,
+f912e713-c40e-4d77-998f-0dbe6e209d55,[Données non publiées],TOTAL SA,Assistante de direction [Données non publiées],
+f91e0c85-c743-4240-8583-74f9b31bf6b8,[Données non publiées],retraité,néant,[Données non publiées]
+f9215c38-4599-4e7a-8882-3f2b75b5b61f,[Données non publiées],honewell aérospace [Données non publiées],responsable [Données non publiées],
+f92390f2-79c7-475d-8dc8-037a0279aee7,[Données non publiées],sarl [Données non publiées],GERANTE,
+f93307c9-9e7f-4537-8b90-96df752c817e,[Données non publiées],CAF,[Données non publiées],
+f9390a8b-f2c6-4973-aaa1-0c7b6051bb9f,[Données non publiées],Indépendant,Agriculteur [Données non publiées],
+f93b94dd-271e-4a1e-b2a5-47487edd3f51,[Données non publiées],Welt Hunger Hilfe,[Données non publiées],
+f951f4e1-c55e-43ed-83f3-2f8b4233c254,[Données non publiées],Domaine de fantaisie [Données non publiées],Association 1901 socio-culturelle [Données non publiées],
+f95e0ee3-e997-48c5-bc73-4c2bc63598d0,[Données non publiées],Auto-entrepreneur,Conseiller en communication [Données non publiées],
+f9620740-3dfe-4d99-b908-8a49d8658b35,[Données non publiées],ESMPI [Données non publiées],Infirmière psychiatrique,
+f96445d4-3a88-494c-8b1f-3a2462436e28,[Données non publiées],Ministère de la Justice,Fonctionnaire d'Etat de catégorie C,
+f974cf6c-1ab5-4fc0-8984-840f9604d346,[Données non publiées],Police Nationale,[Données non publiées],
+f974cf6c-1ab5-4fc0-8984-840f9604d346,[Données non publiées],Police Nationale - [Données non publiées],agent retraité,
+f974cf6c-1ab5-4fc0-8984-840f9604d346,[Données non publiées],POLICE NATIONALE,[Données non publiées],
+f97638d8-248a-48ca-8247-6572943d9bc9,[Données non publiées],Chef d'entreprise,[Données non publiées],
+f97c8f22-f678-41e1-bff5-fce297e4d689,[Données non publiées],retraitée,néant,
+f97d9308-0c7b-4feb-a460-a66d7f59ed9e,[Données non publiées],HP,Ingénieur [Données non publiées],
+f98285fd-0d4f-40ed-988a-603836ba339b,[Données non publiées],Néant,Néant,
+f98287a6-8a0b-4849-9e72-516184748156,[Données non publiées],Education Nationale,Professeur des écoles,
+f982cb49-d620-4558-834c-5ae36ff4ba7e,[Données non publiées],néant,retraité,
+f9867c28-16dc-4131-91cf-a0df9ca38dd4,[Données non publiées],RSM,CHEF DE MISSION,
+f98dfab0-7c00-4fb2-9eca-7e619638a3f8,[Données non publiées],CHUM de MARTINIQUE,[Données non publiées],
+f98fee91-bfea-4758-8a3c-d02bf78b33d2,[Données non publiées],SED,responsable technique en muséologie,
+f9993dd2-a93e-4b61-bfb1-a18da6221ade,[Données non publiées],Earl [Données non publiées],EXPLOITANTE AGRICOLE,[Données non publiées]
+f99d8462-ef02-4829-b02a-033519e17580,[Données non publiées],Université [Données non publiées],professeur,
+f99f268d-1269-4590-abb4-85e2cbfcee12,[Données non publiées],Société Dolmen,Responsable [Données non publiées],
+f99ffd87-ecf2-4c96-84f4-76bef8c2ad36,[Données non publiées],CEPAC,[Données non publiées],
+f9aac3db-0243-439c-b890-e7957aa99dd8,[Données non publiées],Education Nationale,Professeur,
+f9aecc80-8b99-4a4a-820a-506ba6e8f892,[Données non publiées],Ecoles Militaires de Bourges,Responsable du pôle [Données non publiées],
+f9b12cf6-463f-4dec-a1f8-4bd3819f1abc,[Données non publiées],Saint Michel Education,Chef d'établissement [Données non publiées],
+f9b4527a-a4da-4d20-9147-02641aa3d977,[Données non publiées],Pierre Cuypers,[Données non publiées] Exploitante agricole,
+f9b710b9-ae06-41e8-ab43-400c0a8b8c04,[Données non publiées],Erudis formation,conseiller en formation,
+f9be46a4-406d-4e7f-9e19-f474d77c231e,[Données non publiées],Education Nationale,Chargé de mission au Rectorat Départ à la retraite [Données non publiées],
+f9c892a0-f124-4f1d-a8e7-32ba6a998516,[Données non publiées],OT Engenery,Responsable Achats et parc matériel,
+f9e939e0-6f8f-4dbf-a69b-b4e794896475,[Données non publiées],Ministère de la Culture,Conservatrice du patrimoine,
+f9f311a2-6e1b-4e17-adec-edae888d6275,[Données non publiées],collége d artenay,enseignant [Données non publiées],
+f9f397da-e9aa-4be9-8015-cdd8a3ab2004,[Données non publiées],CARSAT,RETRAITE,
+f9f397da-e9aa-4be9-8015-cdd8a3ab2004,[Données non publiées],MAIRIE DE PORTES LES VALENCE,DELEGUE,
+f9f397da-e9aa-4be9-8015-cdd8a3ab2004,[Données non publiées],GARAGE PIETRI,DEPANNEUR,[Données non publiées]
+f9f40a2b-3850-46cb-aa2e-4ea0104ec815,[Données non publiées],sans,"Artiste, sculpteur",
+fa263ce0-b345-4df8-8628-9687d5a7a7c6,[Données non publiées],Education Nationale,Enseignante,
+fa287592-644b-468d-88b7-20a42747e286,[Données non publiées],Cherbourg en Cotentin,[Données non publiées],
+fa2ae980-e033-445c-b60b-08e213a36370,[Données non publiées],EARL DE DUGES,EXPLOITANTE AGRICOLE,commerciale en assurance à groupama d'oc [Données non publiées]
+fa2d86a0-c647-45dc-b73f-ca9bfcea667f,[Données non publiées],Néant,Néant,[Données non publiées]
+fa3a2b16-c76c-44f1-94a4-eb92b54d0ed6,[Données non publiées],[Données non publiées],directrice de crèche,en retraite [Données non publiées]
+fa3aafda-46a6-41c3-8bae-298ee3b64da1,[Données non publiées],AMEFO,[Données non publiées],
+fa42d148-c449-4c7b-a4a7-225b6ff7bad2,[Données non publiées],CAF de Loire Atlantique,Conseillère technique,
+fa44a7e1-62a5-4e78-88c3-1dd9469a2427,[Données non publiées],OGEC ESCR,Assistante de gestion,
+fa571c38-2981-405a-b3a1-5a7d73cb8624,[Données non publiées],retraité,aucune,
+fa5906be-9ba8-4fdb-a7d3-beabc729c508,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+fa6864c6-acce-4d8a-938b-464cf55186e5,[Données non publiées],LCL ANTILLES GUYANE,EMPLOYEE DE BANQUE CHARGE DE LA CLIENTELE DES PROFESSIONNELS,
+fa728704-f7f9-46d4-970a-9967f701cdcf,[Données non publiées],CPAM 93,Cadre de la fonction publique,
+fa750ddf-1f95-4fca-920b-856798de2ee8,[Données non publiées],Neant,néant,[Données non publiées] VGA omnisport [Données non publiées] l'association COBATY
+fa87936c-3c59-4b6e-b7f0-3964476514b7,[Données non publiées],Préfecture d'Indre-et-Loire,[Données non publiées],
+fa8a0fc4-4737-492a-87a7-a59dfeb0727e,[Données non publiées],[Données non publiées],[Données non publiées],Retraité [Données non publiées]
+fa8e5ce2-d594-495d-8cba-d9e4b78b8e3b,[Données non publiées],Groupama Méditerranée,[Données non publiées],[Données non publiées] retraite [Données non publiées]
+faa0eebd-8c5f-49ca-a7ed-b46d56e7c63a,[Données non publiées],sncf,agent en retraite,
+faa15d92-25c8-44fd-addc-4be2335b645a,[Données non publiées],neant,néant,Retraitée
+faa36e81-515a-4ccf-a959-6049127b5831,[Données non publiées],CHRU-Tours,[Données non publiées],
+fac942fd-0252-4948-86c1-227f0903fdb3,[Données non publiées],Neant,neant,retraité education nationale
+facdf0a1-d291-435e-8a26-9e04c2b338d1,[Données non publiées],MBDA,Cadre,
+fadad31f-fdcc-427b-a9a1-b76613dd198b,[Données non publiées],URSSAF [Données non publiées],inspecteur du recouvrement,
+fae27ca1-f455-464f-9a1f-27c04efde59d,[Données non publiées],PMM,[Données non publiées],
+fae499ba-c8a4-48ae-b939-523091f17ad8,[Données non publiées],Hôpital de Guise,Agent [Données non publiées],
+faed9e38-64ab-4e10-afcd-84b6ed9db591,[Données non publiées],Ministère de l'Éducation nationale,Principal du collège [Données non publiées],
+faef963a-b28e-4f85-a46e-d12fe17a36e4,[Données non publiées],Pharmacie [Données non publiées],Préparatrice en pharmacie,[Données non publiées]
+faf24c5f-13ad-4a77-b580-ceac69a15696,[Données non publiées],Ministere de l' économie et des finances - Ministerede l' action et des comptes publics,contrôleur général économique et financier [Données non publiées],
+faf753c0-515c-4033-854c-56decafb1135,[Données non publiées],néant,néant,retraité
+fafe9ffb-4b04-46fa-84f7-0a643c1cb1c5,[Données non publiées],EIPM,Business School,[Données non publiées]
+fb05e2c6-172d-4993-bce5-dcd9ffa2ec96,[Données non publiées],Ministère de l'Intérieur et des Outre-mer,Chargée de mission [Données non publiées],
+fb0be42d-7e36-44cf-bf39-69b70a42fb6b,[Données non publiées],Agriculteur,Responsable d'exploitation agricole,
+fb1075e9-9917-4dfa-a7c1-f2fba999fd7a,[Données non publiées],EARL,Exploitant Agricole,
+fb13ca61-8067-4a8a-aea0-2c9d616b1efd,[Données non publiées],Université [Données non publiées],Opérateur logistique,
+fb1df549-04ef-44ec-8cc7-f58c94974c7f,[Données non publiées],Néant,Retraitée [Données non publiées],
+fb264eec-c915-4580-8f3b-77a9f3d32ae0,[Données non publiées],Haut Bugey Agglomération,éducateur sportif,
+fb277c94-4452-4391-8990-92a463b4b723,[Données non publiées],Métropole de Lyon,Chargée de Mission [Données non publiées],
+fb2b20a2-06f2-4015-8515-6bf9d9fcc9b5,[Données non publiées],néant,infirmière libérale,
+fb504222-e080-475e-89d4-65c4aefe49c0,[Données non publiées],[Données non publiées],INFIRMIERE DE BLOC,
+fb5c7a3e-080d-42a3-9ed0-fc84ebfeab7d,[Données non publiées],Ministère de l'Agriculture,Enseignante en lycée professionnel,
+fb5c7a3e-080d-42a3-9ed0-fc84ebfeab7d,[Données non publiées],AGECE [Données non publiées],Responsable encadrement pédagogique,
+fb5e9aba-5b25-4cb1-b5c2-b00895a9ecf6,[Données non publiées],Province Nord,Instituteur,
+fb5fbfce-b986-446b-9bd4-42d032563330,[Données non publiées],CCIM,SECRETAIRE,[Données non publiées]
+fb63fb32-5bbc-42dd-9d38-7247c146f427,[Données non publiées],Conseil Départemental du Val d'Oise,[Données non publiées] [Données non publiées],
+fb650184-6270-491f-8f97-eed8ddad9313,[Données non publiées],ville de toulouse,agent administratif [Données non publiées],
+fb6d538a-dfaa-4004-91aa-423950dfb011,[Données non publiées],Education nationale,Professeur des écoles,
+fb6d538a-dfaa-4004-91aa-423950dfb011,[Données non publiées],Education nationale,Directrice d'école,
+fb6e77b4-2378-4cce-980c-d4d114b3142c,[Données non publiées],EIRL [Données non publiées],AGENT GENERAL D'ASSURANCE,
+fb78ff16-4ad3-4015-973b-28399a59bd4f,[Données non publiées],sans,"Artiste, sculpteur",
+fb8019d8-c2ad-4748-a3c0-2537884d636a,[Données non publiées],NEANT,NEANT,
+fb876b6f-2cd8-40f7-b6dc-0e6b0d3d6b50,[Données non publiées],Néant,néant,sans activité professionnelle [Données non publiées]
+fb884c0f-a031-4cc0-8fed-229a311de97a,[Données non publiées],Autoentrepreneur,Mandataire immobilier [Données non publiées],
+fb916ead-8c49-43cb-9e9e-e3907bbea6a0,[Données non publiées],Caisse d allocations familiales de l'Aude,chargé de conseil et de développement . Coordinatrice Petite Enfance,
+fb94d80a-5090-49c7-b30f-4e41069b4343,[Données non publiées],néant,néant,[Données non publiées]
+fbac8650-ef95-48d5-9530-19cb35c5ea13,[Données non publiées],RDG,GERANT DE SOCIETE AGENT D'USINES IMPRIMERIE ET EMBALLAGE,[Données non publiées]
+fbc06b11-369c-4bfa-8428-a8f477f9df2a,[Données non publiées],RETRAITE,RETRAITE,RETRAITE [Données non publiées]
+fbc772b6-1b28-4c58-964f-80258f5f48c7,[Données non publiées],néant,néant,[Données non publiées]
+fbce10a0-b320-43b0-90ae-73a09f29c70e,[Données non publiées],VTECH FRANCE,[Données non publiées],
+fbd0dc3e-c8f8-40a5-bfe6-e64735334976,[Données non publiées],retraitée,neant,
+fbf083fc-407c-4475-9c0b-e368eb5b9425,[Données non publiées],NESTENN,AGENCE IMMOBILIERE,
+fbf083fc-407c-4475-9c0b-e368eb5b9425,[Données non publiées],ARTHUR IMMO,agent immobilier,
+fbf090d3-6287-4ac5-afe2-c1aa858f946e,[Données non publiées],NEANT,NEANT,[Données non publiées]
+fbf9ef64-11f0-4294-8881-62f39dec46ac,[Données non publiées],[Données non publiées],néant,Plus d'activité professionnelle à ce jour.
+fc01cb2e-1b7e-4333-ab19-194d529e29ba,[Données non publiées],VILLE DE SAINT-DENIS,[Données non publiées],
+fc08bed0-9d0b-4a13-9556-42055f71e2c5,[Données non publiées],LEASYS,[Données non publiées],
+fc09b3bd-9594-4fc8-b985-458eab471e0d,[Données non publiées],2M conseil,gérant,
+fc1e233e-992f-4da9-a0ae-5e68d598864a,[Données non publiées],Néant,Néant,
+fc2c6928-8ebd-43db-ac59-078f862f829f,[Données non publiées],Ville de Plan de Cuques,[Données non publiées],également : Conseiller métropolitain de la Métropole Aix Marseille Provence ; Vice-Président du Conseil de Territoire
+fc2f4deb-f828-4397-a152-461902ce9426,[Données non publiées],Retraitée,aucune activité professionnelle à son actif,
+fc3bd304-fd22-4950-a212-3324451c996e,[Données non publiées],néant,néant (retraité),
+fc505ce6-b265-4a6e-a073-8cac11c37cf4,[Données non publiées],HCL,MEDECIN HOSPITALIER,
+fc526c8f-fbd4-4688-b7d7-695b45cb2c23,[Données non publiées],sarl [Données non publiées],serveur,
+fc554b01-8828-43cb-9b49-de78370ffc2d,[Données non publiées],ASTBTP,Secrétaire Médicale,
+fc6fd291-7298-4254-926a-39bf1053f4cb,[Données non publiées],AGSS de l'UDAF,Psychologue [Données non publiées],
+fc802287-c13a-4968-a2c4-9fbb554f2fe8,[Données non publiées],lui même,journaliste Président et directeur du journal Le petit mag Lens Liévin exploitant agricole [Données non publiées],[Données non publiées]
+fc8a1b52-2045-4ad9-af0e-f72179962b68,[Données non publiées],France Télévision,Journaliste,
+fc8b5e0a-4a62-43fa-9ec5-ff4f69a11ad5,[Données non publiées],néant,néant,
+fc903b32-dadd-487d-a8af-3b2bac830a87,[Données non publiées],Education Nationale,Proviseur de lycée,[Données non publiées]
+fca29ba0-08ce-41da-8ff2-22e5387c54c5,[Données non publiées],Arundo,gérant,
+fca30dbc-df21-422d-9d2b-4dc008438ac3,[Données non publiées],Retraité,arbitre : chambre arbitrale internationale de Paris,
+fca8b312-1673-4354-a939-476323bd0023,[Données non publiées],Ministère de la Transition Écologique et Solidaire,Ingénieur [Données non publiées],
+fca8d150-7995-486a-8ef8-6783d725294b,[Données non publiées],CD,contractuelle ADE,
+fcabbb66-d9f2-42ea-8c83-f698c8a05ebe,[Données non publiées],Éducation nationale,RETRAITEE,
+fcb579b0-bf96-4ef2-89bb-8f8202884ea9,[Données non publiées],Nom propre,Exploitant agricole,
+fcb6b86d-5335-493d-a265-3994bc06d455,[Données non publiées],VILLE DE LYON,Fonctionnaire territoriale [Données non publiées],[Données non publiées]
+fcc814c4-aef7-40c4-8057-348a091309bf,[Données non publiées],Mairie de Cannes,dgs,
+fccd60d5-0f06-4091-a288-cfb64807235a,[Données non publiées],néant,néant,
+fcd2a6e5-e651-4c40-bf2b-d4c1a8906560,[Données non publiées],neant,neant,
+fcd57181-b816-4364-86c4-5312faaf9e89,[Données non publiées],Université [Données non publiées],Maître de conférences des facultés de droit,
+fcdda4d6-5f29-4c29-8ab0-81cd3c07d112,[Données non publiées],Crédit mutuel,Responsable commercial,
+fce8f07c-da95-4fb5-bd94-5c56fc5db192,[Données non publiées],CAFPI,COURTIER EN PRET IMMOBILIER,
+fceab72b-bbdd-4f8e-9684-7595bba4c4b7,[Données non publiées],[Données non publiées],Assistante ingénieur,
+fcf06bae-4356-4546-8602-263995cb8ffa,[Données non publiées],INSPECTION ACADEMIQUE [Données non publiées],CONSEILLERE PEDAGOGIQUE,
+fcfe0757-640d-46fe-ac7e-e81de09d7861,[Données non publiées],[Données non publiées],[Données non publiées],Retraitée
+fd198ed5-6d8e-404f-a9a4-5c9e1e5a3897,[Données non publiées],[Données non publiées],EMPLOYEE A DOMICILE,
+fd286823-ac99-4163-9eb8-5ebbb11123b6,[Données non publiées],Communauté d'agglomération bergeracoise,[Données non publiées],
+fd2afb4a-27ae-459b-80cd-e1ecd7609e7a,[Données non publiées],Education nationale,Directrice d'école [Données non publiées],
+fd32fffe-587c-4160-9f22-e852aa07a2c1,[Données non publiées],Vivendi,[Données non publiées],
+fd351a9a-16d3-44cd-87f4-30ac3e45be09,[Données non publiées],retraité,retraité,
+fd45cc55-c8db-4f81-ad36-ae1263b96699,[Données non publiées],SARL [Données non publiées],Clerc négociateur immobilier,
+fd4b72a6-7493-4624-a043-caec356f3353,[Données non publiées],CFAI [Données non publiées],Formateur Maths et Sciences Physiques,
+fd5f820a-ca93-47d1-8720-336b913b23ed,[Données non publiées],Egencia,Directeur [Données non publiées],
+fd60a41b-a3b8-4c2e-a651-961987c51300,[Données non publiées],retraitée,néant,[Données non publiées]
+fd63ddae-1999-4065-8c17-6637b7399507,[Données non publiées],TFS France,Responsable Logistique,
+fd67fb1a-d22e-492b-8b3b-b29f5d106fe7,[Données non publiées],Office de Tourisme,Responsable Administrative,
+fd6906f0-751c-4fe4-8ca8-d33d6376495d,[Données non publiées],[Données non publiées],Conseiller en immobilier autoentrepreneur,
+fd6ca7bb-44b6-4b5f-b767-32a18cb25e2e,[Données non publiées],SIM Accor Invest,Assistante de direction,
+fd6f6ba4-dabd-4302-9515-a663b74ed531,[Données non publiées],NEANT,NEANT,SANS PROFESSION
+fd707af8-2d1e-4ef3-8045-6268b4061a83,[Données non publiées],Accelonix SAS Evreux,Directeur du Développement,[Données non publiées]
+fd7445db-44da-422a-8730-5380d3076768,[Données non publiées],Néant,retraité,
+fd78c4a3-bc2e-4536-97e1-711bb688dd31,[Données non publiées],sans emploi,[Données non publiées],[Données non publiées]
+fd7e007a-f05d-4355-ae24-10338dae9be5,[Données non publiées],Néant,Retraitée,
+fd87375d-f116-4631-93f0-82779d4ee8ea,[Données non publiées],[Données non publiées],Ecologue expert,
+fd9c9386-c2a0-4b7e-8311-0958c721f59c,[Données non publiées],Néant,Néant,
+fda19537-23ca-4894-8fe3-82289f7580bd,[Données non publiées],VILLE DE PIERREFITTE,[Données non publiées],[Données non publiées]
+fda3dbd1-a284-43ea-84e4-0614164d976c,[Données non publiées],Avocat -,Avocat,
+fda92332-62b7-4ed2-9ed5-87f226bba7ff,[Données non publiées],[Données non publiées],secrétaire,
+fdae97ce-0564-4b2f-8ad5-25e6f53bd1e0,[Données non publiées],Conseil départemental [Données non publiées],Attachée territoriale [Données non publiées],
+fdb03194-f05a-4d12-9386-e7f3fb0d53da,[Données non publiées],Néant,Néant,
+fdbae935-d815-479d-9a59-bceb8cd764ae,[Données non publiées],RETRAITE,[Données non publiées],[Données non publiées]
+fdc18f67-b9df-46dd-9856-010b60739d16,[Données non publiées],PPA MAHE,Directeur Général [Données non publiées],
+fdc83264-b5d7-4a20-b05e-b9fd018afefc,[Données non publiées],Conseil Régional des Hauts de France,[Données non publiées],
+fdcce973-3f27-475a-83b3-2f9913d0043e,[Données non publiées],Université [Données non publiées],Maître de conférences des facultés de droit,
+fdd16f86-499f-40f1-9541-9a72a9387fab,[Données non publiées],SARL MILPAT,restauratrice,[Données non publiées]
+fdd444d6-bbe0-46b9-bc0b-ba7b7c5803e5,[Données non publiées],OGEC [Données non publiées],directeur d'établissement scolaire [Données non publiées],
+fdd771ac-8c04-4c0f-ad59-d59864db4521,[Données non publiées],Alterlab,[Données non publiées],
+fdd83de3-8901-47aa-8b30-62be68d94a5e,[Données non publiées],SAFER [Données non publiées],Directrice generale,
+fe041bc0-8645-4635-8be1-76eb5f638e16,[Données non publiées],Louis VUITTON,Assistante Administratif,
+fe192a61-e502-4ef4-a5da-079860f4b3a2,[Données non publiées],Ville du HAVRE,[Données non publiées],
+fe1c0624-18d5-41f8-9ae1-1d4ece4e7833,[Données non publiées],Retraité,neant,
+fe2180bd-5f4b-43e5-97f3-406af1a01324,[Données non publiées],EDUCATION NATIONALE,ENSEIGNANTE EN ANGLAIS,
+fe231b5a-1a34-43d6-a742-97045cd61176,[Données non publiées],néant,sans activités,
+fe26ca45-1790-4ef5-b088-e9b91f2530ad,[Données non publiées],OMNImeubles SARL,commercial,
+fe2f045c-aec4-4d55-a6fc-f76d60a22a01,[Données non publiées],Centre de Gestion 67,Cadre administratif [Données non publiées],
+fe30ae43-1a8c-43f2-868f-aa6ac7077c46,[Données non publiées],[Données non publiées],[Données non publiées],arret de l'activité profesionnelle [Données non publiées]
+fe390eac-9911-45c1-9e06-4e214b9e904b,[Données non publiées],BNP PARIBAS,Chargé d'affaires Commerce international,
+fe3eb039-3c3d-4fe3-a692-1a51a4e7dcd3,[Données non publiées],lycée [Données non publiées],enseignant,
+fe4df9fd-dcfb-4da6-aa89-965ffd3ada2c,[Données non publiées],Communauté de Communes des quatres vallées,Directrice Générale des Services,
+fe5189ad-cd77-45be-be0a-11c258cb0574,[Données non publiées],[Données non publiées],[Données non publiées] neant,
+fe5189ad-cd77-45be-be0a-11c258cb0574,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+fe5189ad-cd77-45be-be0a-11c258cb0574,[Données non publiées],[Données non publiées],[Données non publiées],[Données non publiées]
+fe539cf7-3fb0-4adf-87ab-4fbeed596293,[Données non publiées],Néant,Néant,Retraité
+fe5802ec-1aaa-4cf6-a71d-7163b389f4e5,[Données non publiées],France Télévision,Journaliste,
+fe59caae-3719-47b4-b705-75569086cd50,[Données non publiées],[Données non publiées],[Données non publiées],
+fe59caae-3719-47b4-b705-75569086cd50,[Données non publiées],[Données non publiées],[Données non publiées],
+fe5b3095-4bb9-463e-8b18-12ac7d1f4e31,[Données non publiées],travailleur indépendant,prestations dans le domaine culturel : cours de théatre metteuse en scène et aminatrice culturelle,
+fe5b3095-4bb9-463e-8b18-12ac7d1f4e31,[Données non publiées],Maison de la jeune fille [Données non publiées],Salariée à temps partiel animatrice en résidence d'accueil,
+fe5c962a-82d0-40aa-8d1f-66bd2f858f1a,[Données non publiées],[Données non publiées],Masseur Kinésithérapeute DE,
+fe5d7770-e770-4804-9e81-29d2db98af4c,[Données non publiées],[Données non publiées],Comptable Taxateur,
+fe65f14e-5ebb-407f-a3de-61d71c93a8bc,[Données non publiées],néant,Retraité du régime général de la sécurité sociale,
+fe73275d-43ca-4152-a7f8-9cc00aa5982e,[Données non publiées],Variable,Régisseur dans le cinéma sous statut d'intermittent du spectacle. Employeurs variables.,
+fe73275d-43ca-4152-a7f8-9cc00aa5982e,[Données non publiées],La France Insoumise,Régisseur,
+fe77a47a-72b0-4f23-93d0-0abceecf54ad,[Données non publiées],Societe generale,Cadre bancaire,
+fe784f1b-5c56-4195-9468-c03c4f1f5316,[Données non publiées],CENTRE HOSPITALIER DE LA LOUPE,Attachée d'Administration Hospitalière,
+fe7b3ec6-b873-4222-acaf-a5bd79497d8a,[Données non publiées],diocèse de Luçon,déléguée à l'information,
+fe7b577c-d93d-4e39-afa3-786192aa9e04,[Données non publiées],Dinh Van,Responsable commerciale,
+fe86e8ed-9d03-4f0c-926e-62f5e81b7c07,[Données non publiées],IPSEN INNOVATION,Chef de projet,
+fe96e516-5417-45a4-a924-6c5c30b42afd,[Données non publiées],Néant,Médecin généraliste,
+fe980aae-e8ed-437b-a6f3-f36c72387396,[Données non publiées],néant,néant,retraitée de l'éducation nationale.
+fe9c8114-8468-4699-ad7b-6ec3eb6f1caf,[Données non publiées],[Données non publiées],[Données non publiées],à la retraite
+fe9c8114-8468-4699-ad7b-6ec3eb6f1caf,[Données non publiées],[Données non publiées],retraitée,[Données non publiées] [Données non publiées]
+fe9c8114-8468-4699-ad7b-6ec3eb6f1caf,[Données non publiées],Autoentrepreneur,Mandataire immobilier [Données non publiées],
+fe9f781b-f221-4f8e-a04e-d82eceea4b26,[Données non publiées],[Données non publiées],Ingénieur dans le domaine des technologies médicales,[Données non publiées]
+fea5150f-e6eb-44b7-8941-b23fffa7eff8,[Données non publiées],éducation nationale,infirmière scolaire,
+feb3d63d-1ec3-4382-963e-2a289b390bb4,[Données non publiées],Communauté de communes,auxilière petite enfance [Données non publiées],
+feb49b6d-204e-423c-9a85-83f4ad1d77ed,[Données non publiées],BPM,DIRECTEUR GENERAL,
+febb193c-0454-4df9-a8ab-a04a1e78cd39,[Données non publiées],Cabinet infirmier [Données non publiées],Infirmière libérale,
+fec25378-e209-4dde-801a-378ff578f925,[Données non publiées],RETRAITE,Retraite d'exploitant agricole,
+fec81979-165c-4cc3-95e0-a0a70f4cb374,[Données non publiées],Néant,Retraitée,[Données non publiées]
+fecfe03a-c13d-4018-a59b-04a4ecfe5004,[Données non publiées],"Artiste - Auteur indépendant sous le nom de: ""l'Atelier des Muses""",Activités artistiques,[Données non publiées]
+fed0c0cf-2aa2-451f-b344-9f65b2015647,[Données non publiées],SAS conserverie morbihannaise,adjoint production [Données non publiées],
+fee4f466-fb81-454a-8830-71df0925017a,[Données non publiées],EDUCATION NATIONALE,PROFESSEUR DES ECOLES,
+feea8ef2-8874-4587-9afb-55113da47a50,[Données non publiées],SAS Prestations services,Président,
+feed3c0f-79e9-4025-9314-e4cd8876fd4a,[Données non publiées],retraité et [Données non publiées],coach sportif,[Données non publiées]
+fef7aa46-2220-4837-bbe7-7a54fdbc68da,[Données non publiées],Indépendante,Formatrice en communication,
+ff0e3e14-2134-4ef4-9e88-c25d1560cdc0,[Données non publiées],néant,néant,
+ff114d8d-9d92-4f9b-960c-01a7d9af9b50,[Données non publiées],Conseil régional Nouvelle Aquitaine,Déléguée territoriale emploi formation,
+ff121885-e320-411f-959f-5eee4c2c0b35,[Données non publiées],NEANT,Retraité,
+ff1d425c-b201-4381-a24a-fadb69c9e39f,[Données non publiées],Ministère de l'éducation Nationale,Professeur des écoles,
+ff24e7a1-1033-4669-869c-07e4cfaefed6,[Données non publiées],ministere des finances publiques,contrôleur du trésor,[Données non publiées]
+ff302210-7996-4e52-8fe1-eeeb73b83cdd,[Données non publiées],[Données non publiées],AFFRETEUR,
+ff370c8d-a234-4444-9674-9d1b92b1b3d6,[Données non publiées],Cap Coreli SARL,Gérante de l'entreprise. [Données non publiées],[Données non publiées]
+ff4587f0-91db-4426-b3bc-f33b816109ab,[Données non publiées],[Données non publiées],RETRAITEE [Données non publiées],
+ff553e51-70fd-4555-81a7-2bc19e7993bb,[Données non publiées],Ville de Cherbourg-en-Cotentin,Directrice [Données non publiées],
+ff58464c-a3af-447b-bb4e-6b862cbde6cb,[Données non publiées],Néant,Psychologue en libéral,
+ff58464c-a3af-447b-bb4e-6b862cbde6cb,[Données non publiées],Association Les Yeux Dans La Tête,Bénévolat,
+ff591eb4-0d20-48a0-a85a-8f939982f78a,[Données non publiées],Auto-entrepreneur et retraité,Négociateur Immobilier,[Données non publiées]
+ff5a6463-8a0e-45bc-a5e3-92776a8b3c37,[Données non publiées],Travailleur indépendant,Immobilier et commerce de détail (vêtements et décoration),
+ff607fb7-4d63-4616-903a-9acf8b641b69,[Données non publiées],sans,Activité libérale AVOCAT,
+ff6c2e02-6415-4cd4-b1c8-c6c9d3a85c3e,[Données non publiées],CIC,directeur agence banque Privée [Données non publiées],
+ff7da590-099e-4a4b-bf79-6211e9403173,[Données non publiées],Education Nationale,AESH,
+ff851e6d-de06-4e0a-bbe2-06c6867612d4,[Données non publiées],CIKISI FRANCE - [Données non publiées],Directeur Commercial,
+ff8ba221-6183-4f31-a5cd-11ffbce43919,[Données non publiées],Néant,Néant,[Données non publiées] retraite [Données non publiées]
+ff8cfb29-4fe6-4933-8a0c-a4719d3f6081,[Données non publiées],ENERCON,VENTE ET ENTRETIEN D’ÉOLIENNES,
+ff96e526-ddf1-4435-855d-f31fc7619673,[Données non publiées],retraite,neant,
+ff9ed5d2-8705-43fa-9adc-e8a6f3bd834c,[Données non publiées],néant,retraité,
+ffa1fe57-2404-41ab-8483-406268276ff7,[Données non publiées],Neant,néant,[Données non publiées] VGA omnisport [Données non publiées] l'association COBATY
+ffa48002-ebb9-48e6-8096-ff94d5a64c3e,[Données non publiées],Commune de SALSES LE CHATEAU,Direction des Services,
+ffaeed30-c789-49b1-a9af-4bf77eebe4ec,[Données non publiées],Sénat,Conseillère des services du Sénat,
+ffba65cb-d891-4938-be8a-eeac29b37811,[Données non publiées],Travailleur indépendant,Gérante de chambres d'hôtes,
+ffc6c3f8-4451-462c-8463-8e40508a299a,[Données non publiées],Artisan,Menuiserie-- -Ebénisterie,"[Données non publiées] jusqu'au 13 juillet 2021 Fin d'activité enregistrée chambre des métiers et de l'artisanat, et retraité à compter du 15 juillet 2021"
+ffc788a8-630d-4ba9-8dc6-de26eae5d49e,[Données non publiées],Conseillère régionale,Mandat électif,
+ffe77ec2-bc2d-495c-9240-e9e05d0ebccc,[Données non publiées],Crédit Agricole du Morbihan,Responsable [Données non publiées],
+ffe864c3-aaa8-4218-837c-003c6024017e,[Données non publiées],SODEXO Service pénitentiare,[Données non publiées],
+ffeaea0a-543e-429c-8808-daeb77410cc2,[Données non publiées],ETS SARRAZIN [Données non publiées],MONTEUR SOUDEUR,
+ffed42f6-b94c-4219-a4ac-e67848098443,[Données non publiées],sas rouge raisin,[Données non publiées],[Données non publiées]
+fff65bc0-19e2-4b2b-bce0-9b51ea4e6df8,[Données non publiées],Travailleur non salarié,Chef d'entreprise Administrateur de biens,
+fffd490b-bb98-4266-92b7-33b143880ef2,[Données non publiées],Communauté d'agglomération d'Alès,Attachée de Conservation Culture,


### PR DESCRIPTION
## Summary
- extract spouse professional activity from `<activProfConjointDto>` blocks
- write spouse information (uuid, nomConjoint, employeurConjoint, activiteProf, commentaire) to `pii/spouse_activities.csv`

## Testing
- `python -m py_compile extract_spouse_activity.py`
- `python extract_spouse_activity.py`


------
https://chatgpt.com/codex/tasks/task_e_6897d621291c8320862116e0f099ae13