### PR TITLE
Add age feature enrichment for personal info

### DIFF
--- a/pii/extraction.py
+++ b/pii/extraction.py
@@ -1,0 +1,48 @@
+"""Utility functions for personal information extraction."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+AGE_BANDS = [0, 30, 40, 50, 60, 70, 80, 90, 200]
+AGE_LABELS = ["<30", "30-39", "40-49", "50-59", "60-69", "70-79", "80-89", "90+"]
+
+
+def compute_age_features(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute age related features from a personal information dataframe.
+
+    Parameters
+    ----------
+    df:
+        DataFrame containing at least ``dateDepot`` and ``dateNaissance``
+        columns formatted as ``"%d/%m/%Y %H:%M:%S"`` and ``"%d/%m/%Y"``
+        respectively.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Copy of ``df`` with new ``age`` and ``age_band`` columns.
+    """
+
+    data = df.copy()
+    deposit = pd.to_datetime(
+        data["dateDepot"], format="%d/%m/%Y %H:%M:%S", errors="coerce"
+    )
+    birth = pd.to_datetime(
+        data["dateNaissance"], format="%d/%m/%Y", errors="coerce"
+    )
+    valid = deposit.notna() & birth.notna()
+    age = pd.Series(pd.NA, index=data.index, dtype="Int64")
+    year_diff = deposit.dt.year - birth.dt.year
+    before_birthday = (
+        (deposit.dt.month < birth.dt.month)
+        | ((deposit.dt.month == birth.dt.month) & (deposit.dt.day < birth.dt.day))
+    )
+    year_diff = year_diff - before_birthday.astype(int)
+    age[valid] = year_diff[valid]
+    data["age"] = age
+    data["age_band"] = pd.cut(
+        data["age"], bins=AGE_BANDS, labels=AGE_LABELS, right=False
+    )
+    return data

--- a/pii/gender_analysis.py
+++ b/pii/gender_analysis.py
@@ -1,18 +1,29 @@
 """Generate gender predictions for personal_info dataset and output stats."""
 
+import argparse
 from pathlib import Path
+
 import pandas as pd
 from gender_guesser.detector import Detector
 
 
-DATA_PATH = Path("pii/personal_info.csv")
-OUTPUT_CSV = Path("pii/personal_info_with_gender.csv")
+DEFAULT_DATA = Path("pii/personal_info.csv")
+DEFAULT_OUTPUT = Path("pii/personal_info_with_gender.csv")
 REPORT_PATH = Path("pii/gender_report.md")
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate gender predictions and demographic summaries"
+    )
+    parser.add_argument("--data", type=Path, default=DEFAULT_DATA, help="Input CSV")
+    parser.add_argument(
+        "--output", type=Path, default=DEFAULT_OUTPUT, help="Output CSV with gender"
+    )
+    args = parser.parse_args()
+
     # Load dataset
-    df = pd.read_csv(DATA_PATH)
+    df = pd.read_csv(args.data)
 
     # Extract first name
     df["first_name"] = df["prenom"].astype(str).str.split().str[0]
@@ -26,7 +37,7 @@ def main() -> None:
     df["gender"] = df["civilite"].map(civilite_map)
 
     # Save dataframe with gender and guess columns
-    df.to_csv(OUTPUT_CSV, index=False)
+    df.to_csv(args.output, index=False)
 
     # Generate stats
     total = len(df)
@@ -35,6 +46,10 @@ def main() -> None:
 
     civilite_guess = pd.crosstab(df["civilite"], df["gender_guess"])
     top_first_names = df["first_name"].str.title().value_counts().head(10)
+
+    age_gender = None
+    if {"age_band", "gender"}.issubset(df.columns):
+        age_gender = df.groupby(["age_band", "gender"]).size().unstack(fill_value=0)
 
     # Write markdown report
     with REPORT_PATH.open("w", encoding="utf-8") as f:
@@ -51,7 +66,12 @@ def main() -> None:
 
         f.write("## Top 10 first names\n\n")
         f.write(top_first_names.to_markdown())
-        f.write("\n")
+        f.write("\n\n")
+
+        if age_gender is not None:
+            f.write("## Age band by gender\n\n")
+            f.write(age_gender.to_markdown())
+            f.write("\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- compute age and age band from deposit and birth dates
- optional CLI flag to enrich personal_info.csv with age features
- gender analysis script accepts enriched CSV and summarizes age bands

## Testing
- `python pii/extract_personal_info.py --enrich`
- `python pii/gender_analysis.py --data pii/personal_info_enriched.csv --output /tmp/personal_info_with_gender.csv`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897f7c1eab483209f6d6a497b7d50f6