### PR TITLE
Add financial participation parser

### DIFF
--- a/parse_financial_participations.py
+++ b/parse_financial_participations.py
@@ -1,0 +1,63 @@
+import sys
+import csv
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+
+def localname(tag: str) -> str:
+    """Return tag name without namespace."""
+    return tag.split("}", 1)[-1] if "}" in tag else tag
+
+
+def find_child(parent: ET.Element, wanted: str):
+    """Return first child element with given localname."""
+    for ch in parent:
+        if localname(ch.tag) == wanted:
+            return ch
+    return None
+
+
+def child_text(parent: ET.Element, tag: str) -> str:
+    """Get direct child text by tag name (namespace agnostic)."""
+    child = find_child(parent, tag)
+    if child is not None and child.text:
+        return child.text.replace("\n", " ").strip()
+    return ""
+
+
+def parse_file(path: Path):
+    """Yield dictionaries for each participationFinanciere item in a file."""
+    tree = ET.parse(path)
+    root = tree.getroot()
+    for pf in root.iter():
+        if localname(pf.tag) != "participationFinanciereDto":
+            continue
+        items_container = find_child(pf, "items")
+        if items_container is None:
+            continue
+        for item in items_container:
+            if localname(item.tag) != "items":
+                continue
+            yield {
+                "file": path.name,
+                "nomSociete": child_text(item, "nomSociete"),
+                "evaluation": child_text(item, "evaluation"),
+                "capitalDetenu": child_text(item, "capitalDetenu"),
+                "nombreParts": child_text(item, "nombreParts"),
+                "remuneration": child_text(item, "remuneration"),
+            }
+
+
+def main() -> None:
+    paths = sorted(Path("split_declarations").glob("*.xml"))
+    writer = csv.DictWriter(sys.stdout, fieldnames=[
+        "file", "nomSociete", "evaluation", "capitalDetenu", "nombreParts", "remuneration"
+    ])
+    writer.writeheader()
+    for path in paths:
+        for row in parse_file(path):
+            writer.writerow(row)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_parse_financial_participations.py
+++ b/tests/test_parse_financial_participations.py
@@ -1,0 +1,46 @@
+from parse_financial_participations import parse_file
+
+
+def test_parse_file_missing_or_empty_fields(tmp_path):
+    xml_content = """
+    <root>
+      <participationFinanciereDto>
+        <items>
+          <items>
+            <nomSociete>Acme Corp</nomSociete>
+            <evaluation>1000</evaluation>
+            <capitalDetenu></capitalDetenu>
+            <nombreParts>10</nombreParts>
+            <!-- remuneration missing -->
+          </items>
+          <items>
+            <nomSociete>Foo LLC</nomSociete>
+            <!-- other fields missing entirely -->
+          </items>
+        </items>
+      </participationFinanciereDto>
+    </root>
+    """
+    xml_path = tmp_path / "sample.xml"
+    xml_path.write_text(xml_content)
+
+    rows = list(parse_file(xml_path))
+    assert rows == [
+        {
+            "file": "sample.xml",
+            "nomSociete": "Acme Corp",
+            "evaluation": "1000",
+            "capitalDetenu": "",
+            "nombreParts": "10",
+            "remuneration": "",
+        },
+        {
+            "file": "sample.xml",
+            "nomSociete": "Foo LLC",
+            "evaluation": "",
+            "capitalDetenu": "",
+            "nombreParts": "",
+            "remuneration": "",
+        },
+    ]
+


### PR DESCRIPTION
## Summary
- add script to extract financial participation data from XML files
- add unit test verifying parser handles missing or empty fields

## Testing
- `python parse_financial_participations.py > /tmp/participations.csv && head -n 5 /tmp/participations.csv`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898adb838c48320acf18a67c59e4311