### PR TITLE
Add mandate delay feature preparation and exploratory model

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,20 @@ guesses derived from first names and summarises the distribution in
 
 The current dataset spans **11 990 records**, with gender guesses indicating **64.15 % male** and **35.85 % female** entries. Frequent first names include Jean (249), Philippe (205), Patrick (173) and Marie (147). See `pii/gender_report.md` for full tables.
 
+## Mandate compliance analysis
+
+Declarations of mandates are published some time after they are filed. The
+scripts under `mandates/` examine this delay and model factors associated with
+longer turnaround times:
+
+```bash
+python mandates/prepare_features.py --csv liste.csv --out mandates_features.csv
+python mandates/compliance_model.py --csv liste.csv
+```
+
+The generated CSV and any figures remain local artefacts and are not committed
+to version control.
+
 ## HATVP avis PDFs
 
 The repository also includes tooling to work with HATVP deliberations and

--- a/mandates/__init__.py
+++ b/mandates/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities for analysing declaration mandates."""

--- a/mandates/compliance_model.py
+++ b/mandates/compliance_model.py
@@ -1,0 +1,64 @@
+"""Exploratory model for delays in mandate publication.
+
+The script loads features prepared by :mod:`mandates.prepare_features`
+from the raw ``liste.csv`` file and fits a simple logistic regression to
+understand which factors correlate with long publication delays.
+
+Generated artefacts such as figures or CSV files are intended for local
+use only and are not committed to the repository.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import classification_report
+
+# Import within package or as standalone script
+try:  # pragma: no cover - normal package import
+    from .prepare_features import prepare_features
+except ImportError:  # pragma: no cover - fallback when executed as a script
+    import sys
+    from pathlib import Path
+
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    from mandates.prepare_features import prepare_features
+
+
+DEFAULT_THRESHOLD = 90  # days
+
+
+def build_dataset(csv_path: str, delay_threshold: int) -> tuple[pd.DataFrame, pd.Series]:
+    """Prepare design matrix and target for modelling."""
+    df = prepare_features(csv_path)
+    df = df.dropna(subset=["delay_days", "departement", "mandate_type"])
+    df["long_delay"] = df["delay_days"] > delay_threshold
+    X = pd.get_dummies(df[["departement", "mandate_type"]], drop_first=True)
+    y = df["long_delay"]
+    return X, y
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Model factors influencing long delays")
+    parser.add_argument(
+        "--csv", default="liste.csv", help="Raw CSV path (default: %(default)s)"
+    )
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=DEFAULT_THRESHOLD,
+        help="Delay threshold in days to consider 'long' (default: %(default)s)",
+    )
+    args = parser.parse_args()
+
+    X, y = build_dataset(args.csv, args.threshold)
+    model = LogisticRegression(max_iter=1000)
+    model.fit(X, y)
+    report = classification_report(y, model.predict(X))
+    print(report)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/mandates/prepare_features.py
+++ b/mandates/prepare_features.py
@@ -1,0 +1,68 @@
+"""Feature preparation for mandate compliance analysis.
+
+This module parses the publication and deposit dates from the raw
+`liste.csv` dataset, computes the delay between the two events in days
+and exposes the mandate type as a categorical feature.
+
+The script can be executed directly to produce a local CSV file with the
+added features.  Generated files are not tracked in version control.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+
+def prepare_features(csv_path: str | Path) -> pd.DataFrame:
+    """Load dataset and create basic features.
+
+    Parameters
+    ----------
+    csv_path:
+        Path to the raw `liste.csv` file.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with parsed dates, the delay in days and a categorical
+        `mandate_type` column.
+    """
+    df = pd.read_csv(csv_path, sep=";", dtype=str)
+    # Parse the publication and deposit dates
+    df["date_publication"] = pd.to_datetime(df["date_publication"], errors="coerce")
+    df["date_depot"] = pd.to_datetime(df["date_depot"], errors="coerce")
+
+    # Compute the delay in days between deposit and publication
+    df["delay_days"] = (df["date_publication"] - df["date_depot"]).dt.days
+
+    # Expose mandate type as categorical data
+    df["mandate_type"] = df["type_mandat"].astype("category")
+
+    return df
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Prepare mandate features")
+    parser.add_argument(
+        "--csv",
+        default="liste.csv",
+        help="Path to the raw CSV file (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--out",
+        default="mandates_features.csv",
+        help="Where to store the feature CSV (default: %(default)s)",
+    )
+    args = parser.parse_args()
+
+    df = prepare_features(args.csv)
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(args.out, index=False)
+    print(f"Wrote {args.out} with {len(df)} rows")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- add `mandates/prepare_features.py` to compute publication delay and mandate type features
- introduce `mandates/compliance_model.py` logistic model to explore factors behind long delays
- document how to run new analyses and keep generated artefacts local

## Testing
- `python mandates/prepare_features.py --csv liste.csv --out mandates_features.csv`
- `python mandates/compliance_model.py --csv liste.csv`


------
https://chatgpt.com/codex/tasks/task_e_6897f7f98ce083209af4226b58d75be1