### PR TITLE
Add sector mapping and sector exposure metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ python generate_report_figures.py
 ```
 
 Outputs such as `pii/personal_info.csv`, files in `stock_analysis/output/` and images in `report_assets/` are generated locally and should not be committed.
+Running `generate_person_stock_report.py` now also creates `person_stock_sector_report.csv` with valuations by sector and adds a Herfindahl index column to `person_stock_report.csv`.
 
 ## Stock holdings
 

--- a/stock_analysis/generate_person_stock_report.py
+++ b/stock_analysis/generate_person_stock_report.py
@@ -22,9 +22,30 @@ def main() -> None:
         .reset_index()
     )
     report = report.sort_values('total_valuation', ascending=False)
+
+    sector_exposure = (
+        merged.dropna(subset=['GICS Sector', 'evaluation'])
+        .groupby(['uuid', 'nom', 'prenom', 'GICS Sector'])
+        .agg(sector_valuation=('evaluation', 'sum'))
+        .reset_index()
+    )
+    sector_exposure['total_valuation'] = sector_exposure.groupby(
+        ['uuid', 'nom', 'prenom']
+    )['sector_valuation'].transform('sum')
+    sector_exposure['sector_share'] = (
+        sector_exposure['sector_valuation'] / sector_exposure['total_valuation']
+    )
+    hhi = (
+        sector_exposure.groupby(['uuid', 'nom', 'prenom'])['sector_share']
+        .apply(lambda x: (x**2).sum())
+        .reset_index(name='herfindahl_index')
+    )
+    report = report.merge(hhi, on=['uuid', 'nom', 'prenom'], how='left')
+
     output_dir = base / 'stock_analysis' / 'output'
     output_dir.mkdir(parents=True, exist_ok=True)
     report.to_csv(output_dir / 'person_stock_report.csv', index=False)
+    sector_exposure.to_csv(output_dir / 'person_stock_sector_report.csv', index=False)
     print(report.head(10))
 
 


### PR DESCRIPTION
## Summary
- Map normalized stock names to sector data from index lists.
- Compute per-person sector exposure and Herfindahl index in stock reports.
- Document how to run the updated stock analysis pipeline.

## Testing
- `python stock_analysis/normalize_stocks.py`
- `python stock_analysis/generate_person_stock_report.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897f7cf41fc8320872e6df77eab69b5